### PR TITLE
Assign creator as lead owner

### DIFF
--- a/server/src/modules/lead.service.ts
+++ b/server/src/modules/lead.service.ts
@@ -141,18 +141,21 @@ export const getLeads = async (tenantId: string, searchQuery?: string) => {
  * Creates a new lead for a specific tenant with optional point of contacts.
  * @param tenantId - The ID of the tenant the lead will belong to.
  * @param lead - The data for the new lead.
+ * @param ownerId - The ID of the user who will own this lead.
  * @param pointOfContacts - Optional array of point of contacts to create for the lead.
  * @returns A promise that resolves to the newly created lead object with point of contacts.
  */
 export const createLead = async (
   tenantId: string,
   lead: Omit<NewLead, 'tenantId'>,
+  ownerId: string,
   pointOfContacts?: Omit<NewLeadPointOfContact, 'leadId'>[]
 ) => {
-  // Add tenantId to the lead data
+  // Add tenantId and ownerId to the lead data
   const leadWithTenant: NewLead = {
     ...lead,
     tenantId,
+    ownerId,
   };
 
   if (leadWithTenant.url) {

--- a/server/src/routes/lead.routes.ts
+++ b/server/src/routes/lead.routes.ts
@@ -231,6 +231,7 @@ export default async function LeadRoutes(fastify: FastifyInstance, _opts: RouteO
         const newLead = await createLead(
           authenticatedRequest.tenantId,
           leadData as Omit<NewLead, 'tenantId'>,
+          authenticatedRequest.user.id,
           pointOfContacts
         );
 


### PR DESCRIPTION
Automatically assign the user who creates a lead as its owner.

---

[Open in Web](https://cursor.com/agents?id=bc-e20d3b58-4628-4875-a488-2d8c23fc07ca) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e20d3b58-4628-4875-a488-2d8c23fc07ca) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)