### PR TITLE
Design initial campaigns module schema

### DIFF
--- a/server/src/db/migrations/0025_add_campaign_schema.sql
+++ b/server/src/db/migrations/0025_add_campaign_schema.sql
@@ -1,0 +1,168 @@
+-- Migration: Add campaign schema
+-- This migration adds support for multi-channel campaigns (email, SMS, video, etc.)
+
+-- Campaign Templates table
+CREATE TABLE IF NOT EXISTS "crm"."campaign_templates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"created_by" text,
+	"tenant_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Campaign Step Templates table (channel-agnostic with config)
+CREATE TABLE IF NOT EXISTS "crm"."campaign_step_templates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"campaign_template_id" text NOT NULL,
+	"step_order" integer NOT NULL,
+	"step_name" text NOT NULL,
+	"channel" text NOT NULL,
+	"config" jsonb,
+	"send_time_window_start" time,
+	"send_time_window_end" time,
+	"delay_after_previous" interval DEFAULT '0'::interval NOT NULL,
+	"branching" jsonb,
+	"tenant_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Contact Campaign Instances table
+CREATE TABLE IF NOT EXISTS "crm"."contact_campaign_instances" (
+	"id" text PRIMARY KEY NOT NULL,
+	"contact_id" text NOT NULL,
+	"campaign_template_id" text NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"tenant_id" text NOT NULL,
+	"started_at" timestamp DEFAULT now() NOT NULL,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Campaign Step Instances table
+CREATE TABLE IF NOT EXISTS "crm"."campaign_step_instances" (
+	"id" text PRIMARY KEY NOT NULL,
+	"contact_campaign_instance_id" text NOT NULL,
+	"campaign_step_template_id" text NOT NULL,
+	"scheduled_at" timestamp NOT NULL,
+	"sent_at" timestamp,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"branch_outcome" text,
+	"channel" text NOT NULL,
+	"rendered_config" jsonb,
+	"tenant_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Step Events table (engagement tracking, channel-agnostic)
+CREATE TABLE IF NOT EXISTS "crm"."step_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"campaign_step_instance_id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"event_data" jsonb,
+	"tenant_id" text NOT NULL,
+	"occurred_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Add foreign key constraints
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_templates" ADD CONSTRAINT "campaign_templates_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "crm"."users"("id") ON DELETE set null;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_templates" ADD CONSTRAINT "campaign_templates_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "crm"."tenants"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_step_templates" ADD CONSTRAINT "campaign_step_templates_campaign_template_id_campaign_templates_id_fk" FOREIGN KEY ("campaign_template_id") REFERENCES "crm"."campaign_templates"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_step_templates" ADD CONSTRAINT "campaign_step_templates_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "crm"."tenants"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."contact_campaign_instances" ADD CONSTRAINT "contact_campaign_instances_contact_id_lead_point_of_contacts_id_fk" FOREIGN KEY ("contact_id") REFERENCES "crm"."lead_point_of_contacts"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."contact_campaign_instances" ADD CONSTRAINT "contact_campaign_instances_campaign_template_id_campaign_templates_id_fk" FOREIGN KEY ("campaign_template_id") REFERENCES "crm"."campaign_templates"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."contact_campaign_instances" ADD CONSTRAINT "contact_campaign_instances_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "crm"."tenants"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_step_instances" ADD CONSTRAINT "campaign_step_instances_contact_campaign_instance_id_contact_campaign_instances_id_fk" FOREIGN KEY ("contact_campaign_instance_id") REFERENCES "crm"."contact_campaign_instances"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_step_instances" ADD CONSTRAINT "campaign_step_instances_campaign_step_template_id_campaign_step_templates_id_fk" FOREIGN KEY ("campaign_step_template_id") REFERENCES "crm"."campaign_step_templates"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."campaign_step_instances" ADD CONSTRAINT "campaign_step_instances_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "crm"."tenants"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."step_events" ADD CONSTRAINT "step_events_campaign_step_instance_id_campaign_step_instances_id_fk" FOREIGN KEY ("campaign_step_instance_id") REFERENCES "crm"."campaign_step_instances"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "crm"."step_events" ADD CONSTRAINT "step_events_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "crm"."tenants"("id") ON DELETE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS "idx_campaign_templates_tenant_id" ON "crm"."campaign_templates" ("tenant_id");
+CREATE INDEX IF NOT EXISTS "idx_campaign_templates_created_by" ON "crm"."campaign_templates" ("created_by");
+
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_templates_campaign_template_id" ON "crm"."campaign_step_templates" ("campaign_template_id");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_templates_tenant_id" ON "crm"."campaign_step_templates" ("tenant_id");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_templates_channel" ON "crm"."campaign_step_templates" ("channel");
+
+CREATE INDEX IF NOT EXISTS "idx_contact_campaign_instances_contact_id" ON "crm"."contact_campaign_instances" ("contact_id");
+CREATE INDEX IF NOT EXISTS "idx_contact_campaign_instances_campaign_template_id" ON "crm"."contact_campaign_instances" ("campaign_template_id");
+CREATE INDEX IF NOT EXISTS "idx_contact_campaign_instances_tenant_id" ON "crm"."contact_campaign_instances" ("tenant_id");
+CREATE INDEX IF NOT EXISTS "idx_contact_campaign_instances_status" ON "crm"."contact_campaign_instances" ("status");
+
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_instances_contact_campaign_instance_id" ON "crm"."campaign_step_instances" ("contact_campaign_instance_id");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_instances_campaign_step_template_id" ON "crm"."campaign_step_instances" ("campaign_step_template_id");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_instances_tenant_id" ON "crm"."campaign_step_instances" ("tenant_id");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_instances_status" ON "crm"."campaign_step_instances" ("status");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_instances_scheduled_at" ON "crm"."campaign_step_instances" ("scheduled_at");
+CREATE INDEX IF NOT EXISTS "idx_campaign_step_instances_channel" ON "crm"."campaign_step_instances" ("channel");
+
+CREATE INDEX IF NOT EXISTS "idx_step_events_campaign_step_instance_id" ON "crm"."step_events" ("campaign_step_instance_id");
+CREATE INDEX IF NOT EXISTS "idx_step_events_tenant_id" ON "crm"."step_events" ("tenant_id");
+CREATE INDEX IF NOT EXISTS "idx_step_events_event_type" ON "crm"."step_events" ("event_type");
+CREATE INDEX IF NOT EXISTS "idx_step_events_occurred_at" ON "crm"."step_events" ("occurred_at");

--- a/server/src/modules/campaign.service.ts
+++ b/server/src/modules/campaign.service.ts
@@ -1,0 +1,575 @@
+import {
+  CampaignTemplateRepository,
+  CampaignStepTemplateRepository,
+  ContactCampaignInstanceRepository,
+  CampaignStepInstanceRepository,
+  StepEventRepository,
+  LeadPointOfContactRepository,
+  type CampaignTemplateWithDetails,
+  type CampaignTemplateSearchOptions,
+  type ContactCampaignInstanceWithDetails,
+  type CampaignStepInstanceWithDetails,
+  type StepEventWithDetails,
+} from '@/repositories';
+import type {
+  CampaignTemplate,
+  NewCampaignTemplate,
+  CampaignStepTemplate,
+  NewCampaignStepTemplate,
+  ContactCampaignInstance,
+  NewContactCampaignInstance,
+  CampaignStepInstance,
+  NewCampaignStepInstance,
+  StepEvent,
+  NewStepEvent,
+} from '@/db/schema';
+import { NotFoundError, ValidationError } from '@/exceptions/error';
+
+// Initialize repositories
+const campaignTemplateRepository = new CampaignTemplateRepository();
+const campaignStepTemplateRepository = new CampaignStepTemplateRepository();
+const contactCampaignInstanceRepository = new ContactCampaignInstanceRepository();
+const campaignStepInstanceRepository = new CampaignStepInstanceRepository();
+const stepEventRepository = new StepEventRepository();
+const leadPointOfContactRepository = new LeadPointOfContactRepository();
+
+// Types for service operations
+export interface CreateCampaignTemplateData {
+  name: string;
+  description?: string;
+  createdBy?: string;
+  steps?: CreateCampaignStepData[];
+}
+
+export interface CreateCampaignStepData {
+  stepName: string;
+  channel: string;
+  config?: any;
+  sendTimeWindowStart?: string;
+  sendTimeWindowEnd?: string;
+  delayAfterPrevious?: string;
+  branching?: any;
+  stepOrder?: number;
+}
+
+export interface LaunchCampaignData {
+  campaignTemplateId: string;
+  contactIds: string[];
+  startDate?: Date;
+}
+
+export interface CampaignAnalytics {
+  totalCampaigns: number;
+  activeCampaigns: number;
+  completedCampaigns: number;
+  totalStepsSent: number;
+  totalEvents: number;
+  engagementRate: number;
+  channelBreakdown: {
+    channel: string;
+    sent: number;
+    events: number;
+    engagementRate: number;
+  }[];
+}
+
+/**
+ * Campaign Template Operations
+ */
+
+/**
+ * Create a new campaign template with steps
+ */
+export async function createCampaignTemplate(
+  tenantId: string,
+  data: CreateCampaignTemplateData
+): Promise<CampaignTemplate> {
+  try {
+    const { steps, ...templateData } = data;
+
+    // Create the campaign template
+    const template = await campaignTemplateRepository.createForTenant(tenantId, {
+      ...templateData,
+    });
+
+    // Create steps if provided
+    if (steps && steps.length > 0) {
+      const stepPromises = steps.map((step, index) =>
+        campaignStepTemplateRepository.createForTenant(tenantId, {
+          ...step,
+          campaignTemplateId: template.id,
+          stepOrder: step.stepOrder || index + 1,
+        })
+      );
+      await Promise.all(stepPromises);
+    }
+
+    return template;
+  } catch (error) {
+    console.error('Error creating campaign template:', error);
+    throw new Error('Failed to create campaign template');
+  }
+}
+
+/**
+ * Get campaign template with details
+ */
+export async function getCampaignTemplate(
+  templateId: string,
+  tenantId: string
+): Promise<CampaignTemplateWithDetails> {
+  try {
+    return await campaignTemplateRepository.findByIdWithDetails(templateId, tenantId);
+  } catch (error) {
+    console.error('Error getting campaign template:', error);
+    throw error;
+  }
+}
+
+/**
+ * Search campaign templates
+ */
+export async function searchCampaignTemplates(
+  tenantId: string,
+  options: CampaignTemplateSearchOptions = {}
+): Promise<{
+  templates: CampaignTemplateWithDetails[];
+  total: number;
+}> {
+  try {
+    const [templates, total] = await Promise.all([
+      campaignTemplateRepository.searchForTenant(tenantId, options),
+      campaignTemplateRepository.getCountForTenant(tenantId, options),
+    ]);
+
+    return { templates, total };
+  } catch (error) {
+    console.error('Error searching campaign templates:', error);
+    throw new Error('Failed to search campaign templates');
+  }
+}
+
+/**
+ * Update campaign template
+ */
+export async function updateCampaignTemplate(
+  templateId: string,
+  tenantId: string,
+  data: Partial<CreateCampaignTemplateData>
+): Promise<CampaignTemplate> {
+  try {
+    const { steps, ...templateData } = data;
+
+    const updatedTemplate = await campaignTemplateRepository.updateForTenant(
+      templateId,
+      tenantId,
+      templateData
+    );
+
+    // Handle steps update if provided
+    if (steps) {
+      // For simplicity, this would need more complex logic to handle step updates
+      // For now, we'll just indicate that step management should be done separately
+      console.log('Step updates should be handled via separate step management functions');
+    }
+
+    return updatedTemplate;
+  } catch (error) {
+    console.error('Error updating campaign template:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete campaign template
+ */
+export async function deleteCampaignTemplate(
+  templateId: string,
+  tenantId: string
+): Promise<void> {
+  try {
+    await campaignTemplateRepository.deleteForTenant(templateId, tenantId);
+  } catch (error) {
+    console.error('Error deleting campaign template:', error);
+    throw error;
+  }
+}
+
+/**
+ * Campaign Step Template Operations
+ */
+
+/**
+ * Get steps for a campaign template
+ */
+export async function getCampaignSteps(
+  campaignTemplateId: string,
+  tenantId: string
+): Promise<CampaignStepTemplate[]> {
+  try {
+    return await campaignStepTemplateRepository.findByCampaignTemplateId(
+      campaignTemplateId,
+      tenantId
+    );
+  } catch (error) {
+    console.error('Error getting campaign steps:', error);
+    throw error;
+  }
+}
+
+/**
+ * Add step to campaign template
+ */
+export async function addCampaignStep(
+  tenantId: string,
+  data: CreateCampaignStepData & { campaignTemplateId: string }
+): Promise<CampaignStepTemplate> {
+  try {
+    // Get next step order if not provided
+    const stepOrder = data.stepOrder || 
+      await campaignStepTemplateRepository.getNextStepOrder(data.campaignTemplateId, tenantId);
+
+    return await campaignStepTemplateRepository.createForTenant(tenantId, {
+      ...data,
+      stepOrder,
+    });
+  } catch (error) {
+    console.error('Error adding campaign step:', error);
+    throw error;
+  }
+}
+
+/**
+ * Campaign Instance Operations
+ */
+
+/**
+ * Launch a campaign for multiple contacts
+ */
+export async function launchCampaign(
+  tenantId: string,
+  data: LaunchCampaignData
+): Promise<{
+  instances: ContactCampaignInstance[];
+  stepInstances: CampaignStepInstance[];
+}> {
+  try {
+    const { campaignTemplateId, contactIds, startDate = new Date() } = data;
+
+    // Validate campaign template exists
+    await campaignTemplateRepository.findByIdWithDetails(campaignTemplateId, tenantId);
+
+    // Get campaign steps
+    const steps = await campaignStepTemplateRepository.findByCampaignTemplateId(
+      campaignTemplateId,
+      tenantId
+    );
+
+    if (steps.length === 0) {
+      throw new ValidationError('Campaign template has no steps defined');
+    }
+
+    // Validate contacts exist
+    for (const contactId of contactIds) {
+      const contact = await leadPointOfContactRepository.findByIdForTenant(contactId, tenantId);
+      if (!contact) {
+        throw new NotFoundError(`Contact not found: ${contactId}`);
+      }
+    }
+
+    // Create campaign instances for each contact
+    const instanceData = contactIds.map((contactId) => ({
+      contactId,
+      campaignTemplateId,
+      status: 'active' as const,
+      startedAt: startDate,
+    }));
+
+    const instances = await contactCampaignInstanceRepository.createBulkForTenant(
+      tenantId,
+      instanceData
+    );
+
+    // Create step instances for each campaign instance
+    const stepInstanceData: Omit<NewCampaignStepInstance, 'tenantId'>[] = [];
+    
+    for (const instance of instances) {
+      let currentScheduledTime = new Date(startDate);
+
+      for (const step of steps) {
+        // Calculate scheduled time based on delay
+        if (step.stepOrder > 1 && step.delayAfterPrevious) {
+          // Parse delay (simplified - in production you'd want more robust parsing)
+          const delayMatch = step.delayAfterPrevious.match(/(\d+)\s*(day|hour|minute)s?/i);
+          if (delayMatch) {
+            const [, amount, unit] = delayMatch;
+            const delayMs = parseInt(amount) * (
+              unit.toLowerCase().startsWith('day') ? 24 * 60 * 60 * 1000 :
+              unit.toLowerCase().startsWith('hour') ? 60 * 60 * 1000 :
+              60 * 1000
+            );
+            currentScheduledTime = new Date(currentScheduledTime.getTime() + delayMs);
+          }
+        }
+
+        stepInstanceData.push({
+          contactCampaignInstanceId: instance.id,
+          campaignStepTemplateId: step.id,
+          scheduledAt: new Date(currentScheduledTime),
+          status: 'pending',
+          channel: step.channel,
+        });
+      }
+    }
+
+    const stepInstances = await campaignStepInstanceRepository.createBulkForTenant(
+      tenantId,
+      stepInstanceData
+    );
+
+    return { instances, stepInstances };
+  } catch (error) {
+    console.error('Error launching campaign:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get campaign instances for a contact
+ */
+export async function getContactCampaigns(
+  contactId: string,
+  tenantId: string
+): Promise<ContactCampaignInstance[]> {
+  try {
+    return await contactCampaignInstanceRepository.findByContactId(contactId, tenantId);
+  } catch (error) {
+    console.error('Error getting contact campaigns:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get campaign instance with details
+ */
+export async function getCampaignInstance(
+  instanceId: string,
+  tenantId: string
+): Promise<ContactCampaignInstanceWithDetails> {
+  try {
+    return await contactCampaignInstanceRepository.findByIdWithDetails(instanceId, tenantId);
+  } catch (error) {
+    console.error('Error getting campaign instance:', error);
+    throw error;
+  }
+}
+
+/**
+ * Pause a campaign instance
+ */
+export async function pauseCampaign(
+  instanceId: string,
+  tenantId: string
+): Promise<ContactCampaignInstance> {
+  try {
+    return await contactCampaignInstanceRepository.pauseCampaign(instanceId, tenantId);
+  } catch (error) {
+    console.error('Error pausing campaign:', error);
+    throw error;
+  }
+}
+
+/**
+ * Resume a campaign instance
+ */
+export async function resumeCampaign(
+  instanceId: string,
+  tenantId: string
+): Promise<ContactCampaignInstance> {
+  try {
+    return await contactCampaignInstanceRepository.resumeCampaign(instanceId, tenantId);
+  } catch (error) {
+    console.error('Error resuming campaign:', error);
+    throw error;
+  }
+}
+
+/**
+ * Step Instance Operations
+ */
+
+/**
+ * Get pending step instances (for execution)
+ */
+export async function getPendingStepInstances(
+  tenantId: string,
+  limit = 100
+): Promise<CampaignStepInstance[]> {
+  try {
+    return await campaignStepInstanceRepository.findDueStepInstances(tenantId, new Date());
+  } catch (error) {
+    console.error('Error getting pending step instances:', error);
+    throw error;
+  }
+}
+
+/**
+ * Mark step instance as sent
+ */
+export async function markStepAsSent(
+  stepInstanceId: string,
+  tenantId: string,
+  renderedConfig?: any,
+  branchOutcome?: string
+): Promise<CampaignStepInstance> {
+  try {
+    return await campaignStepInstanceRepository.markAsSent(
+      stepInstanceId,
+      tenantId,
+      renderedConfig,
+      branchOutcome
+    );
+  } catch (error) {
+    console.error('Error marking step as sent:', error);
+    throw error;
+  }
+}
+
+/**
+ * Event Tracking Operations
+ */
+
+/**
+ * Record a campaign event
+ */
+export async function recordEvent(
+  tenantId: string,
+  data: Omit<NewStepEvent, 'tenantId'>
+): Promise<StepEvent> {
+  try {
+    return await stepEventRepository.createForTenant(tenantId, data);
+  } catch (error) {
+    console.error('Error recording campaign event:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get events for a step instance
+ */
+export async function getStepEvents(
+  stepInstanceId: string,
+  tenantId: string
+): Promise<StepEvent[]> {
+  try {
+    return await stepEventRepository.findByStepInstanceId(stepInstanceId, tenantId);
+  } catch (error) {
+    console.error('Error getting step events:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get events for a contact
+ */
+export async function getContactEvents(
+  contactId: string,
+  tenantId: string
+): Promise<StepEventWithDetails[]> {
+  try {
+    return await stepEventRepository.findByContactId(contactId, tenantId);
+  } catch (error) {
+    console.error('Error getting contact events:', error);
+    throw error;
+  }
+}
+
+/**
+ * Analytics Operations
+ */
+
+/**
+ * Get campaign analytics for a tenant
+ */
+export async function getCampaignAnalytics(
+  tenantId: string,
+  options: {
+    startDate?: Date;
+    endDate?: Date;
+  } = {}
+): Promise<CampaignAnalytics> {
+  try {
+    const { startDate, endDate } = options;
+
+    // Get basic counts
+    const [
+      totalCampaigns,
+      activeCampaigns,
+      completedCampaigns,
+      totalStepsSent,
+      totalEvents,
+    ] = await Promise.all([
+      contactCampaignInstanceRepository.getCountForTenant(tenantId),
+      contactCampaignInstanceRepository.getCountForTenant(tenantId, { status: 'active' }),
+      contactCampaignInstanceRepository.getCountForTenant(tenantId, { status: 'completed' }),
+      campaignStepInstanceRepository.getCountForTenant(tenantId, { status: 'sent' }),
+      stepEventRepository.getCountForTenant(tenantId, {
+        occurredAfter: startDate,
+        occurredBefore: endDate,
+      }),
+    ]);
+
+    // Calculate engagement rate
+    const engagementRate = totalStepsSent > 0 ? (totalEvents / totalStepsSent) * 100 : 0;
+
+    // Get channel breakdown (simplified)
+    const channels = ['email', 'sms', 'video']; // Could be dynamic
+    const channelBreakdown = await Promise.all(
+      channels.map(async (channel) => {
+        const sent = await campaignStepInstanceRepository.getCountForTenant(tenantId, {
+          channel,
+          status: 'sent',
+        });
+        const events = await stepEventRepository.getChannelEngagementRate(tenantId, channel, {
+          occurredAfter: startDate,
+          occurredBefore: endDate,
+        });
+
+        return {
+          channel,
+          sent,
+          events: events.totalEngagements,
+          engagementRate: events.engagementRate,
+        };
+      })
+    );
+
+    return {
+      totalCampaigns,
+      activeCampaigns,
+      completedCampaigns,
+      totalStepsSent,
+      totalEvents,
+      engagementRate: Number(engagementRate.toFixed(2)),
+      channelBreakdown,
+    };
+  } catch (error) {
+    console.error('Error getting campaign analytics:', error);
+    throw new Error('Failed to get campaign analytics');
+  }
+}
+
+/**
+ * Get recent campaign activity
+ */
+export async function getRecentActivity(
+  tenantId: string,
+  limit = 50
+): Promise<StepEventWithDetails[]> {
+  try {
+    return await stepEventRepository.getRecentEvents(tenantId, limit);
+  } catch (error) {
+    console.error('Error getting recent activity:', error);
+    throw error;
+  }
+}

--- a/server/src/repositories/entities/CampaignStepInstanceRepository.ts
+++ b/server/src/repositories/entities/CampaignStepInstanceRepository.ts
@@ -1,0 +1,496 @@
+import { eq, and, desc, asc, lte, gte, inArray } from 'drizzle-orm';
+import { 
+  campaignStepInstances, 
+  CampaignStepInstance, 
+  NewCampaignStepInstance,
+  campaignStepTemplates,
+  contactCampaignInstances,
+  leadPointOfContacts
+} from '@/db/schema';
+import { NotFoundError } from '@/exceptions/error';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export interface CampaignStepInstanceWithDetails extends CampaignStepInstance {
+  stepTemplate?: {
+    id: string;
+    stepName: string;
+    channel: string;
+    config: any;
+    stepOrder: number;
+  } | null;
+  contactCampaignInstance?: {
+    id: string;
+    status: string;
+    contact?: {
+      id: string;
+      name: string;
+      email: string | null;
+    } | null;
+  } | null;
+}
+
+export interface CampaignStepInstanceSearchOptions {
+  contactCampaignInstanceId?: string;
+  campaignStepTemplateId?: string;
+  status?: string;
+  channel?: string;
+  scheduledBefore?: Date;
+  scheduledAfter?: Date;
+  contactId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export class CampaignStepInstanceRepository extends TenantAwareRepository<
+  typeof campaignStepInstances,
+  CampaignStepInstance,
+  NewCampaignStepInstance
+> {
+  constructor() {
+    super(campaignStepInstances);
+  }
+
+  /**
+   * Find step instance by ID with full details
+   */
+  async findByIdWithDetails(id: string, tenantId: string): Promise<CampaignStepInstanceWithDetails> {
+    const result = await this.db
+      .select({
+        stepInstance: campaignStepInstances,
+        stepTemplate: {
+          id: campaignStepTemplates.id,
+          stepName: campaignStepTemplates.stepName,
+          channel: campaignStepTemplates.channel,
+          config: campaignStepTemplates.config,
+          stepOrder: campaignStepTemplates.stepOrder,
+        },
+        contactCampaignInstance: {
+          id: contactCampaignInstances.id,
+          status: contactCampaignInstances.status,
+        },
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+        },
+      })
+      .from(campaignStepInstances)
+      .leftJoin(campaignStepTemplates, eq(campaignStepInstances.campaignStepTemplateId, campaignStepTemplates.id))
+      .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .limit(1);
+
+    if (!result || !result[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+
+    return {
+      ...result[0].stepInstance,
+      stepTemplate: result[0].stepTemplate,
+      contactCampaignInstance: result[0].contactCampaignInstance ? {
+        ...result[0].contactCampaignInstance,
+        contact: result[0].contact,
+      } : null,
+    };
+  }
+
+  /**
+   * Search step instances for a tenant with pagination and filters
+   */
+  async searchForTenant(
+    tenantId: string,
+    options: CampaignStepInstanceSearchOptions = {}
+  ): Promise<CampaignStepInstanceWithDetails[]> {
+    const { 
+      contactCampaignInstanceId, 
+      campaignStepTemplateId, 
+      status, 
+      channel,
+      scheduledBefore,
+      scheduledAfter,
+      contactId,
+      limit = 50, 
+      offset = 0 
+    } = options;
+
+    let whereConditions = [eq(campaignStepInstances.tenantId, tenantId)];
+
+    if (contactCampaignInstanceId) {
+      whereConditions.push(eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstanceId));
+    }
+
+    if (campaignStepTemplateId) {
+      whereConditions.push(eq(campaignStepInstances.campaignStepTemplateId, campaignStepTemplateId));
+    }
+
+    if (status) {
+      whereConditions.push(eq(campaignStepInstances.status, status));
+    }
+
+    if (channel) {
+      whereConditions.push(eq(campaignStepInstances.channel, channel));
+    }
+
+    if (scheduledBefore) {
+      whereConditions.push(lte(campaignStepInstances.scheduledAt, scheduledBefore));
+    }
+
+    if (scheduledAfter) {
+      whereConditions.push(gte(campaignStepInstances.scheduledAt, scheduledAfter));
+    }
+
+    if (contactId) {
+      whereConditions.push(eq(leadPointOfContacts.id, contactId));
+    }
+
+    const results = await this.db
+      .select({
+        stepInstance: campaignStepInstances,
+        stepTemplate: {
+          id: campaignStepTemplates.id,
+          stepName: campaignStepTemplates.stepName,
+          channel: campaignStepTemplates.channel,
+          config: campaignStepTemplates.config,
+          stepOrder: campaignStepTemplates.stepOrder,
+        },
+        contactCampaignInstance: {
+          id: contactCampaignInstances.id,
+          status: contactCampaignInstances.status,
+        },
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+        },
+      })
+      .from(campaignStepInstances)
+      .leftJoin(campaignStepTemplates, eq(campaignStepInstances.campaignStepTemplateId, campaignStepTemplates.id))
+      .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .where(and(...whereConditions))
+      .orderBy(asc(campaignStepInstances.scheduledAt))
+      .limit(limit)
+      .offset(offset);
+
+    return results.map((result) => ({
+      ...result.stepInstance,
+      stepTemplate: result.stepTemplate,
+      contactCampaignInstance: result.contactCampaignInstance ? {
+        ...result.contactCampaignInstance,
+        contact: result.contact,
+      } : null,
+    }));
+  }
+
+  /**
+   * Get pending step instances scheduled to run now or in the past
+   */
+  async findDueStepInstances(tenantId: string, now: Date = new Date()): Promise<CampaignStepInstance[]> {
+    return await this.db
+      .select()
+      .from(campaignStepInstances)
+      .where(
+        and(
+          eq(campaignStepInstances.tenantId, tenantId),
+          eq(campaignStepInstances.status, 'pending'),
+          lte(campaignStepInstances.scheduledAt, now)
+        )
+      )
+      .orderBy(asc(campaignStepInstances.scheduledAt));
+  }
+
+  /**
+   * Get step instances for a contact campaign instance, ordered by step order
+   */
+  async findByContactCampaignInstanceId(
+    contactCampaignInstanceId: string,
+    tenantId: string
+  ): Promise<CampaignStepInstanceWithDetails[]> {
+    const results = await this.db
+      .select({
+        stepInstance: campaignStepInstances,
+        stepTemplate: {
+          id: campaignStepTemplates.id,
+          stepName: campaignStepTemplates.stepName,
+          channel: campaignStepTemplates.channel,
+          config: campaignStepTemplates.config,
+          stepOrder: campaignStepTemplates.stepOrder,
+        },
+      })
+      .from(campaignStepInstances)
+      .leftJoin(campaignStepTemplates, eq(campaignStepInstances.campaignStepTemplateId, campaignStepTemplates.id))
+      .where(
+        and(
+          eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstanceId),
+          eq(campaignStepInstances.tenantId, tenantId)
+        )
+      )
+      .orderBy(asc(campaignStepTemplates.stepOrder));
+
+    return results.map((result) => ({
+      ...result.stepInstance,
+      stepTemplate: result.stepTemplate,
+      contactCampaignInstance: null,
+    }));
+  }
+
+  /**
+   * Update step instance for tenant
+   */
+  async updateForTenant(
+    id: string,
+    tenantId: string,
+    data: Partial<Omit<NewCampaignStepInstance, 'id' | 'tenantId' | 'createdAt'>>
+  ): Promise<CampaignStepInstance> {
+    const updated = await this.db
+      .update(campaignStepInstances)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Mark step instance as sent
+   */
+  async markAsSent(
+    id: string,
+    tenantId: string,
+    renderedConfig?: any,
+    branchOutcome?: string
+  ): Promise<CampaignStepInstance> {
+    const updated = await this.db
+      .update(campaignStepInstances)
+      .set({
+        status: 'sent',
+        sentAt: new Date(),
+        renderedConfig,
+        branchOutcome,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Mark step instance as completed
+   */
+  async markAsCompleted(
+    id: string,
+    tenantId: string,
+    branchOutcome?: string
+  ): Promise<CampaignStepInstance> {
+    const updated = await this.db
+      .update(campaignStepInstances)
+      .set({
+        status: 'completed',
+        branchOutcome,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Mark step instance as skipped
+   */
+  async markAsSkipped(
+    id: string,
+    tenantId: string,
+    branchOutcome?: string
+  ): Promise<CampaignStepInstance> {
+    const updated = await this.db
+      .update(campaignStepInstances)
+      .set({
+        status: 'skipped',
+        branchOutcome,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Reschedule a step instance
+   */
+  async reschedule(
+    id: string,
+    tenantId: string,
+    newScheduledAt: Date
+  ): Promise<CampaignStepInstance> {
+    const updated = await this.db
+      .update(campaignStepInstances)
+      .set({
+        scheduledAt: newScheduledAt,
+        status: 'pending', // Reset to pending if it was skipped or failed
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Delete step instance for tenant
+   */
+  async deleteForTenant(id: string, tenantId: string): Promise<void> {
+    const deleted = await this.db
+      .delete(campaignStepInstances)
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!deleted || !deleted[0]) {
+      throw new NotFoundError(`Campaign step instance not found with id: ${id}`);
+    }
+  }
+
+  /**
+   * Get step instances count for a tenant
+   */
+  async getCountForTenant(
+    tenantId: string,
+    options: Omit<CampaignStepInstanceSearchOptions, 'limit' | 'offset'> = {}
+  ): Promise<number> {
+    const { 
+      contactCampaignInstanceId, 
+      campaignStepTemplateId, 
+      status, 
+      channel,
+      scheduledBefore,
+      scheduledAfter,
+      contactId
+    } = options;
+
+    let whereConditions = [eq(campaignStepInstances.tenantId, tenantId)];
+
+    if (contactCampaignInstanceId) {
+      whereConditions.push(eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstanceId));
+    }
+
+    if (campaignStepTemplateId) {
+      whereConditions.push(eq(campaignStepInstances.campaignStepTemplateId, campaignStepTemplateId));
+    }
+
+    if (status) {
+      whereConditions.push(eq(campaignStepInstances.status, status));
+    }
+
+    if (channel) {
+      whereConditions.push(eq(campaignStepInstances.channel, channel));
+    }
+
+    if (scheduledBefore) {
+      whereConditions.push(lte(campaignStepInstances.scheduledAt, scheduledBefore));
+    }
+
+    if (scheduledAfter) {
+      whereConditions.push(gte(campaignStepInstances.scheduledAt, scheduledAfter));
+    }
+
+    if (contactId) {
+      // Need to join with contact campaign instances and contacts
+      const result = await this.db
+        .select({ count: this.db.count() })
+        .from(campaignStepInstances)
+        .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+        .where(and(...whereConditions, eq(contactCampaignInstances.contactId, contactId)));
+      
+      return result[0]?.count || 0;
+    }
+
+    const result = await this.db
+      .select({ count: this.db.count() })
+      .from(campaignStepInstances)
+      .where(and(...whereConditions));
+
+    return result[0]?.count || 0;
+  }
+
+  /**
+   * Bulk create step instances for a campaign instance
+   */
+  async createBulkForTenant(
+    tenantId: string,
+    data: Omit<NewCampaignStepInstance, 'tenantId'>[]
+  ): Promise<CampaignStepInstance[]> {
+    const dataWithTenant = data.map((item) => ({ ...item, tenantId }));
+    return await this.createMany(dataWithTenant);
+  }
+
+  /**
+   * Get step instances by status for a tenant
+   */
+  async findByStatus(status: string, tenantId: string): Promise<CampaignStepInstance[]> {
+    return await this.db
+      .select()
+      .from(campaignStepInstances)
+      .where(
+        and(
+          eq(campaignStepInstances.status, status),
+          eq(campaignStepInstances.tenantId, tenantId)
+        )
+      )
+      .orderBy(asc(campaignStepInstances.scheduledAt));
+  }
+
+  /**
+   * Get step instances by channel for a tenant
+   */
+  async findByChannel(channel: string, tenantId: string): Promise<CampaignStepInstance[]> {
+    return await this.db
+      .select()
+      .from(campaignStepInstances)
+      .where(
+        and(
+          eq(campaignStepInstances.channel, channel),
+          eq(campaignStepInstances.tenantId, tenantId)
+        )
+      )
+      .orderBy(asc(campaignStepInstances.scheduledAt));
+  }
+
+  /**
+   * Check if step instance exists for tenant
+   */
+  async existsForTenant(id: string, tenantId: string): Promise<boolean> {
+    const result = await this.db
+      .select({ id: campaignStepInstances.id })
+      .from(campaignStepInstances)
+      .where(and(eq(campaignStepInstances.id, id), eq(campaignStepInstances.tenantId, tenantId)))
+      .limit(1);
+
+    return result.length > 0;
+  }
+}

--- a/server/src/repositories/entities/CampaignStepTemplateRepository.ts
+++ b/server/src/repositories/entities/CampaignStepTemplateRepository.ts
@@ -1,0 +1,267 @@
+import { eq, and, asc, desc } from 'drizzle-orm';
+import { 
+  campaignStepTemplates, 
+  CampaignStepTemplate, 
+  NewCampaignStepTemplate,
+  campaignTemplates 
+} from '@/db/schema';
+import { NotFoundError } from '@/exceptions/error';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export interface CampaignStepTemplateWithCampaign extends CampaignStepTemplate {
+  campaignTemplate?: {
+    id: string;
+    name: string;
+    description: string | null;
+  } | null;
+}
+
+export interface CampaignStepTemplateSearchOptions {
+  campaignTemplateId?: string;
+  channel?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export class CampaignStepTemplateRepository extends TenantAwareRepository<
+  typeof campaignStepTemplates,
+  CampaignStepTemplate,
+  NewCampaignStepTemplate
+> {
+  constructor() {
+    super(campaignStepTemplates);
+  }
+
+  /**
+   * Find step template by ID with campaign details
+   */
+  async findByIdWithDetails(id: string, tenantId: string): Promise<CampaignStepTemplateWithCampaign> {
+    const result = await this.db
+      .select({
+        stepTemplate: campaignStepTemplates,
+        campaignTemplate: {
+          id: campaignTemplates.id,
+          name: campaignTemplates.name,
+          description: campaignTemplates.description,
+        },
+      })
+      .from(campaignStepTemplates)
+      .leftJoin(campaignTemplates, eq(campaignStepTemplates.campaignTemplateId, campaignTemplates.id))
+      .where(and(eq(campaignStepTemplates.id, id), eq(campaignStepTemplates.tenantId, tenantId)))
+      .limit(1);
+
+    if (!result || !result[0]) {
+      throw new NotFoundError(`Campaign step template not found with id: ${id}`);
+    }
+
+    return {
+      ...result[0].stepTemplate,
+      campaignTemplate: result[0].campaignTemplate,
+    };
+  }
+
+  /**
+   * Get all step templates for a campaign template, ordered by step order
+   */
+  async findByCampaignTemplateId(
+    campaignTemplateId: string,
+    tenantId: string
+  ): Promise<CampaignStepTemplate[]> {
+    return await this.db
+      .select()
+      .from(campaignStepTemplates)
+      .where(
+        and(
+          eq(campaignStepTemplates.campaignTemplateId, campaignTemplateId),
+          eq(campaignStepTemplates.tenantId, tenantId)
+        )
+      )
+      .orderBy(asc(campaignStepTemplates.stepOrder));
+  }
+
+  /**
+   * Search step templates for a tenant with pagination
+   */
+  async searchForTenant(
+    tenantId: string,
+    options: CampaignStepTemplateSearchOptions = {}
+  ): Promise<CampaignStepTemplateWithCampaign[]> {
+    const { campaignTemplateId, channel, limit = 50, offset = 0 } = options;
+
+    let whereConditions = [eq(campaignStepTemplates.tenantId, tenantId)];
+
+    if (campaignTemplateId) {
+      whereConditions.push(eq(campaignStepTemplates.campaignTemplateId, campaignTemplateId));
+    }
+
+    if (channel) {
+      whereConditions.push(eq(campaignStepTemplates.channel, channel));
+    }
+
+    const results = await this.db
+      .select({
+        stepTemplate: campaignStepTemplates,
+        campaignTemplate: {
+          id: campaignTemplates.id,
+          name: campaignTemplates.name,
+          description: campaignTemplates.description,
+        },
+      })
+      .from(campaignStepTemplates)
+      .leftJoin(campaignTemplates, eq(campaignStepTemplates.campaignTemplateId, campaignTemplates.id))
+      .where(and(...whereConditions))
+      .orderBy(asc(campaignStepTemplates.stepOrder))
+      .limit(limit)
+      .offset(offset);
+
+    return results.map((result) => ({
+      ...result.stepTemplate,
+      campaignTemplate: result.campaignTemplate,
+    }));
+  }
+
+  /**
+   * Get step templates count for a tenant
+   */
+  async getCountForTenant(
+    tenantId: string,
+    options: Omit<CampaignStepTemplateSearchOptions, 'limit' | 'offset'> = {}
+  ): Promise<number> {
+    const { campaignTemplateId, channel } = options;
+
+    let whereConditions = [eq(campaignStepTemplates.tenantId, tenantId)];
+
+    if (campaignTemplateId) {
+      whereConditions.push(eq(campaignStepTemplates.campaignTemplateId, campaignTemplateId));
+    }
+
+    if (channel) {
+      whereConditions.push(eq(campaignStepTemplates.channel, channel));
+    }
+
+    const result = await this.db
+      .select({ count: this.db.count() })
+      .from(campaignStepTemplates)
+      .where(and(...whereConditions));
+
+    return result[0]?.count || 0;
+  }
+
+  /**
+   * Update step template for tenant
+   */
+  async updateForTenant(
+    id: string,
+    tenantId: string,
+    data: Partial<Omit<NewCampaignStepTemplate, 'id' | 'tenantId' | 'createdAt'>>
+  ): Promise<CampaignStepTemplate> {
+    const updated = await this.db
+      .update(campaignStepTemplates)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignStepTemplates.id, id), eq(campaignStepTemplates.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign step template not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Delete step template for tenant
+   */
+  async deleteForTenant(id: string, tenantId: string): Promise<void> {
+    const deleted = await this.db
+      .delete(campaignStepTemplates)
+      .where(and(eq(campaignStepTemplates.id, id), eq(campaignStepTemplates.tenantId, tenantId)))
+      .returning();
+
+    if (!deleted || !deleted[0]) {
+      throw new NotFoundError(`Campaign step template not found with id: ${id}`);
+    }
+  }
+
+  /**
+   * Get the next step order for a campaign template
+   */
+  async getNextStepOrder(campaignTemplateId: string, tenantId: string): Promise<number> {
+    const result = await this.db
+      .select({ maxOrder: this.db.max(campaignStepTemplates.stepOrder) })
+      .from(campaignStepTemplates)
+      .where(
+        and(
+          eq(campaignStepTemplates.campaignTemplateId, campaignTemplateId),
+          eq(campaignStepTemplates.tenantId, tenantId)
+        )
+      );
+
+    const maxOrder = result[0]?.maxOrder || 0;
+    return maxOrder + 1;
+  }
+
+  /**
+   * Reorder step templates for a campaign template
+   */
+  async reorderSteps(
+    campaignTemplateId: string,
+    tenantId: string,
+    stepOrders: { id: string; stepOrder: number }[]
+  ): Promise<void> {
+    // Update each step's order in a transaction
+    await this.db.transaction(async (tx) => {
+      for (const { id, stepOrder } of stepOrders) {
+        await tx
+          .update(campaignStepTemplates)
+          .set({ 
+            stepOrder,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(campaignStepTemplates.id, id),
+              eq(campaignStepTemplates.campaignTemplateId, campaignTemplateId),
+              eq(campaignStepTemplates.tenantId, tenantId)
+            )
+          );
+      }
+    });
+  }
+
+  /**
+   * Get step templates by channel for a campaign template
+   */
+  async findByChannelForCampaign(
+    campaignTemplateId: string,
+    channel: string,
+    tenantId: string
+  ): Promise<CampaignStepTemplate[]> {
+    return await this.db
+      .select()
+      .from(campaignStepTemplates)
+      .where(
+        and(
+          eq(campaignStepTemplates.campaignTemplateId, campaignTemplateId),
+          eq(campaignStepTemplates.channel, channel),
+          eq(campaignStepTemplates.tenantId, tenantId)
+        )
+      )
+      .orderBy(asc(campaignStepTemplates.stepOrder));
+  }
+
+  /**
+   * Check if step template exists for tenant
+   */
+  async existsForTenant(id: string, tenantId: string): Promise<boolean> {
+    const result = await this.db
+      .select({ id: campaignStepTemplates.id })
+      .from(campaignStepTemplates)
+      .where(and(eq(campaignStepTemplates.id, id), eq(campaignStepTemplates.tenantId, tenantId)))
+      .limit(1);
+
+    return result.length > 0;
+  }
+}

--- a/server/src/repositories/entities/CampaignTemplateRepository.ts
+++ b/server/src/repositories/entities/CampaignTemplateRepository.ts
@@ -1,0 +1,197 @@
+import { eq, and, desc, ilike } from 'drizzle-orm';
+import { campaignTemplates, CampaignTemplate, NewCampaignTemplate, users } from '@/db/schema';
+import { NotFoundError } from '@/exceptions/error';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export interface CampaignTemplateWithDetails extends CampaignTemplate {
+  createdBy?: {
+    id: string;
+    name: string | null;
+    email: string;
+  } | null;
+}
+
+export interface CampaignTemplateSearchOptions {
+  searchQuery?: string;
+  createdBy?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export class CampaignTemplateRepository extends TenantAwareRepository<
+  typeof campaignTemplates,
+  CampaignTemplate,
+  NewCampaignTemplate
+> {
+  constructor() {
+    super(campaignTemplates);
+  }
+
+  /**
+   * Find campaign template by ID with creator details
+   */
+  async findByIdWithDetails(id: string, tenantId: string): Promise<CampaignTemplateWithDetails> {
+    const result = await this.db
+      .select({
+        template: campaignTemplates,
+        createdBy: {
+          id: users.id,
+          name: users.name,
+          email: users.email,
+        },
+      })
+      .from(campaignTemplates)
+      .leftJoin(users, eq(campaignTemplates.createdBy, users.id))
+      .where(and(eq(campaignTemplates.id, id), eq(campaignTemplates.tenantId, tenantId)))
+      .limit(1);
+
+    if (!result || !result[0]) {
+      throw new NotFoundError(`Campaign template not found with id: ${id}`);
+    }
+
+    return {
+      ...result[0].template,
+      createdBy: result[0].createdBy,
+    };
+  }
+
+  /**
+   * Search campaign templates for a tenant with pagination
+   */
+  async searchForTenant(
+    tenantId: string,
+    options: CampaignTemplateSearchOptions = {}
+  ): Promise<CampaignTemplateWithDetails[]> {
+    const { searchQuery, createdBy, limit = 50, offset = 0 } = options;
+
+    let query = this.db
+      .select({
+        template: campaignTemplates,
+        createdBy: {
+          id: users.id,
+          name: users.name,
+          email: users.email,
+        },
+      })
+      .from(campaignTemplates)
+      .leftJoin(users, eq(campaignTemplates.createdBy, users.id))
+      .where(eq(campaignTemplates.tenantId, tenantId));
+
+    // Apply filters
+    if (searchQuery) {
+      query = query.where(
+        and(
+          eq(campaignTemplates.tenantId, tenantId),
+          ilike(campaignTemplates.name, `%${searchQuery}%`)
+        )
+      );
+    }
+
+    if (createdBy) {
+      query = query.where(
+        and(
+          eq(campaignTemplates.tenantId, tenantId),
+          eq(campaignTemplates.createdBy, createdBy)
+        )
+      );
+    }
+
+    const results = await query
+      .orderBy(desc(campaignTemplates.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return results.map((result) => ({
+      ...result.template,
+      createdBy: result.createdBy,
+    }));
+  }
+
+  /**
+   * Get campaign templates count for a tenant
+   */
+  async getCountForTenant(
+    tenantId: string,
+    options: Omit<CampaignTemplateSearchOptions, 'limit' | 'offset'> = {}
+  ): Promise<number> {
+    const { searchQuery, createdBy } = options;
+
+    let query = this.db
+      .select({ count: this.db.count() })
+      .from(campaignTemplates)
+      .where(eq(campaignTemplates.tenantId, tenantId));
+
+    // Apply filters
+    if (searchQuery) {
+      query = query.where(
+        and(
+          eq(campaignTemplates.tenantId, tenantId),
+          ilike(campaignTemplates.name, `%${searchQuery}%`)
+        )
+      );
+    }
+
+    if (createdBy) {
+      query = query.where(
+        and(
+          eq(campaignTemplates.tenantId, tenantId),
+          eq(campaignTemplates.createdBy, createdBy)
+        )
+      );
+    }
+
+    const result = await query;
+    return result[0]?.count || 0;
+  }
+
+  /**
+   * Update campaign template for tenant
+   */
+  async updateForTenant(
+    id: string,
+    tenantId: string,
+    data: Partial<Omit<NewCampaignTemplate, 'id' | 'tenantId' | 'createdAt'>>
+  ): Promise<CampaignTemplate> {
+    const updated = await this.db
+      .update(campaignTemplates)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(campaignTemplates.id, id), eq(campaignTemplates.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Campaign template not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Delete campaign template for tenant
+   */
+  async deleteForTenant(id: string, tenantId: string): Promise<void> {
+    const deleted = await this.db
+      .delete(campaignTemplates)
+      .where(and(eq(campaignTemplates.id, id), eq(campaignTemplates.tenantId, tenantId)))
+      .returning();
+
+    if (!deleted || !deleted[0]) {
+      throw new NotFoundError(`Campaign template not found with id: ${id}`);
+    }
+  }
+
+  /**
+   * Check if campaign template exists for tenant
+   */
+  async existsForTenant(id: string, tenantId: string): Promise<boolean> {
+    const result = await this.db
+      .select({ id: campaignTemplates.id })
+      .from(campaignTemplates)
+      .where(and(eq(campaignTemplates.id, id), eq(campaignTemplates.tenantId, tenantId)))
+      .limit(1);
+
+    return result.length > 0;
+  }
+}

--- a/server/src/repositories/entities/ContactCampaignInstanceRepository.ts
+++ b/server/src/repositories/entities/ContactCampaignInstanceRepository.ts
@@ -1,0 +1,376 @@
+import { eq, and, desc, ilike, inArray } from 'drizzle-orm';
+import { 
+  contactCampaignInstances, 
+  ContactCampaignInstance, 
+  NewContactCampaignInstance,
+  campaignTemplates,
+  leadPointOfContacts,
+  leads
+} from '@/db/schema';
+import { NotFoundError } from '@/exceptions/error';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export interface ContactCampaignInstanceWithDetails extends ContactCampaignInstance {
+  contact?: {
+    id: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    title: string | null;
+    lead?: {
+      id: string;
+      name: string;
+    } | null;
+  } | null;
+  campaignTemplate?: {
+    id: string;
+    name: string;
+    description: string | null;
+  } | null;
+}
+
+export interface ContactCampaignInstanceSearchOptions {
+  contactId?: string;
+  campaignTemplateId?: string;
+  status?: string;
+  leadId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export class ContactCampaignInstanceRepository extends TenantAwareRepository<
+  typeof contactCampaignInstances,
+  ContactCampaignInstance,
+  NewContactCampaignInstance
+> {
+  constructor() {
+    super(contactCampaignInstances);
+  }
+
+  /**
+   * Find campaign instance by ID with full details
+   */
+  async findByIdWithDetails(id: string, tenantId: string): Promise<ContactCampaignInstanceWithDetails> {
+    const result = await this.db
+      .select({
+        instance: contactCampaignInstances,
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+          phone: leadPointOfContacts.phone,
+          title: leadPointOfContacts.title,
+        },
+        lead: {
+          id: leads.id,
+          name: leads.name,
+        },
+        campaignTemplate: {
+          id: campaignTemplates.id,
+          name: campaignTemplates.name,
+          description: campaignTemplates.description,
+        },
+      })
+      .from(contactCampaignInstances)
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .leftJoin(leads, eq(leadPointOfContacts.leadId, leads.id))
+      .leftJoin(campaignTemplates, eq(contactCampaignInstances.campaignTemplateId, campaignTemplates.id))
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .limit(1);
+
+    if (!result || !result[0]) {
+      throw new NotFoundError(`Contact campaign instance not found with id: ${id}`);
+    }
+
+    return {
+      ...result[0].instance,
+      contact: result[0].contact ? {
+        ...result[0].contact,
+        lead: result[0].lead,
+      } : null,
+      campaignTemplate: result[0].campaignTemplate,
+    };
+  }
+
+  /**
+   * Search campaign instances for a tenant with pagination and filters
+   */
+  async searchForTenant(
+    tenantId: string,
+    options: ContactCampaignInstanceSearchOptions = {}
+  ): Promise<ContactCampaignInstanceWithDetails[]> {
+    const { contactId, campaignTemplateId, status, leadId, limit = 50, offset = 0 } = options;
+
+    let whereConditions = [eq(contactCampaignInstances.tenantId, tenantId)];
+
+    if (contactId) {
+      whereConditions.push(eq(contactCampaignInstances.contactId, contactId));
+    }
+
+    if (campaignTemplateId) {
+      whereConditions.push(eq(contactCampaignInstances.campaignTemplateId, campaignTemplateId));
+    }
+
+    if (status) {
+      whereConditions.push(eq(contactCampaignInstances.status, status));
+    }
+
+    if (leadId) {
+      whereConditions.push(eq(leads.id, leadId));
+    }
+
+    const results = await this.db
+      .select({
+        instance: contactCampaignInstances,
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+          phone: leadPointOfContacts.phone,
+          title: leadPointOfContacts.title,
+        },
+        lead: {
+          id: leads.id,
+          name: leads.name,
+        },
+        campaignTemplate: {
+          id: campaignTemplates.id,
+          name: campaignTemplates.name,
+          description: campaignTemplates.description,
+        },
+      })
+      .from(contactCampaignInstances)
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .leftJoin(leads, eq(leadPointOfContacts.leadId, leads.id))
+      .leftJoin(campaignTemplates, eq(contactCampaignInstances.campaignTemplateId, campaignTemplates.id))
+      .where(and(...whereConditions))
+      .orderBy(desc(contactCampaignInstances.startedAt))
+      .limit(limit)
+      .offset(offset);
+
+    return results.map((result) => ({
+      ...result.instance,
+      contact: result.contact ? {
+        ...result.contact,
+        lead: result.lead,
+      } : null,
+      campaignTemplate: result.campaignTemplate,
+    }));
+  }
+
+  /**
+   * Get campaign instances count for a tenant
+   */
+  async getCountForTenant(
+    tenantId: string,
+    options: Omit<ContactCampaignInstanceSearchOptions, 'limit' | 'offset'> = {}
+  ): Promise<number> {
+    const { contactId, campaignTemplateId, status, leadId } = options;
+
+    let whereConditions = [eq(contactCampaignInstances.tenantId, tenantId)];
+
+    if (contactId) {
+      whereConditions.push(eq(contactCampaignInstances.contactId, contactId));
+    }
+
+    if (campaignTemplateId) {
+      whereConditions.push(eq(contactCampaignInstances.campaignTemplateId, campaignTemplateId));
+    }
+
+    if (status) {
+      whereConditions.push(eq(contactCampaignInstances.status, status));
+    }
+
+    if (leadId) {
+      // Join with contacts to filter by leadId
+      const result = await this.db
+        .select({ count: this.db.count() })
+        .from(contactCampaignInstances)
+        .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+        .where(and(...whereConditions, eq(leadPointOfContacts.leadId, leadId)));
+      
+      return result[0]?.count || 0;
+    }
+
+    const result = await this.db
+      .select({ count: this.db.count() })
+      .from(contactCampaignInstances)
+      .where(and(...whereConditions));
+
+    return result[0]?.count || 0;
+  }
+
+  /**
+   * Update campaign instance for tenant
+   */
+  async updateForTenant(
+    id: string,
+    tenantId: string,
+    data: Partial<Omit<NewContactCampaignInstance, 'id' | 'tenantId' | 'createdAt'>>
+  ): Promise<ContactCampaignInstance> {
+    const updated = await this.db
+      .update(contactCampaignInstances)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Contact campaign instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Delete campaign instance for tenant
+   */
+  async deleteForTenant(id: string, tenantId: string): Promise<void> {
+    const deleted = await this.db
+      .delete(contactCampaignInstances)
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!deleted || !deleted[0]) {
+      throw new NotFoundError(`Contact campaign instance not found with id: ${id}`);
+    }
+  }
+
+  /**
+   * Get all campaign instances for a contact
+   */
+  async findByContactId(contactId: string, tenantId: string): Promise<ContactCampaignInstance[]> {
+    return await this.db
+      .select()
+      .from(contactCampaignInstances)
+      .where(
+        and(
+          eq(contactCampaignInstances.contactId, contactId),
+          eq(contactCampaignInstances.tenantId, tenantId)
+        )
+      )
+      .orderBy(desc(contactCampaignInstances.startedAt));
+  }
+
+  /**
+   * Get all campaign instances for a campaign template
+   */
+  async findByCampaignTemplateId(
+    campaignTemplateId: string,
+    tenantId: string
+  ): Promise<ContactCampaignInstance[]> {
+    return await this.db
+      .select()
+      .from(contactCampaignInstances)
+      .where(
+        and(
+          eq(contactCampaignInstances.campaignTemplateId, campaignTemplateId),
+          eq(contactCampaignInstances.tenantId, tenantId)
+        )
+      )
+      .orderBy(desc(contactCampaignInstances.startedAt));
+  }
+
+  /**
+   * Get active campaign instances (for scheduling)
+   */
+  async findActiveInstances(tenantId: string): Promise<ContactCampaignInstance[]> {
+    return await this.db
+      .select()
+      .from(contactCampaignInstances)
+      .where(
+        and(
+          eq(contactCampaignInstances.status, 'active'),
+          eq(contactCampaignInstances.tenantId, tenantId)
+        )
+      )
+      .orderBy(desc(contactCampaignInstances.startedAt));
+  }
+
+  /**
+   * Complete a campaign instance
+   */
+  async completeCampaign(id: string, tenantId: string): Promise<ContactCampaignInstance> {
+    const updated = await this.db
+      .update(contactCampaignInstances)
+      .set({
+        status: 'completed',
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Contact campaign instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Pause a campaign instance
+   */
+  async pauseCampaign(id: string, tenantId: string): Promise<ContactCampaignInstance> {
+    const updated = await this.db
+      .update(contactCampaignInstances)
+      .set({
+        status: 'paused',
+        updatedAt: new Date(),
+      })
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Contact campaign instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Resume a campaign instance
+   */
+  async resumeCampaign(id: string, tenantId: string): Promise<ContactCampaignInstance> {
+    const updated = await this.db
+      .update(contactCampaignInstances)
+      .set({
+        status: 'active',
+        updatedAt: new Date(),
+      })
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Contact campaign instance not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Check if campaign instance exists for tenant
+   */
+  async existsForTenant(id: string, tenantId: string): Promise<boolean> {
+    const result = await this.db
+      .select({ id: contactCampaignInstances.id })
+      .from(contactCampaignInstances)
+      .where(and(eq(contactCampaignInstances.id, id), eq(contactCampaignInstances.tenantId, tenantId)))
+      .limit(1);
+
+    return result.length > 0;
+  }
+
+  /**
+   * Bulk create campaign instances for multiple contacts
+   */
+  async createBulkForTenant(
+    tenantId: string,
+    data: Omit<NewContactCampaignInstance, 'tenantId'>[]
+  ): Promise<ContactCampaignInstance[]> {
+    const dataWithTenant = data.map((item) => ({ ...item, tenantId }));
+    return await this.createMany(dataWithTenant);
+  }
+}

--- a/server/src/repositories/entities/StepEventRepository.ts
+++ b/server/src/repositories/entities/StepEventRepository.ts
@@ -1,0 +1,508 @@
+import { eq, and, desc, asc, gte, lte, inArray } from 'drizzle-orm';
+import { 
+  stepEvents, 
+  StepEvent, 
+  NewStepEvent,
+  campaignStepInstances,
+  contactCampaignInstances,
+  leadPointOfContacts
+} from '@/db/schema';
+import { NotFoundError } from '@/exceptions/error';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export interface StepEventWithDetails extends StepEvent {
+  stepInstance?: {
+    id: string;
+    status: string;
+    channel: string;
+    scheduledAt: Date;
+    sentAt: Date | null;
+  } | null;
+  contact?: {
+    id: string;
+    name: string;
+    email: string | null;
+  } | null;
+}
+
+export interface StepEventSearchOptions {
+  campaignStepInstanceId?: string;
+  eventType?: string;
+  contactId?: string;
+  channel?: string;
+  occurredAfter?: Date;
+  occurredBefore?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export interface EventAnalytics {
+  eventType: string;
+  count: number;
+  channel?: string;
+}
+
+export class StepEventRepository extends TenantAwareRepository<
+  typeof stepEvents,
+  StepEvent,
+  NewStepEvent
+> {
+  constructor() {
+    super(stepEvents);
+  }
+
+  /**
+   * Find step event by ID with full details
+   */
+  async findByIdWithDetails(id: string, tenantId: string): Promise<StepEventWithDetails> {
+    const result = await this.db
+      .select({
+        event: stepEvents,
+        stepInstance: {
+          id: campaignStepInstances.id,
+          status: campaignStepInstances.status,
+          channel: campaignStepInstances.channel,
+          scheduledAt: campaignStepInstances.scheduledAt,
+          sentAt: campaignStepInstances.sentAt,
+        },
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+        },
+      })
+      .from(stepEvents)
+      .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+      .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .where(and(eq(stepEvents.id, id), eq(stepEvents.tenantId, tenantId)))
+      .limit(1);
+
+    if (!result || !result[0]) {
+      throw new NotFoundError(`Step event not found with id: ${id}`);
+    }
+
+    return {
+      ...result[0].event,
+      stepInstance: result[0].stepInstance,
+      contact: result[0].contact,
+    };
+  }
+
+  /**
+   * Search step events for a tenant with pagination and filters
+   */
+  async searchForTenant(
+    tenantId: string,
+    options: StepEventSearchOptions = {}
+  ): Promise<StepEventWithDetails[]> {
+    const { 
+      campaignStepInstanceId, 
+      eventType, 
+      contactId,
+      channel,
+      occurredAfter,
+      occurredBefore,
+      limit = 50, 
+      offset = 0 
+    } = options;
+
+    let whereConditions = [eq(stepEvents.tenantId, tenantId)];
+
+    if (campaignStepInstanceId) {
+      whereConditions.push(eq(stepEvents.campaignStepInstanceId, campaignStepInstanceId));
+    }
+
+    if (eventType) {
+      whereConditions.push(eq(stepEvents.eventType, eventType));
+    }
+
+    if (contactId) {
+      whereConditions.push(eq(leadPointOfContacts.id, contactId));
+    }
+
+    if (channel) {
+      whereConditions.push(eq(campaignStepInstances.channel, channel));
+    }
+
+    if (occurredAfter) {
+      whereConditions.push(gte(stepEvents.occurredAt, occurredAfter));
+    }
+
+    if (occurredBefore) {
+      whereConditions.push(lte(stepEvents.occurredAt, occurredBefore));
+    }
+
+    const results = await this.db
+      .select({
+        event: stepEvents,
+        stepInstance: {
+          id: campaignStepInstances.id,
+          status: campaignStepInstances.status,
+          channel: campaignStepInstances.channel,
+          scheduledAt: campaignStepInstances.scheduledAt,
+          sentAt: campaignStepInstances.sentAt,
+        },
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+        },
+      })
+      .from(stepEvents)
+      .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+      .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .where(and(...whereConditions))
+      .orderBy(desc(stepEvents.occurredAt))
+      .limit(limit)
+      .offset(offset);
+
+    return results.map((result) => ({
+      ...result.event,
+      stepInstance: result.stepInstance,
+      contact: result.contact,
+    }));
+  }
+
+  /**
+   * Get events for a specific step instance
+   */
+  async findByStepInstanceId(
+    campaignStepInstanceId: string,
+    tenantId: string
+  ): Promise<StepEvent[]> {
+    return await this.db
+      .select()
+      .from(stepEvents)
+      .where(
+        and(
+          eq(stepEvents.campaignStepInstanceId, campaignStepInstanceId),
+          eq(stepEvents.tenantId, tenantId)
+        )
+      )
+      .orderBy(asc(stepEvents.occurredAt));
+  }
+
+  /**
+   * Get events by type for a tenant
+   */
+  async findByEventType(
+    eventType: string,
+    tenantId: string,
+    limit = 100
+  ): Promise<StepEvent[]> {
+    return await this.db
+      .select()
+      .from(stepEvents)
+      .where(
+        and(
+          eq(stepEvents.eventType, eventType),
+          eq(stepEvents.tenantId, tenantId)
+        )
+      )
+      .orderBy(desc(stepEvents.occurredAt))
+      .limit(limit);
+  }
+
+  /**
+   * Get events for a specific contact across all campaigns
+   */
+  async findByContactId(
+    contactId: string,
+    tenantId: string
+  ): Promise<StepEventWithDetails[]> {
+    const results = await this.db
+      .select({
+        event: stepEvents,
+        stepInstance: {
+          id: campaignStepInstances.id,
+          status: campaignStepInstances.status,
+          channel: campaignStepInstances.channel,
+          scheduledAt: campaignStepInstances.scheduledAt,
+          sentAt: campaignStepInstances.sentAt,
+        },
+      })
+      .from(stepEvents)
+      .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+      .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+      .where(
+        and(
+          eq(contactCampaignInstances.contactId, contactId),
+          eq(stepEvents.tenantId, tenantId)
+        )
+      )
+      .orderBy(desc(stepEvents.occurredAt));
+
+    return results.map((result) => ({
+      ...result.event,
+      stepInstance: result.stepInstance,
+      contact: null, // Already filtered by contactId
+    }));
+  }
+
+  /**
+   * Get event analytics by type for a tenant
+   */
+  async getEventAnalytics(
+    tenantId: string,
+    options: {
+      occurredAfter?: Date;
+      occurredBefore?: Date;
+      channel?: string;
+    } = {}
+  ): Promise<EventAnalytics[]> {
+    const { occurredAfter, occurredBefore, channel } = options;
+
+    let whereConditions = [eq(stepEvents.tenantId, tenantId)];
+
+    if (occurredAfter) {
+      whereConditions.push(gte(stepEvents.occurredAt, occurredAfter));
+    }
+
+    if (occurredBefore) {
+      whereConditions.push(lte(stepEvents.occurredAt, occurredBefore));
+    }
+
+    if (channel) {
+      whereConditions.push(eq(campaignStepInstances.channel, channel));
+    }
+
+    const results = await this.db
+      .select({
+        eventType: stepEvents.eventType,
+        channel: campaignStepInstances.channel,
+        count: this.db.count(),
+      })
+      .from(stepEvents)
+      .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+      .where(and(...whereConditions))
+      .groupBy(stepEvents.eventType, campaignStepInstances.channel)
+      .orderBy(desc(this.db.count()));
+
+    return results.map((result) => ({
+      eventType: result.eventType,
+      count: result.count,
+      channel: result.channel || undefined,
+    }));
+  }
+
+  /**
+   * Get recent events for a tenant (for dashboards)
+   */
+  async getRecentEvents(
+    tenantId: string,
+    limit = 50
+  ): Promise<StepEventWithDetails[]> {
+    const results = await this.db
+      .select({
+        event: stepEvents,
+        stepInstance: {
+          id: campaignStepInstances.id,
+          status: campaignStepInstances.status,
+          channel: campaignStepInstances.channel,
+          scheduledAt: campaignStepInstances.scheduledAt,
+          sentAt: campaignStepInstances.sentAt,
+        },
+        contact: {
+          id: leadPointOfContacts.id,
+          name: leadPointOfContacts.name,
+          email: leadPointOfContacts.email,
+        },
+      })
+      .from(stepEvents)
+      .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+      .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+      .leftJoin(leadPointOfContacts, eq(contactCampaignInstances.contactId, leadPointOfContacts.id))
+      .where(eq(stepEvents.tenantId, tenantId))
+      .orderBy(desc(stepEvents.occurredAt))
+      .limit(limit);
+
+    return results.map((result) => ({
+      ...result.event,
+      stepInstance: result.stepInstance,
+      contact: result.contact,
+    }));
+  }
+
+  /**
+   * Update step event for tenant
+   */
+  async updateForTenant(
+    id: string,
+    tenantId: string,
+    data: Partial<Omit<NewStepEvent, 'id' | 'tenantId' | 'occurredAt' | 'createdAt'>>
+  ): Promise<StepEvent> {
+    const updated = await this.db
+      .update(stepEvents)
+      .set(data)
+      .where(and(eq(stepEvents.id, id), eq(stepEvents.tenantId, tenantId)))
+      .returning();
+
+    if (!updated || !updated[0]) {
+      throw new NotFoundError(`Step event not found with id: ${id}`);
+    }
+
+    return updated[0];
+  }
+
+  /**
+   * Delete step event for tenant
+   */
+  async deleteForTenant(id: string, tenantId: string): Promise<void> {
+    const deleted = await this.db
+      .delete(stepEvents)
+      .where(and(eq(stepEvents.id, id), eq(stepEvents.tenantId, tenantId)))
+      .returning();
+
+    if (!deleted || !deleted[0]) {
+      throw new NotFoundError(`Step event not found with id: ${id}`);
+    }
+  }
+
+  /**
+   * Get step events count for a tenant
+   */
+  async getCountForTenant(
+    tenantId: string,
+    options: Omit<StepEventSearchOptions, 'limit' | 'offset'> = {}
+  ): Promise<number> {
+    const { 
+      campaignStepInstanceId, 
+      eventType, 
+      contactId,
+      channel,
+      occurredAfter,
+      occurredBefore
+    } = options;
+
+    let whereConditions = [eq(stepEvents.tenantId, tenantId)];
+
+    if (campaignStepInstanceId) {
+      whereConditions.push(eq(stepEvents.campaignStepInstanceId, campaignStepInstanceId));
+    }
+
+    if (eventType) {
+      whereConditions.push(eq(stepEvents.eventType, eventType));
+    }
+
+    if (occurredAfter) {
+      whereConditions.push(gte(stepEvents.occurredAt, occurredAfter));
+    }
+
+    if (occurredBefore) {
+      whereConditions.push(lte(stepEvents.occurredAt, occurredBefore));
+    }
+
+    if (contactId || channel) {
+      // Need to join with step instances for these filters
+      const result = await this.db
+        .select({ count: this.db.count() })
+        .from(stepEvents)
+        .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+        .leftJoin(contactCampaignInstances, eq(campaignStepInstances.contactCampaignInstanceId, contactCampaignInstances.id))
+        .where(and(
+          ...whereConditions,
+          ...(contactId ? [eq(contactCampaignInstances.contactId, contactId)] : []),
+          ...(channel ? [eq(campaignStepInstances.channel, channel)] : [])
+        ));
+      
+      return result[0]?.count || 0;
+    }
+
+    const result = await this.db
+      .select({ count: this.db.count() })
+      .from(stepEvents)
+      .where(and(...whereConditions));
+
+    return result[0]?.count || 0;
+  }
+
+  /**
+   * Bulk create step events
+   */
+  async createBulkForTenant(
+    tenantId: string,
+    data: Omit<NewStepEvent, 'tenantId'>[]
+  ): Promise<StepEvent[]> {
+    const dataWithTenant = data.map((item) => ({ ...item, tenantId }));
+    return await this.createMany(dataWithTenant);
+  }
+
+  /**
+   * Get engagement rate for a channel (opens, clicks, etc.)
+   */
+  async getChannelEngagementRate(
+    tenantId: string,
+    channel: string,
+    options: {
+      occurredAfter?: Date;
+      occurredBefore?: Date;
+      engagementEvents?: string[]; // e.g., ['open', 'click']
+    } = {}
+  ): Promise<{
+    totalSent: number;
+    totalEngagements: number;
+    engagementRate: number;
+  }> {
+    const { occurredAfter, occurredBefore, engagementEvents = ['open', 'click'] } = options;
+
+    let whereConditions = [
+      eq(stepEvents.tenantId, tenantId),
+      eq(campaignStepInstances.channel, channel)
+    ];
+
+    if (occurredAfter) {
+      whereConditions.push(gte(stepEvents.occurredAt, occurredAfter));
+    }
+
+    if (occurredBefore) {
+      whereConditions.push(lte(stepEvents.occurredAt, occurredBefore));
+    }
+
+    // Get total sent count
+    const sentResult = await this.db
+      .select({ count: this.db.count() })
+      .from(campaignStepInstances)
+      .where(
+        and(
+          eq(campaignStepInstances.tenantId, tenantId),
+          eq(campaignStepInstances.channel, channel),
+          eq(campaignStepInstances.status, 'sent')
+        )
+      );
+
+    // Get engagement count
+    const engagementResult = await this.db
+      .select({ count: this.db.count() })
+      .from(stepEvents)
+      .leftJoin(campaignStepInstances, eq(stepEvents.campaignStepInstanceId, campaignStepInstances.id))
+      .where(and(
+        ...whereConditions,
+        inArray(stepEvents.eventType, engagementEvents)
+      ));
+
+    const totalSent = sentResult[0]?.count || 0;
+    const totalEngagements = engagementResult[0]?.count || 0;
+    const engagementRate = totalSent > 0 ? (totalEngagements / totalSent) * 100 : 0;
+
+    return {
+      totalSent,
+      totalEngagements,
+      engagementRate: Number(engagementRate.toFixed(2)),
+    };
+  }
+
+  /**
+   * Check if step event exists for tenant
+   */
+  async existsForTenant(id: string, tenantId: string): Promise<boolean> {
+    const result = await this.db
+      .select({ id: stepEvents.id })
+      .from(stepEvents)
+      .where(and(eq(stepEvents.id, id), eq(stepEvents.tenantId, tenantId)))
+      .limit(1);
+
+    return result.length > 0;
+  }
+}

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -16,6 +16,11 @@ export { LeadProductRepository } from './entities/LeadProductRepository';
 export { UserTenantRepository } from './entities/UserTenantRepository';
 export { SiteEmbeddingDomainRepository } from './entities/SiteEmbeddingDomainRepository';
 export { SiteEmbeddingRepository } from './entities/SiteEmbeddingRepository';
+export { CampaignTemplateRepository } from './entities/CampaignTemplateRepository';
+export { CampaignStepTemplateRepository } from './entities/CampaignStepTemplateRepository';
+export { ContactCampaignInstanceRepository } from './entities/ContactCampaignInstanceRepository';
+export { CampaignStepInstanceRepository } from './entities/CampaignStepInstanceRepository';
+export { StepEventRepository } from './entities/StepEventRepository';
 
 // Transaction repositories
 export { LeadTransactionRepository } from './transactions/LeadTransactionRepository';
@@ -32,6 +37,27 @@ export type {
   EmbeddingSearchOptions,
   EmbeddingWithDomain,
 } from './entities/SiteEmbeddingRepository';
+export type {
+  CampaignTemplateWithDetails,
+  CampaignTemplateSearchOptions,
+} from './entities/CampaignTemplateRepository';
+export type {
+  CampaignStepTemplateWithCampaign,
+  CampaignStepTemplateSearchOptions,
+} from './entities/CampaignStepTemplateRepository';
+export type {
+  ContactCampaignInstanceWithDetails,
+  ContactCampaignInstanceSearchOptions,
+} from './entities/ContactCampaignInstanceRepository';
+export type {
+  CampaignStepInstanceWithDetails,
+  CampaignStepInstanceSearchOptions,
+} from './entities/CampaignStepInstanceRepository';
+export type {
+  StepEventWithDetails,
+  StepEventSearchOptions,
+  EventAnalytics,
+} from './entities/StepEventRepository';
 
 // Export types from transaction repositories
 export type {


### PR DESCRIPTION
Implements the initial PostgreSQL schema and data access layers for the new multi-channel Campaigns module.

This foundational work establishes tables, Drizzle ORM definitions, and repositories for campaign templates, steps, instances, and events, designed to be channel-agnostic and support future expansion.

---
<a href="https://cursor.com/background-agent?bcId=bc-30640809-e41b-4f82-86df-1c9a288d5b4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30640809-e41b-4f82-86df-1c9a288d5b4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

