### PR TITLE
Implement lead processing statuses

### DIFF
--- a/LEAD_STATUS_IMPLEMENTATION.md
+++ b/LEAD_STATUS_IMPLEMENTATION.md
@@ -1,0 +1,118 @@
+# Lead Status System Implementation
+
+## Overview
+This implementation adds a comprehensive status tracking system for leads, allowing multiple statuses to track the progress of lead processing through different stages.
+
+## Database Changes
+
+### New Table: `lead_statuses`
+- **Purpose**: Track multiple statuses for each lead
+- **Fields**:
+  - `id`: Primary key
+  - `lead_id`: Foreign key to leads table
+  - `status`: Enum ('New', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed')
+  - `tenant_id`: Foreign key to tenants table (for tenant isolation)
+  - `created_at`, `updated_at`: Timestamps
+- **Constraints**: Unique constraint on `(lead_id, status)` to prevent duplicates
+
+### Migration
+- **File**: `0021_add_lead_statuses.sql`
+- **Features**:
+  - Creates the new table with proper foreign keys
+  - Data migration to populate existing leads with appropriate statuses:
+    - Leads with summaries get "Processed" status
+    - Other leads get "New" status
+
+## Backend Changes
+
+### Lead Service (`lead.service.ts`)
+**New Functions**:
+- `getLeadStatuses(tenantId, leadId)`: Get all statuses for a lead
+- `hasStatus(tenantId, leadId, status)`: Check if lead has specific status
+- `ensureDefaultStatus(tenantId, leadId)`: Ensure lead has at least "New" status
+- `updateLeadStatuses(tenantId, leadId, statusesToAdd, statusesToRemove)`: Central status management
+
+**Updated Functions**:
+- `getLeadById()`: Now returns statuses array
+- `createLead()`: Automatically creates "New" status for new leads
+
+### Processing Services Integration
+
+#### LeadAnalyzerService (`leadAnalyzer.service.ts`)
+- `indexSite()`: Adds "Scraping Site" status when scraping starts
+- `analyze()`: Manages status transitions:
+  - Removes "New", adds "Analyzing Site"
+  - Removes "Analyzing Site" and "Extracting Contacts", adds "Processed" when complete
+- `extractContacts()`: Adds "Extracting Contacts" status
+
+#### SiteAnalyzerService (`siteAnalyzer.service.ts`)
+- `completeFirecrawlCrawl()`: Removes "Scraping Site" status when scraping completes
+
+### API Updates
+- **Lead Response Schema**: Now includes `statuses` array
+- **Status Schema**: Defines the structure for lead status responses
+
+## Frontend Changes
+
+### New Component: `LeadStatusBadges.tsx`
+- **Purpose**: Display status badges with appropriate colors and icons
+- **Features**:
+  - Color-coded badges for each status type
+  - Icons for visual distinction
+  - Sorted by creation date to show progression
+
+### Updated Pages
+
+#### LeadDetailPage (`LeadDetailPage.tsx`)
+- Added status badges display in the header section
+- Updated LeadDetailsTab integration
+
+#### LeadsPage (`LeadsPage.tsx`)
+- Updated table to show status badges instead of single status
+- Uses new `statuses` accessor instead of `status`
+
+#### LeadDetailsTab (`LeadDetailsTab.tsx`)
+- Updated to use LeadStatusBadges component
+- Changed from single status to multiple statuses display
+
+### Type Updates (`leads.service.ts`)
+- Added `LeadStatus` interface
+- Updated `Lead` interface to include `statuses` array
+
+## Status Flow
+
+### Typical Lead Processing Flow:
+1. **New**: Default status for newly created leads
+2. **Scraping Site**: Added when `indexSite()` is called
+3. **Analyzing Site**: Added when scraping completes and analysis begins
+4. **Extracting Contacts**: Added during contact extraction phase
+5. **Processed**: Final status when all processing is complete
+
+### Business Rules:
+- Leads must have at least one status (defaults to "New")
+- Multiple statuses can exist simultaneously during processing
+- Statuses are automatically managed by the processing services
+- Statuses are read-only in the UI (not user-editable)
+
+## Migration Notes
+
+To apply these changes:
+
+1. **Run Database Migration**:
+   ```bash
+   npm run db:migrate
+   ```
+
+2. **Restart Server**: To load new schema and functions
+
+3. **Frontend**: Changes are automatically available
+
+## Status Icons and Colors
+
+- **New**: ✨ Blue
+- **Scraping Site**: 🔍 Yellow  
+- **Analyzing Site**: 🧠 Orange
+- **Extracting Contacts**: 📞 Purple
+- **Processed**: ✅ Green
+
+This implementation provides comprehensive tracking of lead processing status while maintaining backward compatibility with the existing status field.

--- a/client/src/components/LeadStatusBadges.tsx
+++ b/client/src/components/LeadStatusBadges.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { LeadStatus } from '../services/leads.service'
+
+interface LeadStatusBadgesProps {
+  statuses: LeadStatus[]
+}
+
+const getStatusColor = (status: LeadStatus['status']) => {
+  switch (status) {
+    case 'New':
+      return 'bg-blue-100 text-blue-800 border-blue-200'
+    case 'Scraping Site':
+      return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+    case 'Analyzing Site':
+      return 'bg-orange-100 text-orange-800 border-orange-200'
+    case 'Extracting Contacts':
+      return 'bg-purple-100 text-purple-800 border-purple-200'
+    case 'Processed':
+      return 'bg-green-100 text-green-800 border-green-200'
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200'
+  }
+}
+
+const getStatusIcon = (status: LeadStatus['status']) => {
+  switch (status) {
+    case 'New':
+      return '✨'
+    case 'Scraping Site':
+      return '🔍'
+    case 'Analyzing Site':
+      return '🧠'
+    case 'Extracting Contacts':
+      return '📞'
+    case 'Processed':
+      return '✅'
+    default:
+      return '●'
+  }
+}
+
+const LeadStatusBadges: React.FC<LeadStatusBadgesProps> = ({ statuses }) => {
+  if (!statuses || statuses.length === 0) {
+    return null
+  }
+
+  // Sort statuses by creation date to show progression
+  const sortedStatuses = [...statuses].sort((a, b) => 
+    new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  )
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {sortedStatuses.map((status) => (
+        <span
+          key={status.id}
+          className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium border ${getStatusColor(status.status)}`}
+        >
+          <span className="text-xs">{getStatusIcon(status.status)}</span>
+          {status.status}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export default LeadStatusBadges

--- a/client/src/components/tabs/LeadDetailsTab.tsx
+++ b/client/src/components/tabs/LeadDetailsTab.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 import { User, Globe } from 'lucide-react'
+import LeadStatusBadges from '../LeadStatusBadges'
+import { LeadStatus } from '../../services/leads.service'
 
 interface LeadDetailsTabProps {
   status: string
   url: string
-  getStatusBadge: (status: string) => React.ReactNode
+  statuses?: LeadStatus[]
 }
 
 const LeadDetailsTab: React.FC<LeadDetailsTabProps> = ({
   status,
   url,
-  getStatusBadge,
+  statuses,
 }) => {
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200">
@@ -23,8 +25,10 @@ const LeadDetailsTab: React.FC<LeadDetailsTabProps> = ({
             <div className="flex items-center space-x-3">
               <User className="h-5 w-5 text-gray-400" />
               <div>
-                <p className="text-sm font-medium text-gray-900">Status</p>
-                <div className="mt-1">{getStatusBadge(status)}</div>
+                <p className="text-sm font-medium text-gray-900">Processing Status</p>
+                <div className="mt-1">
+                  <LeadStatusBadges statuses={statuses || []} />
+                </div>
               </div>
             </div>
           </div>

--- a/client/src/pages/LeadDetailPage.tsx
+++ b/client/src/pages/LeadDetailPage.tsx
@@ -22,6 +22,7 @@ import ContactsTab from '../components/tabs/ContactsTab'
 import AIDetailsTab from '../components/tabs/AIDetailsTab'
 import BrandingTab from '../components/tabs/BrandingTab'
 import LeadDetailsTab from '../components/tabs/LeadDetailsTab'
+import LeadStatusBadges from '../components/LeadStatusBadges'
 
 const LeadDetailPage: React.FC = () => {
   const navigate = useNavigate()
@@ -245,7 +246,7 @@ const LeadDetailPage: React.FC = () => {
           <LeadDetailsTab
             status={lead.status}
             url={lead.url}
-            getStatusBadge={getStatusBadge}
+            statuses={lead.statuses}
           />
         )
       default:
@@ -299,11 +300,13 @@ const LeadDetailPage: React.FC = () => {
                     </a>
                   )}
                 </div>
+                <div className="mt-3">
+                  <LeadStatusBadges statuses={lead.statuses || []} />
+                </div>
                 <p className="mt-2 text-gray-600">Lead Details</p>
               </div>
             </div>
             <div className="flex items-center space-x-3">
-              {getStatusBadge(lead.status)}
               <button
                 onClick={handleResync}
                 disabled={resyncLead.isPending}

--- a/client/src/pages/LeadsPage.tsx
+++ b/client/src/pages/LeadsPage.tsx
@@ -19,6 +19,7 @@ import {
   useUsers,
 } from '../hooks/useLeadsQuery'
 import type { Lead } from '../services/leads.service'
+import LeadStatusBadges from '../components/LeadStatusBadges'
 
 // Define a simple fuzzy filter function (required by global module declaration)
 const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
@@ -289,9 +290,9 @@ const LeadsPage: React.FC = () => {
         ),
       },
       {
-        accessorKey: 'status',
+        accessorKey: 'statuses',
         header: 'Status',
-        cell: (info) => getStatusBadge(info.getValue() as string),
+        cell: (info) => <LeadStatusBadges statuses={info.row.original.statuses || []} />,
       },
       {
         accessorKey: 'ownerId',

--- a/client/src/services/leads.service.ts
+++ b/client/src/services/leads.service.ts
@@ -14,6 +14,13 @@ export interface LeadPointOfContact {
   updatedAt: string
 }
 
+export interface LeadStatus {
+  id: string
+  status: 'New' | 'Scraping Site' | 'Analyzing Site' | 'Extracting Contacts' | 'Processed'
+  createdAt: string
+  updatedAt: string
+}
+
 export interface Lead {
   id: string
   name: string
@@ -32,6 +39,7 @@ export interface Lead {
   createdAt: string
   updatedAt: string
   pointOfContacts?: LeadPointOfContact[]
+  statuses?: LeadStatus[]
 }
 
 export interface CreateLeadData {

--- a/server/src/db/migrations/0021_add_lead_statuses.sql
+++ b/server/src/db/migrations/0021_add_lead_statuses.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS "dripiq_app"."lead_statuses" (
+	"id" text PRIMARY KEY NOT NULL,
+	"lead_id" text NOT NULL,
+	"status" text NOT NULL,
+	"tenant_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "lead_status_unique" UNIQUE("lead_id","status")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "dripiq_app"."lead_statuses" ADD CONSTRAINT "lead_statuses_lead_id_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "dripiq_app"."leads"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "dripiq_app"."lead_statuses" ADD CONSTRAINT "lead_statuses_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "dripiq_app"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+-- Data migration: Add default statuses for existing leads
+INSERT INTO "dripiq_app"."lead_statuses" ("id", "lead_id", "status", "tenant_id", "created_at", "updated_at")
+SELECT 
+  'ls_' || substr(md5(random()::text), 1, 22) as id,
+  l."id" as lead_id,
+  CASE 
+    WHEN l."summary" IS NOT NULL THEN 'Processed'
+    ELSE 'New'
+  END as status,
+  l."tenant_id",
+  now() as created_at,
+  now() as updated_at
+FROM "dripiq_app"."leads" l
+WHERE NOT EXISTS (
+  SELECT 1 FROM "dripiq_app"."lead_statuses" ls 
+  WHERE ls."lead_id" = l."id"
+);

--- a/server/src/db/migrations/meta/0021_snapshot.json
+++ b/server/src/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1188 @@
+{
+  "id": "bd00ab3f-a3ff-4153-ac95-1d40552bdf80",
+  "prevId": "74b2a3a4-f59a-4c97-b35e-d4aac7e2e439",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "dripiq_app.lead_point_of_contacts": {
+      "name": "lead_point_of_contacts",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_reviewed": {
+          "name": "manually_reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_point_of_contacts_lead_id_leads_id_fk": {
+          "name": "lead_point_of_contacts_lead_id_leads_id_fk",
+          "tableFrom": "lead_point_of_contacts",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.lead_statuses": {
+      "name": "lead_statuses",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_statuses_lead_id_leads_id_fk": {
+          "name": "lead_statuses_lead_id_leads_id_fk",
+          "tableFrom": "lead_statuses",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_statuses_tenant_id_tenants_id_fk": {
+          "name": "lead_statuses_tenant_id_tenants_id_fk",
+          "tableFrom": "lead_statuses",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lead_status_unique": {
+          "name": "lead_status_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lead_id",
+            "status"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.leads": {
+      "name": "leads",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "products": {
+          "name": "products",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "differentiators": {
+          "name": "differentiators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_colors": {
+          "name": "brand_colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_contact_id": {
+          "name": "primary_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_embedding_domain_id": {
+          "name": "site_embedding_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leads_owner_id_users_id_fk": {
+          "name": "leads_owner_id_users_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "leads_tenant_id_tenants_id_fk": {
+          "name": "leads_tenant_id_tenants_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leads_site_embedding_domain_id_site_embedding_domains_id_fk": {
+          "name": "leads_site_embedding_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "site_embedding_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.permissions": {
+      "name": "permissions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.products": {
+      "name": "products",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_voice": {
+          "name": "sales_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_tenant_id_tenants_id_fk": {
+          "name": "products_tenant_id_tenants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.role_permissions": {
+      "name": "role_permissions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_permission_unique": {
+          "name": "role_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.roles": {
+      "name": "roles",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.site_embedding_domains": {
+      "name": "site_embedding_domains",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "site_scraped_at_idx": {
+          "name": "site_scraped_at_idx",
+          "columns": [
+            {
+              "expression": "scraped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "site_embedding_domains_domain_unique": {
+          "name": "site_embedding_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.site_embeddings": {
+      "name": "site_embeddings",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_summary": {
+          "name": "content_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firecrawl_id": {
+          "name": "firecrawl_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_embeddings_idx": {
+          "name": "domain_embeddings_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_embedding_idx": {
+          "name": "site_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "site_embedding_token_count_idx": {
+          "name": "site_embedding_token_count_idx",
+          "columns": [
+            {
+              "expression": "token_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_embedding_content_idx": {
+          "name": "site_embedding_content_idx",
+          "columns": [
+            {
+              "expression": "content",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_embeddings_domain_id_site_embedding_domains_id_fk": {
+          "name": "site_embeddings_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "site_embeddings",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.tenants": {
+      "name": "tenants",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_name": {
+          "name": "organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_website": {
+          "name": "organization_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_summary": {
+          "name": "organization_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "differentiators": {
+          "name": "differentiators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_colors": {
+          "name": "brand_colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_embedding_domain_id": {
+          "name": "site_embedding_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenants_site_embedding_domain_id_site_embedding_domains_id_fk": {
+          "name": "tenants_site_embedding_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "tenants",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "site_embedding_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.user_tenants": {
+      "name": "user_tenants",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_user": {
+          "name": "is_super_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tenants_user_id_users_id_fk": {
+          "name": "user_tenants_user_id_users_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenants_tenant_id_tenants_id_fk": {
+          "name": "user_tenants_tenant_id_tenants_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenants_role_id_roles_id_fk": {
+          "name": "user_tenants_role_id_roles_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "roles",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_tenant_unique": {
+          "name": "user_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.users": {
+      "name": "users",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supabase_id": {
+          "name": "supabase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_supabase_id_unique": {
+          "name": "users_supabase_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "dripiq_app": "dripiq_app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1753066104608,
       "tag": "0020_add_manually_reviewed_to_contacts",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1753067851146,
+      "tag": "0021_add_lead_statuses",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/modules/ai/siteAnalyzer.service.ts
+++ b/server/src/modules/ai/siteAnalyzer.service.ts
@@ -3,6 +3,7 @@ import { FireCrawlWebhookPayload } from '@/libs/firecrawl/firecrawl';
 import firecrawlClient from '@/libs/firecrawl/firecrawl.client';
 import { EmbeddingsService } from './embeddings.service';
 import { LeadAnalyzerService } from './leadAnalyzer.service';
+import { updateLeadStatuses } from '../lead.service';
 
 export interface SiteAnalyzerDto {
   storageKey: string;
@@ -42,6 +43,8 @@ export const SiteAnalyzerService = {
 
     switch (metadata.type) {
       case 'lead_site':
+        // Remove "Scraping Site" status when scraping is complete
+        await updateLeadStatuses(metadata.tenantId, metadata.leadId, [], ['Scraping Site']);
         LeadAnalyzerService.analyze(metadata.tenantId, metadata.leadId);
         break;
     }

--- a/server/src/routes/lead.routes.ts
+++ b/server/src/routes/lead.routes.ts
@@ -42,6 +42,17 @@ const pointOfContactResponseSchema = Type.Object({
   updatedAt: Type.String({ format: 'date-time', description: 'Updated timestamp' }),
 });
 
+// Schema for lead status response
+const leadStatusResponseSchema = Type.Object({
+  id: Type.String({ description: 'Status ID' }),
+  status: Type.String({
+    enum: ['New', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed'],
+    description: 'Status value',
+  }),
+  createdAt: Type.String({ format: 'date-time', description: 'Created timestamp' }),
+  updatedAt: Type.String({ format: 'date-time', description: 'Updated timestamp' }),
+});
+
 // Schema for create lead endpoint
 const createLeadBodySchema = Type.Object({
   name: Type.String({ minLength: 1, description: 'Lead name' }),
@@ -83,6 +94,11 @@ const leadResponseSchema = Type.Object({
   pointOfContacts: Type.Optional(
     Type.Array(pointOfContactResponseSchema, {
       description: 'Array of point of contacts for the lead',
+    })
+  ),
+  statuses: Type.Optional(
+    Type.Array(leadStatusResponseSchema, {
+      description: 'Array of processing statuses for the lead',
     })
   ),
 });


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement a multi-status tracking system for leads to reflect their processing stages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR replaces the single `status` field with a dedicated `lead_statuses` table, allowing leads to have multiple concurrent statuses (e.g., 'Scraping Site' and 'New') and providing a more granular view of their processing progress. The UI is updated to display these multiple statuses in a read-only format.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-03f68bea-6594-447b-b8ed-bd084e742aa2) · [Cursor](https://cursor.com/background-agent?bcId=bc-03f68bea-6594-447b-b8ed-bd084e742aa2)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)