### PR TITLE
Update agent models to gpt-5-mini and gpt-5-nano

### DIFF
--- a/server/src/modules/ai/contactStrategy.service.ts
+++ b/server/src/modules/ai/contactStrategy.service.ts
@@ -42,7 +42,7 @@ export const generateContactStrategy = async (
 
     // Execute agent analysis
     try {
-      const agent = createContactStrategyAgent({ ...defaultLangChainConfig, model: 'gpt-4.1' });
+      const agent = createContactStrategyAgent({ ...defaultLangChainConfig, model: 'gpt-5-mini' });
       const result = await agent.generateContactStrategy(tenantId, leadId, contactId);
 
       await cacheContactStrategy(result, cacheKey);

--- a/server/src/modules/ai/contactStrategy.service.ts
+++ b/server/src/modules/ai/contactStrategy.service.ts
@@ -42,7 +42,7 @@ export const generateContactStrategy = async (
 
     // Execute agent analysis
     try {
-      const agent = createContactStrategyAgent({ ...defaultLangChainConfig, model: 'gpt-5-mini' });
+      const agent = createContactStrategyAgent({ ...defaultLangChainConfig, model: 'gpt-5' });
       const result = await agent.generateContactStrategy(tenantId, leadId, contactId);
 
       await cacheContactStrategy(result, cacheKey);

--- a/server/src/modules/ai/langchain/config/langchain.config.ts
+++ b/server/src/modules/ai/langchain/config/langchain.config.ts
@@ -9,7 +9,7 @@ export interface LangChainConfig {
 }
 
 export const defaultLangChainConfig: LangChainConfig = {
-  model: 'gpt-4.1-mini',
+  model: 'gpt-5-mini',
   temperature: 0.3,
   maxIterations: 20,
   timeout: 60000, // 60 seconds

--- a/server/src/modules/ai/siteScrape.service.ts
+++ b/server/src/modules/ai/siteScrape.service.ts
@@ -3,7 +3,7 @@ import z from 'zod';
 import { logger } from '@/libs/logger';
 import { promptHelper } from '@/prompts/prompt.helper';
 import firecrawlClient from '@/libs/firecrawl/firecrawl.client';
-import { createChatModel, defaultLangChainConfig } from './langchain/config/langchain.config';
+import { createChatModel } from './langchain/config/langchain.config';
 import { getContentFromMessage } from './langchain/utils/messageUtils';
 
 const smartFilterSiteMapSchema = z.object({

--- a/server/src/modules/ai/siteScrape.service.ts
+++ b/server/src/modules/ai/siteScrape.service.ts
@@ -32,7 +32,7 @@ export const SiteScrapeService = {
 
     try {
       const chatModel = createChatModel({
-        model: defaultLangChainConfig.model,
+        model: 'gpt-5-nano',
       }).withStructuredOutput(z.toJSONSchema(smartFilterSiteMapSchema));
 
       const initialPrompt = promptHelper.getPromptAndInject('smart_filter_site', {


### PR DESCRIPTION
Update AI model configurations to use `gpt-5-mini` as the default for agents and `gpt-5-nano` for the smart URL filter.

---
<a href="https://cursor.com/background-agent?bcId=bc-0be29c21-ab6f-460d-b983-3f9c08413bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0be29c21-ab6f-460d-b983-3f9c08413bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

