### PR TITLE
Improve contact strategy agent typing with zod

### DIFF
--- a/server/src/modules/ai/schemas/contactStrategyInputSchema.ts
+++ b/server/src/modules/ai/schemas/contactStrategyInputSchema.ts
@@ -1,9 +1,0 @@
-import { z } from 'zod';
-
-const contactStrategyInputSchema = z.object({
-  leadId: z.string().describe('The ID of the lead/opportunity to analyze'),
-  contactId: z.number().describe('The index of the specific contact to focus the analysis on'),
-  tenantId: z.string().describe('The ID of the tenant/partner'),
-});
-
-export default contactStrategyInputSchema;

--- a/server/src/modules/ai/schemas/contactStrategyOutputSchema.ts
+++ b/server/src/modules/ai/schemas/contactStrategyOutputSchema.ts
@@ -1,5 +1,92 @@
 import { z } from 'zod';
 
+// Input Schemas with Business Context
+
+const leadDetailsSchema = z.object({
+  id: z.string().describe('Unique identifier for the lead company'),
+  name: z.string().describe('Company name for personalization and targeting'),
+  url: z.string().describe('Company website for research and validation'),
+  summary: z
+    .string()
+    .optional()
+    .describe('AI-generated company overview for context understanding'),
+  products: z
+    .array(z.string())
+    .optional()
+    .describe("Company's product offerings to identify integration opportunities"),
+  services: z
+    .array(z.string())
+    .optional()
+    .describe("Company's service offerings to find complementary solutions"),
+  differentiators: z
+    .array(z.string())
+    .optional()
+    .describe('Unique value propositions to understand competitive positioning'),
+  targetMarket: z.string().optional().describe("Company's target audience to align messaging"),
+  tone: z.string().optional().describe("Company's communication style for message matching"),
+  status: z.string().describe('Current lead stage for appropriate outreach timing'),
+});
+
+const contactDetailsSchema = z.object({
+  id: z.string().describe('Unique contact identifier'),
+  name: z.string().describe("Contact's full name for personalization"),
+  email: z.string().optional().describe('Primary communication channel'),
+  phone: z.string().optional().describe('Alternative contact method for calls'),
+  title: z
+    .string()
+    .optional()
+    .describe('Job title to understand decision-making authority and pain points'),
+  company: z.string().optional().describe('Company affiliation for context'),
+  sourceUrl: z.string().optional().describe('Where contact info was found for credibility'),
+  manuallyReviewed: z.boolean().describe('Data quality indicator for trust level'),
+});
+
+const partnerDetailsSchema = z.object({
+  id: z.string().describe('Partner organization identifier'),
+  name: z.string().describe('Partner company name for credibility'),
+  website: z.string().optional().describe('Partner website for reference and trust building'),
+  organizationName: z
+    .string()
+    .optional()
+    .describe('Formal organization name if different from brand'),
+  summary: z.string().optional().describe('Partner value proposition and background'),
+  differentiators: z.array(z.string()).optional().describe('Unique selling points to emphasize'),
+  targetMarket: z.string().optional().describe("Partner's ideal customer profile for alignment"),
+  tone: z.string().optional().describe("Partner's communication style for consistent messaging"),
+});
+
+const salesmanSchema = z.object({
+  id: z.string().optional().describe('Salesperson identifier'),
+  name: z.string().optional().describe('Salesperson name for signature and personalization'),
+  email: z.string().optional().describe('Salesperson contact for responses and scheduling'),
+});
+
+const partnerProductSchema = z.object({
+  id: z.string().describe('Product identifier'),
+  title: z.string().describe('Product name for clear communication'),
+  description: z.string().optional().describe('Product overview for value proposition'),
+  salesVoice: z.string().optional().describe('Tailored messaging for this product'),
+  siteUrl: z.string().optional().describe('Product-specific landing page for referrals'),
+});
+
+const contactStrategyInputSchema = z.object({
+  leadDetails: leadDetailsSchema.describe('Represents the target company/prospect being pursued'),
+  contactDetails: contactDetailsSchema.describe(
+    'Represents the specific person being contacted within the target company'
+  ),
+  partnerDetails: partnerDetailsSchema.describe(
+    "Represents the selling organization's information for positioning"
+  ),
+  partnerProducts: z
+    .array(partnerProductSchema)
+    .describe('Represents products/services being sold to match with prospect needs'),
+  salesman: salesmanSchema.describe(
+    'Represents the sales person conducting outreach for personalization'
+  ),
+});
+
+// Output Schemas (existing)
+
 const outreachTouchpointSchema = z.object({
   type: z.enum(['email', 'call']).describe('Communication channel for this touchpoint'),
   timing: z.string().describe('When to send this touchpoint (e.g., "Day 1", "Day 3")'),
@@ -17,6 +104,26 @@ const outreachStrategyOutputSchema = z.object({
   summary: z.string().describe('Brief summary of outreach campaign goals'),
 });
 
-export default outreachStrategyOutputSchema;
+// Type exports for input schemas
+export type LeadDetails = z.infer<typeof leadDetailsSchema>;
+export type ContactDetails = z.infer<typeof contactDetailsSchema>;
+export type PartnerDetails = z.infer<typeof partnerDetailsSchema>;
+export type Salesman = z.infer<typeof salesmanSchema>;
+export type PartnerProduct = z.infer<typeof partnerProductSchema>;
+export type ContactStrategyInput = z.infer<typeof contactStrategyInputSchema>;
+
+// Type exports for output schemas (existing)
 export type OutreachTouchpoint = z.infer<typeof outreachTouchpointSchema>;
 export type OutreachStrategyOutput = z.infer<typeof outreachStrategyOutputSchema>;
+
+// Schema exports
+export {
+  leadDetailsSchema,
+  contactDetailsSchema,
+  partnerDetailsSchema,
+  salesmanSchema,
+  partnerProductSchema,
+  contactStrategyInputSchema,
+};
+
+export default outreachStrategyOutputSchema;


### PR DESCRIPTION
Replace `any` types in `ContactStrategyAgent` with Zod schemas and add input validation to improve type safety and LLM context.

The original `ContactStrategyInput` used `any` types, leading to a lack of type safety and insufficient context for the LLM. This PR introduces comprehensive Zod schemas with detailed business descriptions for all input properties, enabling robust validation and clearer LLM understanding while ensuring backward compatibility through graceful degradation for partial data.

---
<a href="https://cursor.com/background-agent?bcId=bc-5459c763-80d0-4c4c-9aed-deeb26a78eb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5459c763-80d0-4c4c-9aed-deeb26a78eb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>