### PR TITLE
Add default product association for new leads

### DIFF
--- a/client/src/components/AnimatedCheckbox.tsx
+++ b/client/src/components/AnimatedCheckbox.tsx
@@ -22,6 +22,7 @@ const AnimatedCheckbox: React.FC<AnimatedCheckboxProps> = ({
 }) => {
   return (
     <button
+      type="button"
       onClick={onChange}
       disabled={disabled || loading}
       className={`flex items-center space-x-2 px-3 py-1 rounded-md border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${className}`}

--- a/client/src/components/AnimatedCheckbox.tsx
+++ b/client/src/components/AnimatedCheckbox.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { CheckSquare, Square } from 'lucide-react'
+
+interface AnimatedCheckboxProps {
+  checked: boolean
+  onChange: () => void
+  disabled?: boolean
+  loading?: boolean
+  label: string
+  title?: string
+  className?: string
+}
+
+const AnimatedCheckbox: React.FC<AnimatedCheckboxProps> = ({
+  checked,
+  onChange,
+  disabled = false,
+  loading = false,
+  label,
+  title,
+  className = '',
+}) => {
+  return (
+    <button
+      onClick={onChange}
+      disabled={disabled || loading}
+      className={`flex items-center space-x-2 px-3 py-1 rounded-md border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      title={title}
+    >
+      {loading ? (
+        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"></div>
+      ) : checked ? (
+        <CheckSquare className="h-4 w-4 text-green-600" />
+      ) : (
+        <Square className="h-4 w-4 text-gray-400" />
+      )}
+      <span className="text-sm font-medium text-gray-700">
+        {label}
+      </span>
+    </button>
+  )
+}
+
+export default AnimatedCheckbox

--- a/client/src/components/tabs/ContactsTab.tsx
+++ b/client/src/components/tabs/ContactsTab.tsx
@@ -7,8 +7,6 @@ import {
   Phone,
   Building,
   ExternalLink,
-  CheckSquare,
-  Square,
   Target,
   Loader2,
   Edit3,
@@ -18,6 +16,7 @@ import {
 import { useMutation } from '@tanstack/react-query'
 import CopyButton from '../CopyButton'
 import LeadQualificationModal from '../LeadQualificationModal'
+import AnimatedCheckbox from '../AnimatedCheckbox'
 import type { LeadPointOfContact } from '../../types/lead.types'
 import { getLeadsService } from '../../services/leads.service'
 import { useUpdateContact, useToggleContactManuallyReviewed } from '../../hooks/useLeadsQuery'
@@ -441,27 +440,18 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
                               : 'Generate Strategy'}
                           </span>
                         </button>
-                        <button
-                          onClick={() => handleToggleManuallyReviewed(contact)}
+                        <AnimatedCheckbox
+                          checked={contact.manuallyReviewed}
+                          onChange={() => handleToggleManuallyReviewed(contact)}
                           disabled={loadingContactId === contact.id || editingContactId !== null || toggleManuallyReviewedMutation.isPending}
-                          className="flex items-center space-x-2 px-3 py-1 rounded-md border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          loading={loadingContactId === contact.id || toggleManuallyReviewedMutation.isPending}
+                          label="Manually Reviewed"
                           title={
                             contact.manuallyReviewed
                               ? 'Mark as not manually reviewed'
                               : 'Mark as manually reviewed'
                           }
-                        >
-                          {(loadingContactId === contact.id || toggleManuallyReviewedMutation.isPending) ? (
-                            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"></div>
-                          ) : contact.manuallyReviewed ? (
-                            <CheckSquare className="h-4 w-4 text-green-600" />
-                          ) : (
-                            <Square className="h-4 w-4 text-gray-400" />
-                          )}
-                          <span className="text-sm font-medium text-gray-700">
-                            Manually Reviewed
-                          </span>
-                        </button>
+                        />
                       </>
                     )}
                   </div>

--- a/client/src/hooks/useProductsQuery.ts
+++ b/client/src/hooks/useProductsQuery.ts
@@ -19,7 +19,7 @@ export const productsQueryKeys = {
 export function useProducts(tenantId: string) {
   return useQuery({
     queryKey: productsQueryKeys.list(tenantId),
-    queryFn: () => productsService.getProducts(tenantId),
+    queryFn: () => productsService.getProducts(),
     enabled: !!tenantId,
     staleTime: 1000 * 60 * 5, // Consider data stale after 5 minutes
     refetchOnMount: 'always',

--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -34,6 +34,7 @@ function ProductModal({
     title: product?.title || '',
     description: product?.description || '',
     salesVoice: product?.salesVoice || '',
+    isDefault: product?.isDefault || false,
   })
 
   // Update form data when product prop changes
@@ -42,6 +43,7 @@ function ProductModal({
       title: product?.title || '',
       description: product?.description || '',
       salesVoice: product?.salesVoice || '',
+      isDefault: product?.isDefault || false,
     })
   }, [product])
 
@@ -59,6 +61,7 @@ function ProductModal({
       title: product?.title || '',
       description: product?.description || '',
       salesVoice: product?.salesVoice || '',
+      isDefault: product?.isDefault || false,
     })
     onClose()
   }
@@ -138,6 +141,25 @@ function ProductModal({
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent"
               placeholder="How would you describe this product to a potential customer?"
             />
+          </div>
+
+          <div>
+            <label className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={formData.isDefault}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, isDefault: e.target.checked }))
+                }
+                className="w-4 h-4 text-[var(--color-primary-600)] bg-gray-100 border-gray-300 rounded focus:ring-[var(--color-primary-500)] focus:ring-2"
+              />
+              <span className="text-sm font-medium text-gray-700">
+                Default Product
+              </span>
+            </label>
+            <p className="text-xs text-gray-500 mt-1">
+              Default products are automatically associated with new leads
+            </p>
           </div>
 
           <div className="flex justify-end space-x-3 pt-4">
@@ -322,9 +344,16 @@ export default function ProductsPage() {
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
-                      <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                        {product.title}
-                      </h3>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <h3 className="text-lg font-semibold text-gray-900">
+                          {product.title}
+                        </h3>
+                        {product.isDefault && (
+                          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                            Default
+                          </span>
+                        )}
+                      </div>
                       {product.description && (
                         <p className="text-gray-600 mb-3">
                           {product.description}

--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -385,13 +385,13 @@ export default function ProductsPage() {
                           Created:{' '}
                           {new Date(product.createdAt).toLocaleDateString()}
                         </div>
-                        <label className="flex items-center space-x-2">
+                        <label className="flex items-center space-x-2 px-3 py-1 rounded-md border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                           <input
                             type="checkbox"
                             checked={product.isDefault}
                             onChange={() => handleToggleDefault(product)}
                             disabled={updateProductMutation.isPending}
-                            className="w-4 h-4 text-[var(--color-primary-600)] bg-gray-100 border-gray-300 rounded focus:ring-[var(--color-primary-500)] focus:ring-2 disabled:opacity-50"
+                            className="w-4 h-4 text-[var(--color-primary-600)] bg-gray-100 border-gray-300 rounded focus:ring-[var(--color-primary-500)] focus:ring-2"
                           />
                           <span className="text-sm text-gray-700">
                             Default Product

--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -237,6 +237,17 @@ export default function ProductsPage() {
     }
   }
 
+  const handleToggleDefault = async (product: Product) => {
+    try {
+      await updateProductMutation.mutateAsync({
+        id: product.id,
+        data: { isDefault: !product.isDefault }
+      })
+    } catch (error) {
+      console.error('Error updating product default status:', error)
+    }
+  }
+
   const openEditModal = (product: Product) => {
     setEditingProduct(product)
     setIsModalOpen(true)
@@ -369,9 +380,23 @@ export default function ProductsPage() {
                           </p>
                         </div>
                       )}
-                      <div className="mt-3 text-xs text-gray-500">
-                        Created:{' '}
-                        {new Date(product.createdAt).toLocaleDateString()}
+                      <div className="mt-3 flex items-center justify-between">
+                        <div className="text-xs text-gray-500">
+                          Created:{' '}
+                          {new Date(product.createdAt).toLocaleDateString()}
+                        </div>
+                        <label className="flex items-center space-x-2">
+                          <input
+                            type="checkbox"
+                            checked={product.isDefault}
+                            onChange={() => handleToggleDefault(product)}
+                            disabled={updateProductMutation.isPending}
+                            className="w-4 h-4 text-[var(--color-primary-600)] bg-gray-100 border-gray-300 rounded focus:ring-[var(--color-primary-500)] focus:ring-2 disabled:opacity-50"
+                          />
+                          <span className="text-sm text-gray-700">
+                            Default Product
+                          </span>
+                        </label>
                       </div>
                     </div>
                     <div className="flex items-center space-x-2 ml-4">

--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Package, Plus, Edit, Trash2, AlertCircle, CheckSquare, Square } from 'lucide-react'
+import { Package, Plus, Edit, Trash2, AlertCircle } from 'lucide-react'
 import {
   useProducts,
   useCreateProduct,
@@ -7,6 +7,7 @@ import {
   useDeleteProduct,
 } from '../../hooks/useProductsQuery'
 import { useAuth } from '../../contexts/AuthContext'
+import AnimatedCheckbox from '../../components/AnimatedCheckbox'
 import type {
   Product,
   CreateProductData,
@@ -390,27 +391,18 @@ export default function ProductsPage() {
                           Created:{' '}
                           {new Date(product.createdAt).toLocaleDateString()}
                         </div>
-                        <button
-                          onClick={() => handleToggleDefault(product)}
+                        <AnimatedCheckbox
+                          checked={product.isDefault}
+                          onChange={() => handleToggleDefault(product)}
                           disabled={loadingProductId === product.id || updateProductMutation.isPending}
-                          className="flex items-center space-x-2 px-3 py-1 rounded-md border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          loading={loadingProductId === product.id}
+                          label="Default Product"
                           title={
                             product.isDefault
                               ? 'Remove as default product'
                               : 'Set as default product'
                           }
-                        >
-                          {loadingProductId === product.id ? (
-                            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"></div>
-                          ) : product.isDefault ? (
-                            <CheckSquare className="h-4 w-4 text-green-600" />
-                          ) : (
-                            <Square className="h-4 w-4 text-gray-400" />
-                          )}
-                          <span className="text-sm font-medium text-gray-700">
-                            Default Product
-                          </span>
-                        </button>
+                        />
                       </div>
                     </div>
                     <div className="flex items-center space-x-2 ml-4">

--- a/client/src/pages/settings/ProductsPage.tsx
+++ b/client/src/pages/settings/ProductsPage.tsx
@@ -145,19 +145,15 @@ function ProductModal({
           </div>
 
           <div>
-            <label className="flex items-center space-x-2">
-              <input
-                type="checkbox"
-                checked={formData.isDefault}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, isDefault: e.target.checked }))
-                }
-                className="w-4 h-4 text-[var(--color-primary-600)] bg-gray-100 border-gray-300 rounded focus:ring-[var(--color-primary-500)] focus:ring-2"
-              />
-              <span className="text-sm font-medium text-gray-700">
-                Default Product
-              </span>
-            </label>
+            <AnimatedCheckbox
+              checked={formData.isDefault}
+              onChange={() =>
+                setFormData((prev) => ({ ...prev, isDefault: !prev.isDefault }))
+              }
+              disabled={isLoading}
+              label="Default Product"
+              title="Set as default product"
+            />
             <p className="text-xs text-gray-500 mt-1">
               Default products are automatically associated with new leads
             </p>

--- a/client/src/services/products.service.ts
+++ b/client/src/services/products.service.ts
@@ -5,6 +5,7 @@ export interface Product {
   title: string
   description?: string
   salesVoice?: string
+  isDefault: boolean
   tenantId: string
   createdAt: string
   updatedAt: string
@@ -14,12 +15,14 @@ export interface CreateProductData {
   title: string
   description?: string
   salesVoice?: string
+  isDefault?: boolean
 }
 
 export interface UpdateProductData {
   title?: string
   description?: string
   salesVoice?: string
+  isDefault?: boolean
 }
 
 class ProductsService {

--- a/client/src/services/products.service.ts
+++ b/client/src/services/products.service.ts
@@ -29,20 +29,17 @@ class ProductsService {
   private baseUrl = import.meta.env.VITE_API_BASE_URL + '/api'
 
   // Get all products for a tenant
-  async getProducts(tenantId: string): Promise<Product[]> {
+  async getProducts(): Promise<Product[]> {
     try {
       const authHeaders = await authService.getAuthHeaders()
 
-      const response = await fetch(
-        `${this.baseUrl}/products?tenantId=${tenantId}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            ...authHeaders,
-          },
+      const response = await fetch(`${this.baseUrl}/products`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authHeaders,
         },
-      )
+      })
 
       if (!response.ok) {
         throw new Error(`Failed to fetch products: ${response.statusText}`)

--- a/server/src/db/migrations/0023_default_product.sql
+++ b/server/src/db/migrations/0023_default_product.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "dripiq_app"."products" ADD COLUMN "is_default" boolean DEFAULT false NOT NULL;

--- a/server/src/db/migrations/meta/0023_snapshot.json
+++ b/server/src/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,1285 @@
+{
+  "id": "35ce87c3-3e0e-4edd-b0cc-80c61005cc0f",
+  "prevId": "2447586a-f85a-4435-83a2-6d6c3f82969e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "dripiq_app.lead_point_of_contacts": {
+      "name": "lead_point_of_contacts",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_reviewed": {
+          "name": "manually_reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_point_of_contacts_lead_id_leads_id_fk": {
+          "name": "lead_point_of_contacts_lead_id_leads_id_fk",
+          "tableFrom": "lead_point_of_contacts",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.lead_products": {
+      "name": "lead_products",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_products_lead_id_leads_id_fk": {
+          "name": "lead_products_lead_id_leads_id_fk",
+          "tableFrom": "lead_products",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_products_product_id_products_id_fk": {
+          "name": "lead_products_product_id_products_id_fk",
+          "tableFrom": "lead_products",
+          "tableTo": "products",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lead_products_lead_id_product_id_unique": {
+          "name": "lead_products_lead_id_product_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lead_id",
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.lead_statuses": {
+      "name": "lead_statuses",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_statuses_lead_id_leads_id_fk": {
+          "name": "lead_statuses_lead_id_leads_id_fk",
+          "tableFrom": "lead_statuses",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_statuses_tenant_id_tenants_id_fk": {
+          "name": "lead_statuses_tenant_id_tenants_id_fk",
+          "tableFrom": "lead_statuses",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lead_status_unique": {
+          "name": "lead_status_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lead_id",
+            "status"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.leads": {
+      "name": "leads",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "products": {
+          "name": "products",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "differentiators": {
+          "name": "differentiators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_colors": {
+          "name": "brand_colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_contact_id": {
+          "name": "primary_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_embedding_domain_id": {
+          "name": "site_embedding_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leads_owner_id_users_id_fk": {
+          "name": "leads_owner_id_users_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "leads_tenant_id_tenants_id_fk": {
+          "name": "leads_tenant_id_tenants_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leads_site_embedding_domain_id_site_embedding_domains_id_fk": {
+          "name": "leads_site_embedding_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "site_embedding_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.permissions": {
+      "name": "permissions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.products": {
+      "name": "products",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_voice": {
+          "name": "sales_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_tenant_id_tenants_id_fk": {
+          "name": "products_tenant_id_tenants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.role_permissions": {
+      "name": "role_permissions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_permission_unique": {
+          "name": "role_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.roles": {
+      "name": "roles",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.site_embedding_domains": {
+      "name": "site_embedding_domains",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "site_scraped_at_idx": {
+          "name": "site_scraped_at_idx",
+          "columns": [
+            {
+              "expression": "scraped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "site_embedding_domains_domain_unique": {
+          "name": "site_embedding_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.site_embeddings": {
+      "name": "site_embeddings",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_summary": {
+          "name": "content_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firecrawl_id": {
+          "name": "firecrawl_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_embeddings_idx": {
+          "name": "domain_embeddings_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_embedding_idx": {
+          "name": "site_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "site_embedding_token_count_idx": {
+          "name": "site_embedding_token_count_idx",
+          "columns": [
+            {
+              "expression": "token_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_embedding_content_idx": {
+          "name": "site_embedding_content_idx",
+          "columns": [
+            {
+              "expression": "content",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_embeddings_domain_id_site_embedding_domains_id_fk": {
+          "name": "site_embeddings_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "site_embeddings",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.tenants": {
+      "name": "tenants",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_name": {
+          "name": "organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_website": {
+          "name": "organization_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_summary": {
+          "name": "organization_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "differentiators": {
+          "name": "differentiators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_colors": {
+          "name": "brand_colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_embedding_domain_id": {
+          "name": "site_embedding_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenants_site_embedding_domain_id_site_embedding_domains_id_fk": {
+          "name": "tenants_site_embedding_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "tenants",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "site_embedding_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.user_tenants": {
+      "name": "user_tenants",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_user": {
+          "name": "is_super_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tenants_user_id_users_id_fk": {
+          "name": "user_tenants_user_id_users_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenants_tenant_id_tenants_id_fk": {
+          "name": "user_tenants_tenant_id_tenants_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenants_role_id_roles_id_fk": {
+          "name": "user_tenants_role_id_roles_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "roles",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_tenant_unique": {
+          "name": "user_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.users": {
+      "name": "users",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supabase_id": {
+          "name": "supabase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_supabase_id_unique": {
+          "name": "users_supabase_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "dripiq_app": "dripiq_app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1753585699954,
       "tag": "0022_lead_products",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1753591676840,
+      "tag": "0023_default_product",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -58,6 +58,7 @@ export const products = appSchema.table('products', {
   title: text('title').notNull(),
   description: text('description'),
   salesVoice: text('sales_voice'),
+  isDefault: boolean('is_default').notNull().default(false),
   tenantId: text('tenant_id')
     .notNull()
     .references(() => tenants.id, { onDelete: 'cascade' }),

--- a/server/src/modules/lead.service.ts
+++ b/server/src/modules/lead.service.ts
@@ -211,7 +211,7 @@ export const createLead = async (
   try {
     const defaultProducts = await ProductsService.getDefaultProducts(tenantId);
     if (defaultProducts.length > 0) {
-      const defaultProductIds = defaultProducts.map(product => product.id);
+      const defaultProductIds = defaultProducts.map((product) => product.id);
       await attachProductsToLead(result.id, defaultProductIds, tenantId);
     }
   } catch (error) {

--- a/server/src/modules/products.service.ts
+++ b/server/src/modules/products.service.ts
@@ -14,6 +14,16 @@ export const ProductsService = {
     return productsList;
   },
 
+  // Get default products for a tenant (for internal use)
+  async getDefaultProducts(tenantId: string): Promise<Product[]> {
+    const defaultProducts = await db.query.products.findMany({
+      where: and(eq(products.tenantId, tenantId), eq(products.isDefault, true)),
+      orderBy: (products, { desc }) => [desc(products.createdAt)],
+    });
+
+    return defaultProducts;
+  },
+
   // Get a single product by ID
   async getProduct(id: string): Promise<Product | null> {
     const product = await db.query.products.findFirst({

--- a/server/src/routes/products.routes.ts
+++ b/server/src/routes/products.routes.ts
@@ -8,6 +8,7 @@ interface CreateProductBody {
   title: string;
   description?: string;
   salesVoice?: string;
+  isDefault?: boolean;
   tenantId: string;
 }
 
@@ -15,6 +16,7 @@ interface UpdateProductBody {
   title?: string;
   description?: string;
   salesVoice?: string;
+  isDefault?: boolean;
 }
 
 interface ProductParams {
@@ -102,7 +104,7 @@ export default async function ProductsRoutes(fastify: FastifyInstance, _opts: Ro
     url: basePath,
     handler: async (request, reply) => {
       try {
-        const { title, description, salesVoice, tenantId } = request.body;
+        const { title, description, salesVoice, isDefault, tenantId } = request.body;
         const authenticatedRequest = request as AuthenticatedRequest;
         const {
           user: { id: userId },
@@ -118,6 +120,7 @@ export default async function ProductsRoutes(fastify: FastifyInstance, _opts: Ro
           title,
           description,
           salesVoice,
+          isDefault: isDefault || false,
           tenantId,
         });
 

--- a/server/src/routes/products.routes.ts
+++ b/server/src/routes/products.routes.ts
@@ -28,7 +28,6 @@ interface ProductQuery {
 }
 
 export default async function ProductsRoutes(fastify: FastifyInstance, _opts: RouteOptions) {
-  // GET /products?tenantId=xxx - Get all products for a tenant
   fastify.route<{
     Querystring: ProductQuery;
   }>({
@@ -104,9 +103,10 @@ export default async function ProductsRoutes(fastify: FastifyInstance, _opts: Ro
     url: basePath,
     handler: async (request, reply) => {
       try {
-        const { title, description, salesVoice, isDefault, tenantId } = request.body;
+        const { title, description, salesVoice, isDefault } = request.body;
         const authenticatedRequest = request as AuthenticatedRequest;
         const {
+          tenantId,
           user: { id: userId },
         } = authenticatedRequest;
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds a "default product" option to products, automatically associating them with new leads, and provides UI for management.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This feature streamlines lead creation by pre-populating new leads with pre-defined default products, reducing manual effort and ensuring consistency. Users can now mark products as default directly from the product settings page, either via the edit modal or a new checkbox on the product card.

---

[Open in Web](https://cursor.com/agents?id=bc-df33ea75-1672-43cf-af17-3da78586f5f1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-df33ea75-1672-43cf-af17-3da78586f5f1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)