### PR TITLE
Update home to leads page, restrict dashboard access

### DIFF
--- a/client/src/components/AuthGuard.tsx
+++ b/client/src/components/AuthGuard.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { Navigate } from '@tanstack/react-router'
 import { useAuth } from '../contexts/AuthContext'
+import { HOME_URL } from '../constants/navigation'
 
 interface AuthGuardProps {
   children: ReactNode
@@ -45,7 +46,7 @@ export function PublicOnlyGuard({ children }: PublicOnlyGuardProps) {
   }
 
   if (session && user) {
-    return <Navigate to="/leads" replace />
+    return <Navigate to={HOME_URL} replace />
   }
 
   return <>{children}</>

--- a/client/src/components/AuthGuard.tsx
+++ b/client/src/components/AuthGuard.tsx
@@ -45,7 +45,7 @@ export function PublicOnlyGuard({ children }: PublicOnlyGuardProps) {
   }
 
   if (session && user) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to="/leads" replace />
   }
 
   return <>{children}</>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -72,7 +72,7 @@ export default function Header() {
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center space-x-8">
               <Link
-                to="/dashboard"
+                to="/leads"
                 className="flex items-center hover:scale-105 transition-transform duration-200 cursor-pointer"
               >
                 <Logo size="md" showText={true} />

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext'
 import Logo from './Logo'
 import { useState, useRef, useEffect } from 'react'
 import { Settings } from 'lucide-react'
+import { HOME_URL } from '../constants/navigation'
 
 export default function Header() {
   const { user, logout } = useAuth()
@@ -72,7 +73,7 @@ export default function Header() {
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center space-x-8">
               <Link
-                to="/leads"
+                to={HOME_URL}
                 className="flex items-center hover:scale-105 transition-transform duration-200 cursor-pointer"
               >
                 <Logo size="md" showText={true} />
@@ -81,7 +82,7 @@ export default function Header() {
               {/* Desktop Navigation */}
               <nav className="hidden md:flex space-x-6">
                 <button
-                  onClick={() => navigate({ to: '/leads' })}
+                  onClick={() => navigate({ to: HOME_URL })}
                   className="text-[var(--color-surface-950)] hover:text-[var(--color-primary-600)] px-3 py-2 text-sm font-medium bg-transparent border-none cursor-pointer transition-all duration-200 rounded-lg hover:bg-[var(--color-primary-50)] hover:shadow-sm transform hover:-translate-y-0.5"
                 >
                   Leads
@@ -196,7 +197,7 @@ export default function Header() {
           <div className="px-4 py-6 bg-[var(--color-surface-100)]/95 backdrop-blur-sm border-t border-[var(--color-border-light)]/50">
             <nav className="flex flex-col space-y-4">
               <button
-                onClick={() => navigateAndClose('/leads')}
+                onClick={() => navigateAndClose(HOME_URL)}
                 className="text-[var(--color-surface-950)] hover:text-[var(--color-primary-600)] px-4 py-3 text-base font-medium bg-transparent border-none cursor-pointer transition-all duration-200 rounded-lg hover:bg-[var(--color-primary-50)] text-left hover:shadow-sm transform hover:translate-x-2"
               >
                 Leads

--- a/client/src/components/Logo.tsx
+++ b/client/src/components/Logo.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-ignore SVG import with ?react suffix not recognized by TypeScript
 // import LogoImg from '../assets/logo.svg?react'
 import LogoImg from '../assets/logo.png'
 

--- a/client/src/constants/navigation.ts
+++ b/client/src/constants/navigation.ts
@@ -1,0 +1,1 @@
+export const HOME_URL = '/leads'

--- a/client/src/hooks/useOrganizationQuery.ts
+++ b/client/src/hooks/useOrganizationQuery.ts
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { 
   organizationService, 
-  organizationQueryKeys,
-  type Organization,
-  type UpdateOrganizationData,
+  organizationQueryKeys
+  
+  
 } from '../services/organization.service'
+import type {Organization, UpdateOrganizationData} from '../services/organization.service';
 
 // Hook to get organization details
 export function useOrganization(id: string) {

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -92,10 +92,10 @@ function LandingPage() {
                 </>
               ) : (
                 <button
-                  onClick={() => navigate({ to: '/dashboard' })}
+                  onClick={() => navigate({ to: '/leads' })}
                   className="bg-gradient-to-r from-[var(--color-primary-600)] to-[var(--color-primary-600)] hover:from-[var(--color-primary-700)] hover:to-[var(--color-primary-700)] text-white px-6 py-2 rounded-lg font-semibold shadow-md hover:shadow-lg transition-all duration-200"
                 >
-                  Go to Dashboard
+                  Go to Leads
                 </button>
               )}
             </div>
@@ -142,10 +142,10 @@ function LandingPage() {
                 </>
               ) : (
                 <button
-                  onClick={() => navigate({ to: '/dashboard' })}
+                  onClick={() => navigate({ to: '/leads' })}
                   className="bg-gradient-to-r from-[var(--color-primary-600)] to-[var(--color-primary-600)] hover:from-[var(--color-primary-700)] hover:to-[var(--color-primary-700)] text-white px-8 py-4 rounded-xl text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
                 >
-                  Go to Dashboard
+                  Go to Leads
                 </button>
               )}
             </div>
@@ -237,10 +237,10 @@ function LandingPage() {
               </>
             ) : (
               <button
-                onClick={() => navigate({ to: '/dashboard' })}
+                onClick={() => navigate({ to: '/leads' })}
                 className="bg-white hover:bg-gray-100 text-[var(--color-primary-600)] px-8 py-4 rounded-xl text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
               >
-                Go to Dashboard
+                Go to Leads
               </button>
             )}
           </div>

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import Logo from '../components/Logo'
 import ContactSalesModal from '../components/ContactSalesModal'
+import { HOME_URL } from '../constants/navigation'
 
 function LandingPage() {
   const navigate = useNavigate()
@@ -92,7 +93,7 @@ function LandingPage() {
                 </>
               ) : (
                 <button
-                  onClick={() => navigate({ to: '/leads' })}
+                  onClick={() => navigate({ to: HOME_URL })}
                   className="bg-gradient-to-r from-[var(--color-primary-600)] to-[var(--color-primary-600)] hover:from-[var(--color-primary-700)] hover:to-[var(--color-primary-700)] text-white px-6 py-2 rounded-lg font-semibold shadow-md hover:shadow-lg transition-all duration-200"
                 >
                   Go to Leads
@@ -142,7 +143,7 @@ function LandingPage() {
                 </>
               ) : (
                 <button
-                  onClick={() => navigate({ to: '/leads' })}
+                  onClick={() => navigate({ to: HOME_URL })}
                   className="bg-gradient-to-r from-[var(--color-primary-600)] to-[var(--color-primary-600)] hover:from-[var(--color-primary-700)] hover:to-[var(--color-primary-700)] text-white px-8 py-4 rounded-xl text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
                 >
                   Go to Leads
@@ -237,7 +238,7 @@ function LandingPage() {
               </>
             ) : (
               <button
-                onClick={() => navigate({ to: '/leads' })}
+                onClick={() => navigate({ to: HOME_URL })}
                 className="bg-white hover:bg-gray-100 text-[var(--color-primary-600)] px-8 py-4 rounded-xl text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
               >
                 Go to Leads

--- a/client/src/pages/LeadDetailPage.tsx
+++ b/client/src/pages/LeadDetailPage.tsx
@@ -25,6 +25,7 @@ import BrandingTab from '../components/tabs/BrandingTab'
 import LeadDetailsTab from '../components/tabs/LeadDetailsTab'
 import ProductsTab from '../components/tabs/ProductsTab'
 import LeadStatusBadges from '../components/LeadStatusBadges'
+import { HOME_URL } from '../constants/navigation'
 
 const LeadDetailPage: React.FC = () => {
   const navigate = useNavigate()
@@ -39,7 +40,7 @@ const LeadDetailPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState('contacts')
 
   const handleBack = () => {
-    navigate({ to: '/leads' })
+    navigate({ to: HOME_URL })
   }
 
   const handleResync = () => {

--- a/client/src/pages/NewLeadPage.tsx
+++ b/client/src/pages/NewLeadPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useCreateLead } from '../hooks/useLeadsQuery'
 import type { CreateLeadData } from '../services/leads.service'
 import { Plus, X, User, Crown } from 'lucide-react'
+import { HOME_URL } from '../constants/navigation'
 
 interface ContactFormData {
   name: string
@@ -79,7 +80,7 @@ const NewLeadPage: React.FC = () => {
   }
 
   const handleCancel = () => {
-    navigate({ to: '/leads' })
+    navigate({ to: HOME_URL })
   }
 
   return (

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -10,7 +10,7 @@ export default function NotFoundPage() {
 
   const handleGoHome = () => {
     if (isAuthenticated) {
-      navigate({ to: '/dashboard' })
+      navigate({ to: '/leads' })
     } else {
       navigate({ to: '/' })
     }
@@ -66,7 +66,7 @@ export default function NotFoundPage() {
               onClick={handleGoHome}
               className="w-full bg-gradient-to-r from-[var(--color-primary-600)] to-[var(--color-primary-600)] hover:from-[var(--color-primary-700)] hover:to-[var(--color-primary-700)] text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
             >
-              {isAuthenticated ? 'Go to Dashboard' : 'Go to Home'}
+              {isAuthenticated ? 'Go to Leads' : 'Go to Home'}
             </button>
 
             <button

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
 import { useAuth } from '../contexts/AuthContext'
 import Logo from '../components/Logo'
+import { HOME_URL } from '../constants/navigation'
 
 export default function NotFoundPage() {
   const navigate = useNavigate()
@@ -8,13 +9,13 @@ export default function NotFoundPage() {
 
   const isAuthenticated = !!(session && user)
 
-  const handleGoHome = () => {
-    if (isAuthenticated) {
-      navigate({ to: '/leads' })
-    } else {
-      navigate({ to: '/' })
+      const handleGoHome = () => {
+      if (isAuthenticated) {
+        navigate({ to: HOME_URL })
+      } else {
+        navigate({ to: '/' })
+      }
     }
-  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-[var(--color-primary-50)] to-[var(--color-primary-100)] flex items-center justify-center px-4 sm:px-6 lg:px-8">

--- a/client/src/pages/auth/SetupPassword.tsx
+++ b/client/src/pages/auth/SetupPassword.tsx
@@ -107,9 +107,9 @@ export default function SetupPassword() {
 
       setStatus('success')
 
-      // Redirect to dashboard after success
-      setTimeout(() => {
-        router.navigate({ to: '/dashboard' })
+              // Redirect to leads after success
+        setTimeout(() => {
+          router.navigate({ to: '/leads' })
       }, 2000)
     } catch (err: any) {
       console.error('Password setup error:', err)
@@ -132,7 +132,7 @@ export default function SetupPassword() {
               Password Set Successfully!
             </h2>
             <p className="mt-2 text-center text-sm text-gray-600">
-              Your password has been set. You'll be redirected to the dashboard
+              Your password has been set. You'll be redirected to the leads page
               shortly.
             </p>
             <div className="mt-4 animate-pulse">

--- a/client/src/pages/auth/SetupPassword.tsx
+++ b/client/src/pages/auth/SetupPassword.tsx
@@ -4,6 +4,7 @@ import { KeyRound, CheckCircle, XCircle } from 'lucide-react'
 import Logo from '../../components/Logo'
 import { supabase } from '../../lib/supabaseClient'
 import { invitesService } from '../../services/invites.service'
+import { HOME_URL } from '../../constants/navigation'
 
 export default function SetupPassword() {
   const router = useRouter()
@@ -109,8 +110,8 @@ export default function SetupPassword() {
 
               // Redirect to leads after success
         setTimeout(() => {
-          router.navigate({ to: '/leads' })
-      }, 2000)
+          router.navigate({ to: HOME_URL })
+        }, 2000)
     } catch (err: any) {
       console.error('Password setup error:', err)
       setError(

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -79,16 +79,11 @@ const authRoute = createRoute({
   ),
 })
 
-// Home route - protected (leads page)
+// Home route - public (landing page)
 const landingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
-  component: () => (
-    <AuthGuard>
-      <Header />
-      <LeadsPage />
-    </AuthGuard>
-  ),
+  component: () => <LandingPage />,
 })
 
 // Setup password route - public (for invited users who don't have passwords yet)

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -79,11 +79,16 @@ const authRoute = createRoute({
   ),
 })
 
-// Landing page route - public
+// Home route - protected (leads page)
 const landingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
-  component: () => <LandingPage />,
+  component: () => (
+    <AuthGuard>
+      <Header />
+      <LeadsPage />
+    </AuthGuard>
+  ),
 })
 
 // Setup password route - public (for invited users who don't have passwords yet)


### PR DESCRIPTION
Set the leads page as the default authenticated home and remove UI navigation to the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bd4634c-87a7-4284-a4da-cfd069b07379">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bd4634c-87a7-4284-a4da-cfd069b07379">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

