### PR TITLE
Implement qualify lead contact caching

### DIFF
--- a/server/src/libs/supabase.storage.ts
+++ b/server/src/libs/supabase.storage.ts
@@ -82,7 +82,7 @@ export const supabaseStorage = {
         logger.error(`Error downloading file ${key}`, error);
         return null;
       }
-      
+
       if (data) {
         const text = await data.text();
         try {
@@ -92,7 +92,7 @@ export const supabaseStorage = {
           return null;
         }
       }
-      
+
       return null;
     } catch (error) {
       logger.error(`Error downloading file ${key}`, error);
@@ -104,14 +104,14 @@ export const supabaseStorage = {
     try {
       const jsonString = JSON.stringify(jsonData, null, 2);
       const fileBlob = new Blob([jsonString], { type: 'application/json' });
-      
+
       const file: IUploadFile = {
         contentType: 'application/json',
         fileName: key.split('/').pop() || 'data.json',
         fileBody: fileBlob,
         slug: '',
       };
-      
+
       return await supabaseStorage.uploadFile(key, file);
     } catch (error) {
       logger.error(`Error uploading JSON file ${key}`, error);

--- a/server/src/libs/supabase.storage.ts
+++ b/server/src/libs/supabase.storage.ts
@@ -57,4 +57,65 @@ export const supabaseStorage = {
       logger.error(`Error uploading files ${key}`, error);
     }
   },
+
+  fileExists: async (key: string): Promise<boolean> => {
+    try {
+      const { data, error } = await supabase.storage.from(bucket).exists(key);
+      if (error) {
+        logger.error(`Error checking if file exists ${key}`, error);
+        return false;
+      }
+      return !!data;
+    } catch (error) {
+      logger.error(`Error checking if file exists ${key}`, error);
+      return false;
+    }
+  },
+
+  downloadFile: async (key: string): Promise<any | null> => {
+    try {
+      const { data, error } = await supabase.storage.from(bucket).download(key);
+      if (error) {
+        if (error.message.includes('not found') || error.message.includes('Object not found')) {
+          return null;
+        }
+        logger.error(`Error downloading file ${key}`, error);
+        return null;
+      }
+      
+      if (data) {
+        const text = await data.text();
+        try {
+          return JSON.parse(text);
+        } catch (parseError) {
+          logger.error(`Error parsing JSON from file ${key}`, parseError);
+          return null;
+        }
+      }
+      
+      return null;
+    } catch (error) {
+      logger.error(`Error downloading file ${key}`, error);
+      return null;
+    }
+  },
+
+  uploadJsonFile: async (key: string, jsonData: any): Promise<any> => {
+    try {
+      const jsonString = JSON.stringify(jsonData, null, 2);
+      const fileBlob = new Blob([jsonString], { type: 'application/json' });
+      
+      const file: IUploadFile = {
+        contentType: 'application/json',
+        fileName: key.split('/').pop() || 'data.json',
+        fileBody: fileBlob,
+        slug: '',
+      };
+      
+      return await supabaseStorage.uploadFile(key, file);
+    } catch (error) {
+      logger.error(`Error uploading JSON file ${key}`, error);
+      throw error;
+    }
+  },
 };

--- a/server/src/modules/ai/leadQualification.service.ts
+++ b/server/src/modules/ai/leadQualification.service.ts
@@ -1,10 +1,10 @@
 import { logger } from '@/libs/logger';
+import { supabaseStorage } from '@/libs/supabase.storage';
 import { ProductsService } from '../products.service';
 import { getLeadById } from '../lead.service';
 import { TenantService } from '../tenant.service';
 import type { LeadQualificationResult } from './langchain/agents/LeadQualificationAgent';
 import { getLeadQualificationAgent } from './langchain';
-import { supabaseStorage } from '@/libs/supabase.storage';
 
 export interface QualifyLeadContactParams {
   leadId: string;
@@ -24,7 +24,7 @@ export const qualifyLeadContact = async (
   try {
     // Check if cached result exists in storage
     const cacheKey = `${tenantId}/${leadId}/${contactId}/qualify.json`;
-    
+
     logger.info('Checking for cached qualification result', {
       leadId,
       contactId,
@@ -145,7 +145,7 @@ export const qualifyLeadContact = async (
     try {
       const agent = getLeadQualificationAgent();
       const result = await agent.qualifyLead(agentInput);
-      
+
       // Save result to cache
       try {
         await supabaseStorage.uploadJsonFile(cacheKey, result);
@@ -165,7 +165,7 @@ export const qualifyLeadContact = async (
         });
         // Don't throw error for cache failures - return the result anyway
       }
-      
+
       return result;
     } catch (agentError) {
       logger.error('Agent execution failed', {


### PR DESCRIPTION
Implement caching for `qualifyLeadContact` using Supabase storage to improve performance and reduce redundant agent calls.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-07160f21-20be-48d0-934c-b80fe4b02b35) · [Cursor](https://cursor.com/background-agent?bcId=bc-07160f21-20be-48d0-934c-b80fe4b02b35)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)