### PR TITLE
Generate sitemap xml for public pages

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://example.com/sitemap.xml

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,4 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
-Sitemap: https://example.com/sitemap.xml
+Sitemap: https://dripiq.ai/sitemap.xml

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,4 +1,9 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /dashboard
+Disallow: /profile
+Disallow: /leads
+Disallow: /settings
+Disallow: /demo
+
 Sitemap: https://dripiq.ai/sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- TODO: Replace https://example.com with your production site URL -->
   <url>
-    <loc>https://example.com/</loc>
+    <loc>https://dripiq.ai/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://example.com/privacy-policy</loc>
+    <loc>https://dripiq.ai/privacy-policy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://example.com/login</loc>
+    <loc>https://dripiq.ai/login</loc>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
-    <loc>https://example.com/register</loc>
+    <loc>https://dripiq.ai/register</loc>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
-    <loc>https://example.com/setup-password</loc>
+    <loc>https://dripiq.ai/setup-password</loc>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- TODO: Replace https://example.com with your production site URL -->
+  <url>
+    <loc>https://example.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://example.com/privacy-policy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://example.com/login</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>https://example.com/register</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>https://example.com/setup-password</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
+  </url>
+</urlset>

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -10,19 +10,4 @@
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
-  <url>
-    <loc>https://dripiq.ai/login</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.2</priority>
-  </url>
-  <url>
-    <loc>https://dripiq.ai/register</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.2</priority>
-  </url>
-  <url>
-    <loc>https://dripiq.ai/setup-password</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.2</priority>
-  </url>
 </urlset>


### PR DESCRIPTION
Add `sitemap.xml` to `client/public` and update `robots.txt` to improve SEO by listing public pages.

The sitemap uses `https://example.com` as a placeholder domain, which should be replaced with the production site URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1403d67-6f51-4dd0-86f2-ce3423bf0d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1403d67-6f51-4dd0-86f2-ce3423bf0d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

