### PR TITLE
Refine lead status and UI

### DIFF
--- a/client/src/components/LeadStatusBadges.tsx
+++ b/client/src/components/LeadStatusBadges.tsx
@@ -9,7 +9,9 @@ interface LeadStatusBadgesProps {
 
 const getStatusColor = (status: LeadStatus['status']) => {
   switch (status) {
-    case LEAD_STATUS.NEW:
+    case LEAD_STATUS.UNPROCESSED:
+      return 'bg-gray-100 text-gray-800 border-gray-200'
+    case LEAD_STATUS.SYNCING_SITE:
       return 'bg-blue-100 text-blue-800 border-blue-200'
     case LEAD_STATUS.SCRAPING_SITE:
       return 'bg-yellow-100 text-yellow-800 border-yellow-200'
@@ -26,8 +28,10 @@ const getStatusColor = (status: LeadStatus['status']) => {
 
 const getStatusIcon = (status: LeadStatus['status']) => {
   switch (status) {
-    case LEAD_STATUS.NEW:
-      return '✨'
+    case LEAD_STATUS.UNPROCESSED:
+      return '⏳'
+    case LEAD_STATUS.SYNCING_SITE:
+      return '🔄'
     case LEAD_STATUS.SCRAPING_SITE:
       return '🔍'
     case LEAD_STATUS.ANALYZING_SITE:

--- a/client/src/components/StatusInfoModal.tsx
+++ b/client/src/components/StatusInfoModal.tsx
@@ -1,18 +1,27 @@
 import React from 'react'
-import { LEAD_STATUS_DEFINITIONS, LEAD_STATUS_ORDERED } from '../constants/leadStatusDefinitions'
+import {
+  LEAD_STATUS_DEFINITIONS,
+  LEAD_STATUS_ORDERED,
+} from '../constants/leadStatusDefinitions'
 
 interface StatusInfoModalProps {
   isOpen: boolean
   onClose: () => void
 }
 
-const StatusInfoModal: React.FC<StatusInfoModalProps> = ({ isOpen, onClose }) => {
+const StatusInfoModal: React.FC<StatusInfoModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
   const modalRef = React.useRef<HTMLDivElement>(null)
 
   // Close modal when clicking outside
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node)
+      ) {
         onClose()
       }
     }
@@ -49,19 +58,26 @@ const StatusInfoModal: React.FC<StatusInfoModalProps> = ({ isOpen, onClose }) =>
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-white bg-opacity-80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-opacity-80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"
       >
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Lead Status Definitions</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Lead Status Definitions
+          </h2>
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-gray-600 transition-colors"
             title="Close"
           >
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -71,7 +87,7 @@ const StatusInfoModal: React.FC<StatusInfoModalProps> = ({ isOpen, onClose }) =>
             </svg>
           </button>
         </div>
-        
+
         <div className="p-6">
           <div className="space-y-4">
             {LEAD_STATUS_ORDERED.map((status) => (

--- a/client/src/components/StatusInfoModal.tsx
+++ b/client/src/components/StatusInfoModal.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { LEAD_STATUS_DEFINITIONS, LEAD_STATUS_ORDERED } from '../constants/leadStatusDefinitions'
+
+interface StatusInfoModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const StatusInfoModal: React.FC<StatusInfoModalProps> = ({ isOpen, onClose }) => {
+  const modalRef = React.useRef<HTMLDivElement>(null)
+
+  // Close modal when clicking outside
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      // Prevent body scroll when modal is open
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.body.style.overflow = 'unset'
+    }
+  }, [isOpen, onClose])
+
+  // Close modal on Escape key
+  React.useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-white bg-opacity-80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div
+        ref={modalRef}
+        className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"
+      >
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Lead Status Definitions</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+            title="Close"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        
+        <div className="p-6">
+          <div className="space-y-4">
+            {LEAD_STATUS_ORDERED.map((status) => (
+              <div key={status} className="flex flex-col">
+                <div className="font-medium text-gray-900 mb-1">{status}:</div>
+                <div className="text-gray-600 text-sm leading-relaxed">
+                  {LEAD_STATUS_DEFINITIONS[status]}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default StatusInfoModal

--- a/client/src/constants/leadStatus.constants.ts
+++ b/client/src/constants/leadStatus.constants.ts
@@ -1,9 +1,9 @@
 export const LEAD_STATUS = {
   UNPROCESSED: 'Unprocessed',
-  SYNCING_SITE: 'Syncing site',
-  SCRAPING_SITE: 'Scraping site',
-  ANALYZING_SITE: 'Analyzing site',
-  EXTRACTING_CONTACTS: 'Extracting contacts',
+  SYNCING_SITE: 'Syncing Site',
+  SCRAPING_SITE: 'Scraping Site',
+  ANALYZING_SITE: 'Analyzing Site',
+  EXTRACTING_CONTACTS: 'Extracting Contacts',
   PROCESSED: 'Processed',
 } as const;
 

--- a/client/src/constants/leadStatus.constants.ts
+++ b/client/src/constants/leadStatus.constants.ts
@@ -1,5 +1,6 @@
 export const LEAD_STATUS = {
-  NEW: 'New',
+  UNPROCESSED: 'Unprocessed',
+  SYNCING_SITE: 'Syncing Site',
   SCRAPING_SITE: 'Scraping Site',
   ANALYZING_SITE: 'Analyzing Site',
   EXTRACTING_CONTACTS: 'Extracting Contacts',
@@ -11,9 +12,10 @@ export type LeadStatusValue = typeof LEAD_STATUS[keyof typeof LEAD_STATUS];
 export const LEAD_STATUS_VALUES = Object.values(LEAD_STATUS);
 
 export const LEAD_STATUS_PRIORITY = {
-  [LEAD_STATUS.PROCESSED]: 5,
-  [LEAD_STATUS.EXTRACTING_CONTACTS]: 4,
-  [LEAD_STATUS.ANALYZING_SITE]: 3,
-  [LEAD_STATUS.SCRAPING_SITE]: 2,
-  [LEAD_STATUS.NEW]: 1,
+  [LEAD_STATUS.PROCESSED]: 6,
+  [LEAD_STATUS.EXTRACTING_CONTACTS]: 5,
+  [LEAD_STATUS.ANALYZING_SITE]: 4,
+  [LEAD_STATUS.SCRAPING_SITE]: 3,
+  [LEAD_STATUS.SYNCING_SITE]: 2,
+  [LEAD_STATUS.UNPROCESSED]: 1,
 } as const;

--- a/client/src/constants/leadStatus.constants.ts
+++ b/client/src/constants/leadStatus.constants.ts
@@ -1,9 +1,9 @@
 export const LEAD_STATUS = {
   UNPROCESSED: 'Unprocessed',
-  SYNCING_SITE: 'Syncing Site',
-  SCRAPING_SITE: 'Scraping Site',
-  ANALYZING_SITE: 'Analyzing Site',
-  EXTRACTING_CONTACTS: 'Extracting Contacts',
+  SYNCING_SITE: 'Syncing site',
+  SCRAPING_SITE: 'Scraping site',
+  ANALYZING_SITE: 'Analyzing site',
+  EXTRACTING_CONTACTS: 'Extracting contacts',
   PROCESSED: 'Processed',
 } as const;
 

--- a/client/src/constants/leadStatusDefinitions.ts
+++ b/client/src/constants/leadStatusDefinitions.ts
@@ -1,0 +1,19 @@
+import { LEAD_STATUS } from './leadStatus.constants'
+
+export const LEAD_STATUS_DEFINITIONS = {
+  [LEAD_STATUS.UNPROCESSED]: 'Lead has been created and is waiting to be processed',
+  [LEAD_STATUS.SYNCING_SITE]: 'Initial site sync and preparation is in progress',
+  [LEAD_STATUS.SCRAPING_SITE]: 'Website content is being scraped and collected',
+  [LEAD_STATUS.ANALYZING_SITE]: 'AI is analyzing the website content and extracting insights',
+  [LEAD_STATUS.EXTRACTING_CONTACTS]: 'Contact information is being extracted from the website',
+  [LEAD_STATUS.PROCESSED]: 'Lead has been fully processed and analyzed',
+} as const
+
+export const LEAD_STATUS_ORDERED = [
+  LEAD_STATUS.UNPROCESSED,
+  LEAD_STATUS.SYNCING_SITE,
+  LEAD_STATUS.SCRAPING_SITE,
+  LEAD_STATUS.ANALYZING_SITE,
+  LEAD_STATUS.EXTRACTING_CONTACTS,
+  LEAD_STATUS.PROCESSED,
+] as const

--- a/client/src/constants/leadStatusDefinitions.ts
+++ b/client/src/constants/leadStatusDefinitions.ts
@@ -1,12 +1,12 @@
 import { LEAD_STATUS } from './leadStatus.constants'
 
 export const LEAD_STATUS_DEFINITIONS = {
-  [LEAD_STATUS.UNPROCESSED]: 'Lead has been created and is waiting to be processed',
-  [LEAD_STATUS.SYNCING_SITE]: 'Initial site sync and preparation is in progress',
-  [LEAD_STATUS.SCRAPING_SITE]: 'Website content is being scraped and collected',
-  [LEAD_STATUS.ANALYZING_SITE]: 'AI is analyzing the website content and extracting insights',
-  [LEAD_STATUS.EXTRACTING_CONTACTS]: 'Contact information is being extracted from the website',
-  [LEAD_STATUS.PROCESSED]: 'Lead has been fully processed and analyzed',
+  [LEAD_STATUS.UNPROCESSED]: 'Lead has been created and is waiting to be processed.',
+  [LEAD_STATUS.SYNCING_SITE]: 'Initial site sync and preparation is in progress.',
+  [LEAD_STATUS.SCRAPING_SITE]: 'Website content is being scraped and collected.',
+  [LEAD_STATUS.ANALYZING_SITE]: 'AI is analyzing the website content and extracting insights.',
+  [LEAD_STATUS.EXTRACTING_CONTACTS]: 'Contact information is being extracted from the website.',
+  [LEAD_STATUS.PROCESSED]: 'Lead has been fully processed and analyzed.',
 } as const
 
 export const LEAD_STATUS_ORDERED = [

--- a/client/src/pages/LeadsPage.tsx
+++ b/client/src/pages/LeadsPage.tsx
@@ -63,49 +63,124 @@ function DebouncedInput({
   )
 }
 
-// Status Header Component with Info Tooltip
-function StatusHeader() {
-  const [showTooltip, setShowTooltip] = React.useState(false)
+// Status Info Modal Component
+function StatusInfoModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const modalRef = React.useRef<HTMLDivElement>(null)
+
+  // Close modal when clicking outside
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      // Prevent body scroll when modal is open
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.body.style.overflow = 'unset'
+    }
+  }, [isOpen, onClose])
+
+  // Close modal on Escape key
+  React.useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
 
   return (
-    <div className="flex items-center gap-1">
-      <span>Status</span>
-      <div 
-        className="relative"
-        onMouseEnter={() => setShowTooltip(true)}
-        onMouseLeave={() => setShowTooltip(false)}
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div
+        ref={modalRef}
+        className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"
       >
-        <svg
-          className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Lead Status Definitions</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+            title="Close"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
         
-        {showTooltip && (
-          <div className="absolute z-50 top-6 left-1/2 transform -translate-x-1/2 bg-gray-900 text-white text-xs rounded-lg py-2 px-3 shadow-lg min-w-64 max-w-80">
-            <div className="font-semibold mb-2">Lead Status Definitions:</div>
-            <div className="space-y-1">
-              {LEAD_STATUS_ORDERED.map((status) => (
-                <div key={status} className="flex flex-col">
-                  <span className="font-medium text-gray-200">{status}:</span>
-                  <span className="text-gray-300 ml-2">{LEAD_STATUS_DEFINITIONS[status]}</span>
+        <div className="p-6">
+          <div className="space-y-4">
+            {LEAD_STATUS_ORDERED.map((status) => (
+              <div key={status} className="flex flex-col">
+                <div className="font-medium text-gray-900 mb-1">{status}:</div>
+                <div className="text-gray-600 text-sm leading-relaxed">
+                  {LEAD_STATUS_DEFINITIONS[status]}
                 </div>
-              ))}
-            </div>
-            {/* Tooltip arrow */}
-            <div className="absolute -top-1 left-1/2 transform -translate-x-1/2 w-2 h-2 bg-gray-900 rotate-45"></div>
+              </div>
+            ))}
           </div>
-        )}
+        </div>
       </div>
     </div>
+  )
+}
+
+// Status Header Component with Info Modal
+function StatusHeader() {
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+
+  return (
+    <>
+      <div className="flex items-center gap-1">
+        <span>Status</span>
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="flex items-center justify-center"
+          title="View status definitions"
+        >
+          <svg
+            className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help transition-colors"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </button>
+      </div>
+      
+      <StatusInfoModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
   )
 }
 

--- a/client/src/pages/LeadsPage.tsx
+++ b/client/src/pages/LeadsPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../hooks/useLeadsQuery'
 import type { Lead } from '../types/lead.types'
 import LeadStatusBadges from '../components/LeadStatusBadges'
+import { LEAD_STATUS_DEFINITIONS, LEAD_STATUS_ORDERED } from '../constants/leadStatusDefinitions'
 
 // Define a simple fuzzy filter function (required by global module declaration)
 const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
@@ -59,6 +60,52 @@ function DebouncedInput({
       value={value}
       onChange={(e) => setValue(e.target.value)}
     />
+  )
+}
+
+// Status Header Component with Info Tooltip
+function StatusHeader() {
+  const [showTooltip, setShowTooltip] = React.useState(false)
+
+  return (
+    <div className="flex items-center gap-1">
+      <span>Status</span>
+      <div 
+        className="relative"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        <svg
+          className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        
+        {showTooltip && (
+          <div className="absolute z-50 top-6 left-1/2 transform -translate-x-1/2 bg-gray-900 text-white text-xs rounded-lg py-2 px-3 shadow-lg min-w-64 max-w-80">
+            <div className="font-semibold mb-2">Lead Status Definitions:</div>
+            <div className="space-y-1">
+              {LEAD_STATUS_ORDERED.map((status) => (
+                <div key={status} className="flex flex-col">
+                  <span className="font-medium text-gray-200">{status}:</span>
+                  <span className="text-gray-300 ml-2">{LEAD_STATUS_DEFINITIONS[status]}</span>
+                </div>
+              ))}
+            </div>
+            {/* Tooltip arrow */}
+            <div className="absolute -top-1 left-1/2 transform -translate-x-1/2 w-2 h-2 bg-gray-900 rotate-45"></div>
+          </div>
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -273,7 +320,7 @@ const LeadsPage: React.FC = () => {
       },
       {
         accessorKey: 'statuses',
-        header: 'Status',
+        header: () => <StatusHeader />,
         cell: (info) => <LeadStatusBadges statuses={info.row.original.statuses || []} compact />,
       },
       {

--- a/client/src/pages/LeadsPage.tsx
+++ b/client/src/pages/LeadsPage.tsx
@@ -20,7 +20,7 @@ import {
 } from '../hooks/useLeadsQuery'
 import type { Lead } from '../types/lead.types'
 import LeadStatusBadges from '../components/LeadStatusBadges'
-import { LEAD_STATUS_DEFINITIONS, LEAD_STATUS_ORDERED } from '../constants/leadStatusDefinitions'
+import StatusInfoModal from '../components/StatusInfoModal'
 
 // Define a simple fuzzy filter function (required by global module declaration)
 const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
@@ -60,90 +60,6 @@ function DebouncedInput({
       value={value}
       onChange={(e) => setValue(e.target.value)}
     />
-  )
-}
-
-// Status Info Modal Component
-function StatusInfoModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
-  const modalRef = React.useRef<HTMLDivElement>(null)
-
-  // Close modal when clicking outside
-  React.useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
-        onClose()
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-      // Prevent body scroll when modal is open
-      document.body.style.overflow = 'hidden'
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.body.style.overflow = 'unset'
-    }
-  }, [isOpen, onClose])
-
-  // Close modal on Escape key
-  React.useEffect(() => {
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose()
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape)
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [isOpen, onClose])
-
-  if (!isOpen) return null
-
-  return (
-    <div className="fixed inset-0 bg-white bg-opacity-80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div
-        ref={modalRef}
-        className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"
-      >
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Lead Status Definitions</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
-            title="Close"
-          >
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-        
-        <div className="p-6">
-          <div className="space-y-4">
-            {LEAD_STATUS_ORDERED.map((status) => (
-              <div key={status} className="flex flex-col">
-                <div className="font-medium text-gray-900 mb-1">{status}:</div>
-                <div className="text-gray-600 text-sm leading-relaxed">
-                  {LEAD_STATUS_DEFINITIONS[status]}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
   )
 }
 

--- a/client/src/pages/LeadsPage.tsx
+++ b/client/src/pages/LeadsPage.tsx
@@ -107,7 +107,7 @@ function StatusInfoModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-white bg-opacity-80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"

--- a/client/src/pages/LeadsPage.tsx
+++ b/client/src/pages/LeadsPage.tsx
@@ -77,7 +77,7 @@ function StatusHeader() {
           title="View status definitions"
         >
           <svg
-            className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help transition-colors"
+            className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-pointer transition-colors"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -91,7 +91,7 @@ function StatusHeader() {
           </svg>
         </button>
       </div>
-      
+
       <StatusInfoModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
@@ -162,8 +162,6 @@ const LeadsPage: React.FC = () => {
       day: 'numeric',
     })
   }
-
-
 
   const getOwnerDisplay = (lead: Lead) => {
     // Find the owner user from the users list
@@ -312,7 +310,12 @@ const LeadsPage: React.FC = () => {
       {
         accessorKey: 'statuses',
         header: () => <StatusHeader />,
-        cell: (info) => <LeadStatusBadges statuses={info.row.original.statuses || []} compact />,
+        cell: (info) => (
+          <LeadStatusBadges
+            statuses={info.row.original.statuses || []}
+            compact
+          />
+        ),
       },
       {
         accessorKey: 'ownerId',
@@ -639,7 +642,7 @@ const LeadsPage: React.FC = () => {
                         <th
                           key={header.id}
                           scope="col"
-                          className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                          className="px-6 py-3 text-left text-xs font-medium text-gray-500 tracking-wider"
                         >
                           {header.isPlaceholder
                             ? null

--- a/server/src/constants/leadStatus.constants.ts
+++ b/server/src/constants/leadStatus.constants.ts
@@ -1,9 +1,9 @@
 export const LEAD_STATUS = {
   UNPROCESSED: 'Unprocessed',
-  SYNCING_SITE: 'Syncing site',
-  SCRAPING_SITE: 'Scraping site',
-  ANALYZING_SITE: 'Analyzing site',
-  EXTRACTING_CONTACTS: 'Extracting contacts',
+  SYNCING_SITE: 'Syncing Site',
+  SCRAPING_SITE: 'Scraping Site',
+  ANALYZING_SITE: 'Analyzing Site',
+  EXTRACTING_CONTACTS: 'Extracting Contacts',
   PROCESSED: 'Processed',
 } as const;
 

--- a/server/src/constants/leadStatus.constants.ts
+++ b/server/src/constants/leadStatus.constants.ts
@@ -1,5 +1,6 @@
 export const LEAD_STATUS = {
-  NEW: 'New',
+  UNPROCESSED: 'Unprocessed',
+  SYNCING_SITE: 'Syncing Site',
   SCRAPING_SITE: 'Scraping Site',
   ANALYZING_SITE: 'Analyzing Site',
   EXTRACTING_CONTACTS: 'Extracting Contacts',
@@ -11,9 +12,10 @@ export type LeadStatusValue = (typeof LEAD_STATUS)[keyof typeof LEAD_STATUS];
 export const LEAD_STATUS_VALUES = Object.values(LEAD_STATUS);
 
 export const LEAD_STATUS_PRIORITY = {
-  [LEAD_STATUS.PROCESSED]: 5,
-  [LEAD_STATUS.EXTRACTING_CONTACTS]: 4,
-  [LEAD_STATUS.ANALYZING_SITE]: 3,
-  [LEAD_STATUS.SCRAPING_SITE]: 2,
-  [LEAD_STATUS.NEW]: 1,
+  [LEAD_STATUS.PROCESSED]: 6,
+  [LEAD_STATUS.EXTRACTING_CONTACTS]: 5,
+  [LEAD_STATUS.ANALYZING_SITE]: 4,
+  [LEAD_STATUS.SCRAPING_SITE]: 3,
+  [LEAD_STATUS.SYNCING_SITE]: 2,
+  [LEAD_STATUS.UNPROCESSED]: 1,
 } as const;

--- a/server/src/constants/leadStatus.constants.ts
+++ b/server/src/constants/leadStatus.constants.ts
@@ -1,9 +1,9 @@
 export const LEAD_STATUS = {
   UNPROCESSED: 'Unprocessed',
-  SYNCING_SITE: 'Syncing Site',
-  SCRAPING_SITE: 'Scraping Site',
-  ANALYZING_SITE: 'Analyzing Site',
-  EXTRACTING_CONTACTS: 'Extracting Contacts',
+  SYNCING_SITE: 'Syncing site',
+  SCRAPING_SITE: 'Scraping site',
+  ANALYZING_SITE: 'Analyzing site',
+  EXTRACTING_CONTACTS: 'Extracting contacts',
   PROCESSED: 'Processed',
 } as const;
 

--- a/server/src/modules/ai/leadAnalyzer.service.ts
+++ b/server/src/modules/ai/leadAnalyzer.service.ts
@@ -1,9 +1,9 @@
 import { getLeadById, updateLead, updateLeadStatuses } from '../lead.service';
+import { LEAD_STATUS } from '../../constants/leadStatus.constants';
 import { siteAnalysisAgent } from './langchain';
 import { EmbeddingsService } from './embeddings.service';
 import { SiteScrapeService } from './siteScrape.service';
 import { ContactExtractionService } from './contactExtraction.service';
-import { LEAD_STATUS } from '../../constants/leadStatus.constants';
 
 export const LeadAnalyzerService = {
   analyze: async (tenantId: string, leadId: string) => {
@@ -24,7 +24,12 @@ export const LeadAnalyzerService = {
     );
   },
   summarizeSite: async (tenantId: string, leadId: string, domain: string) => {
-    await updateLeadStatuses(tenantId, leadId, [LEAD_STATUS.ANALYZING_SITE], [LEAD_STATUS.SYNCING_SITE, LEAD_STATUS.SCRAPING_SITE]);
+    await updateLeadStatuses(
+      tenantId,
+      leadId,
+      [LEAD_STATUS.ANALYZING_SITE],
+      [LEAD_STATUS.SYNCING_SITE, LEAD_STATUS.SCRAPING_SITE]
+    );
 
     // Run site analysis
     const aiOutput = await siteAnalysisAgent.analyze(domain);
@@ -56,7 +61,12 @@ export const LeadAnalyzerService = {
     const { url } = await getLeadById(tenantId, leadId);
 
     // Add "Syncing Site" status when starting to index
-    await updateLeadStatuses(tenantId, leadId, [LEAD_STATUS.SYNCING_SITE], [LEAD_STATUS.UNPROCESSED]);
+    await updateLeadStatuses(
+      tenantId,
+      leadId,
+      [LEAD_STATUS.SYNCING_SITE],
+      [LEAD_STATUS.UNPROCESSED]
+    );
 
     if (await LeadAnalyzerService.wasLastScrapeTooRecent(url.getDomain())) {
       await LeadAnalyzerService.analyze(tenantId, leadId);
@@ -64,7 +74,12 @@ export const LeadAnalyzerService = {
     }
 
     // Add "Scraping Site" status when starting to scrape
-    await updateLeadStatuses(tenantId, leadId, [LEAD_STATUS.SCRAPING_SITE], [LEAD_STATUS.SYNCING_SITE]);
+    await updateLeadStatuses(
+      tenantId,
+      leadId,
+      [LEAD_STATUS.SCRAPING_SITE],
+      [LEAD_STATUS.SYNCING_SITE]
+    );
 
     const metadata = {
       leadId,

--- a/server/src/modules/ai/siteAnalyzer.service.ts
+++ b/server/src/modules/ai/siteAnalyzer.service.ts
@@ -2,9 +2,9 @@ import { supabaseStorage } from '@/libs/supabase.storage';
 import { FireCrawlWebhookPayload } from '@/libs/firecrawl/firecrawl';
 import firecrawlClient from '@/libs/firecrawl/firecrawl.client';
 import { updateLeadStatuses } from '../lead.service';
+import { LEAD_STATUS } from '../../constants/leadStatus.constants';
 import { EmbeddingsService } from './embeddings.service';
 import { LeadAnalyzerService } from './leadAnalyzer.service';
-import { LEAD_STATUS } from '../../constants/leadStatus.constants';
 
 export interface SiteAnalyzerDto {
   storageKey: string;
@@ -45,7 +45,12 @@ export const SiteAnalyzerService = {
     switch (metadata.type) {
       case 'lead_site':
         // Remove "Scraping Site" status when scraping is complete
-        await updateLeadStatuses(metadata.tenantId, metadata.leadId, [], [LEAD_STATUS.SCRAPING_SITE]);
+        await updateLeadStatuses(
+          metadata.tenantId,
+          metadata.leadId,
+          [],
+          [LEAD_STATUS.SCRAPING_SITE]
+        );
         LeadAnalyzerService.analyze(metadata.tenantId, metadata.leadId);
         break;
     }

--- a/server/src/modules/ai/siteAnalyzer.service.ts
+++ b/server/src/modules/ai/siteAnalyzer.service.ts
@@ -4,6 +4,7 @@ import firecrawlClient from '@/libs/firecrawl/firecrawl.client';
 import { updateLeadStatuses } from '../lead.service';
 import { EmbeddingsService } from './embeddings.service';
 import { LeadAnalyzerService } from './leadAnalyzer.service';
+import { LEAD_STATUS } from '../../constants/leadStatus.constants';
 
 export interface SiteAnalyzerDto {
   storageKey: string;
@@ -44,7 +45,7 @@ export const SiteAnalyzerService = {
     switch (metadata.type) {
       case 'lead_site':
         // Remove "Scraping Site" status when scraping is complete
-        await updateLeadStatuses(metadata.tenantId, metadata.leadId, [], ['Scraping Site']);
+        await updateLeadStatuses(metadata.tenantId, metadata.leadId, [], [LEAD_STATUS.SCRAPING_SITE]);
         LeadAnalyzerService.analyze(metadata.tenantId, metadata.leadId);
         break;
     }

--- a/server/src/modules/lead.service.ts
+++ b/server/src/modules/lead.service.ts
@@ -15,6 +15,7 @@ import {
 } from '../db/schema';
 import { logger } from '../libs/logger';
 import { storageService } from './storage/storage.service';
+import { LEAD_STATUS } from '../constants/leadStatus.constants';
 
 // Helper function to transform lead data with signed URLs
 const transformLeadWithSignedUrls = async (tenantId: string, lead: any) => {
@@ -188,11 +189,11 @@ export const createLead = async (
       }
     }
 
-    // Create default "New" status for the lead
+    // Create default "Unprocessed" status for the lead
     await tx.insert(leadStatuses).values({
       leadId: createdLead.id,
       tenantId,
-      status: 'New',
+      status: LEAD_STATUS.UNPROCESSED,
     });
 
     // Transform lead with signed URLs
@@ -592,7 +593,7 @@ export const hasStatus = async (
 };
 
 /**
- * Ensure a lead has the default "New" status if no statuses exist
+ * Ensure a lead has the default "Unprocessed" status if no statuses exist
  * @param tenantId - The ID of the tenant
  * @param leadId - The ID of the lead
  * @returns A promise that resolves when the default status is ensured
@@ -609,10 +610,10 @@ export const ensureDefaultStatus = async (tenantId: string, leadId: string): Pro
       await db.insert(leadStatuses).values({
         leadId,
         tenantId,
-        status: 'New',
+        status: LEAD_STATUS.UNPROCESSED,
       });
 
-      logger.info(`Added default "New" status to lead ${leadId}`);
+      logger.info(`Added default "Unprocessed" status to lead ${leadId}`);
     }
   } catch (error) {
     logger.error('Error ensuring default status:', error);
@@ -653,11 +654,11 @@ export const ensureAllLeadsHaveDefaultStatus = async (tenantId: string): Promise
       const defaultStatuses = leadsWithoutStatus.map((lead) => ({
         leadId: lead.id,
         tenantId,
-        status: 'New' as const,
+        status: LEAD_STATUS.UNPROCESSED,
       }));
 
       await db.insert(leadStatuses).values(defaultStatuses);
-      logger.info(`Added default "New" status to ${leadsWithoutStatus.length} leads`);
+      logger.info(`Added default "Unprocessed" status to ${leadsWithoutStatus.length} leads`);
     }
   } catch (error) {
     logger.error('Error ensuring all leads have default status:', error);
@@ -731,12 +732,12 @@ export const updateLeadStatuses = async (
         .where(and(eq(leadStatuses.leadId, leadId), eq(leadStatuses.tenantId, tenantId)))
         .orderBy(leadStatuses.createdAt);
 
-      // Ensure at least one status exists (add "New" if none exist)
+      // Ensure at least one status exists (add "Unprocessed" if none exist)
       if (updatedStatuses.length === 0) {
         await tx.insert(leadStatuses).values({
           leadId,
           tenantId,
-          status: 'New',
+          status: LEAD_STATUS.UNPROCESSED,
         });
 
         // Get the final statuses including the default one

--- a/server/src/modules/lead.service.ts
+++ b/server/src/modules/lead.service.ts
@@ -14,8 +14,8 @@ import {
   users,
 } from '../db/schema';
 import { logger } from '../libs/logger';
-import { storageService } from './storage/storage.service';
 import { LEAD_STATUS } from '../constants/leadStatus.constants';
+import { storageService } from './storage/storage.service';
 
 // Helper function to transform lead data with signed URLs
 const transformLeadWithSignedUrls = async (tenantId: string, lead: any) => {

--- a/server/src/routes/lead.routes.ts
+++ b/server/src/routes/lead.routes.ts
@@ -46,7 +46,14 @@ const pointOfContactResponseSchema = Type.Object({
 const leadStatusResponseSchema = Type.Object({
   id: Type.String({ description: 'Status ID' }),
   status: Type.String({
-    enum: ['Unprocessed', 'Syncing Site', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed'],
+    enum: [
+      'Unprocessed',
+      'Syncing Site',
+      'Scraping Site',
+      'Analyzing Site',
+      'Extracting Contacts',
+      'Processed',
+    ],
     description: 'Status value',
   }),
   createdAt: Type.String({ format: 'date-time', description: 'Created timestamp' }),

--- a/server/src/routes/lead.routes.ts
+++ b/server/src/routes/lead.routes.ts
@@ -46,7 +46,7 @@ const pointOfContactResponseSchema = Type.Object({
 const leadStatusResponseSchema = Type.Object({
   id: Type.String({ description: 'Status ID' }),
   status: Type.String({
-    enum: ['New', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed'],
+    enum: ['Unprocessed', 'Syncing Site', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed'],
     description: 'Status value',
   }),
   createdAt: Type.String({ format: 'date-time', description: 'Created timestamp' }),
@@ -231,8 +231,8 @@ export default async function LeadRoutes(fastify: FastifyInstance, _opts: RouteO
           return;
         }
 
-        // analyze lead
-        // await LeadAnalyzerService.analyze(authenticatedRequest.tenantId, newLead.id);
+        // Index the lead's site after creation
+        await LeadAnalyzerService.indexSite(authenticatedRequest.tenantId, newLead.id);
 
         reply.status(201).send({
           message: 'Lead created successfully',

--- a/server/src/routes/lead.routes.ts
+++ b/server/src/routes/lead.routes.ts
@@ -46,7 +46,7 @@ const pointOfContactResponseSchema = Type.Object({
 const leadStatusResponseSchema = Type.Object({
   id: Type.String({ description: 'Status ID' }),
   status: Type.String({
-    enum: ['Unprocessed', 'Syncing site', 'Scraping site', 'Analyzing site', 'Extracting contacts', 'Processed'],
+    enum: ['Unprocessed', 'Syncing Site', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed'],
     description: 'Status value',
   }),
   createdAt: Type.String({ format: 'date-time', description: 'Created timestamp' }),

--- a/server/src/routes/lead.routes.ts
+++ b/server/src/routes/lead.routes.ts
@@ -46,7 +46,7 @@ const pointOfContactResponseSchema = Type.Object({
 const leadStatusResponseSchema = Type.Object({
   id: Type.String({ description: 'Status ID' }),
   status: Type.String({
-    enum: ['Unprocessed', 'Syncing Site', 'Scraping Site', 'Analyzing Site', 'Extracting Contacts', 'Processed'],
+    enum: ['Unprocessed', 'Syncing site', 'Scraping site', 'Analyzing site', 'Extracting contacts', 'Processed'],
     description: 'Status value',
   }),
   createdAt: Type.String({ format: 'date-time', description: 'Created timestamp' }),


### PR DESCRIPTION
Update lead statuses, automate site indexing on creation, and replace status tooltip with an accessible modal.

The previous hover-based tooltip for lead status definitions had UI issues (jittering, clipping). This PR replaces it with a click-to-open modal for a better user experience, while also standardizing lead statuses (e.g., "Unprocessed" as default) and automating the initial site analysis flow by invoking `LeadAnalyzerService.indexSite` upon lead creation.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-5ca5b35f-3c50-403e-8385-d3bb942397f5) · [Cursor](https://cursor.com/background-agent?bcId=bc-5ca5b35f-3c50-403e-8385-d3bb942397f5)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)