### PR TITLE
Fix product edit modal prepopulation and resize

### DIFF
--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -102,13 +102,17 @@ function ProductModal({
             <textarea
               id="description"
               value={formData.description}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData((prev) => ({
                   ...prev,
                   description: e.target.value,
                 }))
-              }
+                // Auto-resize textarea
+                e.target.style.height = 'auto'
+                e.target.style.height = e.target.scrollHeight + 'px'
+              }}
               rows={3}
+              style={{ resize: 'none', overflow: 'hidden' }}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent"
             />
           </div>
@@ -123,10 +127,14 @@ function ProductModal({
             <textarea
               id="salesVoice"
               value={formData.salesVoice}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData((prev) => ({ ...prev, salesVoice: e.target.value }))
-              }
+                // Auto-resize textarea
+                e.target.style.height = 'auto'
+                e.target.style.height = e.target.scrollHeight + 'px'
+              }}
               rows={3}
+              style={{ resize: 'none', overflow: 'hidden' }}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent"
               placeholder="How would you describe this product to a potential customer?"
             />

--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Package, Plus, Edit, Trash2, AlertCircle } from 'lucide-react'
 import {
   useProducts,
@@ -36,6 +36,15 @@ function ProductModal({
     salesVoice: product?.salesVoice || '',
   })
 
+  // Update form data when product prop changes
+  useEffect(() => {
+    setFormData({
+      title: product?.title || '',
+      description: product?.description || '',
+      salesVoice: product?.salesVoice || '',
+    })
+  }, [product])
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (product) {
@@ -58,7 +67,7 @@ function ProductModal({
 
   return (
     <div className="fixed inset-0 backdrop-blur bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4">
+      <div className="bg-white rounded-lg p-6 w-4/5 mx-4 min-h-[50vh] max-h-[90vh] overflow-y-auto">
         <h2 className="text-xl font-semibold mb-4">
           {product ? 'Edit Product' : 'Create Product'}
         </h2>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes product modal prepopulation bug and updates modal dimensions.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `formData` state in `ProductModal` was initialized only on component mount. When the `product` prop changed (e.g., on the first edit click), the `useState` hook did not re-evaluate, leading to empty fields until a subsequent re-render. A `useEffect` hook now updates `formData` whenever the `product` prop changes, ensuring immediate prepopulation.

---

[Open in Web](https://cursor.com/agents?id=bc-9976f8c4-2404-4346-bb02-7de810d2f3f1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9976f8c4-2404-4346-bb02-7de810d2f3f1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)