### PR TITLE
Update sendgrid token validation for protected links

### DIFF
--- a/server/src/libs/email/sendgridToken.helper.test.ts
+++ b/server/src/libs/email/sendgridToken.helper.test.ts
@@ -1,7 +1,8 @@
 import { SendgridTokenHelper } from './sendgridToken.helper';
 
 describe('SendgridTokenHelper.extractTokenFromUrlOrToken', () => {
-  const sampleToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NTUyOTI0NjIsImlkIjoiNzc1Njk1NyIsInRva2VuX2lkIjoiMjczZWRjNjUtZWQ5OS00ODhlLThmZjQtYzkxYTZkOThmM2Y2IiwidXNlcl9pZCI6IjU0OTkyMTU1In0.XvP6I7tJUsyWcPnl6xM1IXhgHEx6VTB-YFB8sF2YCoM';
+  const sampleToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NTUyOTI0NjIsImlkIjoiNzc1Njk1NyIsInRva2VuX2lkIjoiMjczZWRjNjUtZWQ5OS00ODhlLThmZjQtYzkxYTZkOThmM2Y2IiwidXNlcl9pZCI6IjU0OTkyMTU1In0.XvP6I7tJUsyWcPnl6xM1IXhgHEx6VTB-YFB8sF2YCoM';
 
   it('returns token from a direct SendGrid verify URL', () => {
     const url = `https://app.sendgrid.com/settings/sender_auth/senders/verify?token=${sampleToken}`;

--- a/server/src/libs/email/sendgridToken.helper.test.ts
+++ b/server/src/libs/email/sendgridToken.helper.test.ts
@@ -1,0 +1,58 @@
+import { SendgridTokenHelper } from './sendgridToken.helper';
+
+describe('SendgridTokenHelper.extractTokenFromUrlOrToken', () => {
+  const sampleToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NTUyOTI0NjIsImlkIjoiNzc1Njk1NyIsInRva2VuX2lkIjoiMjczZWRjNjUtZWQ5OS00ODhlLThmZjQtYzkxYTZkOThmM2Y2IiwidXNlcl9pZCI6IjU0OTkyMTU1In0.XvP6I7tJUsyWcPnl6xM1IXhgHEx6VTB-YFB8sF2YCoM';
+
+  it('returns token from a direct SendGrid verify URL', () => {
+    const url = `https://app.sendgrid.com/settings/sender_auth/senders/verify?token=${sampleToken}`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(url)).toBe(sampleToken);
+  });
+
+  it('returns token from a raw token input', () => {
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(sampleToken)).toBe(sampleToken);
+  });
+
+  it('extracts token from Outlook Safe Links wrapped URL', () => {
+    const safeLink = `https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fapp.sendgrid.com%2Fsettings%2Fsender_auth%2Fsenders%2Fverify%3Ftoken%3D${sampleToken}%26utm_campaign%3Dwebsite%26utm_medium%3Demail%26utm_source%3Dsendgrid.com&data=05%7C02%7Cryanhutchison%40filevine.com%7C04b4ff97bf964d4a275408dddaae6002%7C3d1bbaf049274cfc92348281a92fb7ad%7C0%7C0%7C638907164673667652%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=LFjoYezE4avEPndJZ%2BZGFZXDjQFgR19TY3Tlj0EU43s%3D&reserved=0`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(safeLink)).toBe(sampleToken);
+  });
+
+  it("extracts token when wrapped under 'u' param", () => {
+    const inner = `https://app.sendgrid.com/settings/sender_auth/senders/verify?token=${sampleToken}`;
+    const wrapped = `https://redirector.example.com/?u=${encodeURIComponent(inner)}`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(wrapped)).toBe(sampleToken);
+  });
+
+  it("extracts token when wrapped under 'target' param", () => {
+    const inner = `https://app.sendgrid.com/settings/sender_auth/senders/verify?token=${sampleToken}`;
+    const wrapped = `https://redirector.example.com/?target=${encodeURIComponent(inner)}`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(wrapped)).toBe(sampleToken);
+  });
+
+  it("extracts token when wrapped under 'redirect' param", () => {
+    const inner = `https://app.sendgrid.com/settings/sender_auth/senders/verify?token=${sampleToken}`;
+    const wrapped = `https://redirector.example.com/?redirect=${encodeURIComponent(inner)}`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(wrapped)).toBe(sampleToken);
+  });
+
+  it('extracts token when nested URL is double-encoded', () => {
+    const inner = `https://app.sendgrid.com/settings/sender_auth/senders/verify?token=${sampleToken}`;
+    const doubleEncoded = encodeURIComponent(encodeURIComponent(inner));
+    const wrapped = `https://nam11.safelinks.protection.outlook.com/?url=${doubleEncoded}`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(wrapped)).toBe(sampleToken);
+  });
+
+  it('extracts token from proofpoint-like encoded string', () => {
+    const proofpoint = `https-3A__app.sendgrid.com-2Fsettings-2Fsender_auth-2Fsenders-2Fverify-3Ftoken-3D${sampleToken}-26extra-3D1`;
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(proofpoint)).toBe(sampleToken);
+  });
+
+  it('returns null when no token is present', () => {
+    const url = 'https://example.com/some/path?foo=bar';
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(url)).toBeNull();
+  });
+
+  it('returns null for empty/whitespace input', () => {
+    expect(SendgridTokenHelper.extractTokenFromUrlOrToken(' \n')).toBeNull();
+  });
+});

--- a/server/src/libs/email/sendgridToken.helper.ts
+++ b/server/src/libs/email/sendgridToken.helper.ts
@@ -12,7 +12,16 @@ export class SendgridTokenHelper {
         if (directToken) return directToken;
 
         // 2) Nested URL inside common wrapper params (Safe Links, redirectors, etc.)
-        const nestedParamKeys = ['url', 'u', 'target', 'destination', 'redirect', 'redir', 'r', 'd'];
+        const nestedParamKeys = [
+          'url',
+          'u',
+          'target',
+          'destination',
+          'redirect',
+          'redir',
+          'r',
+          'd',
+        ];
         for (const key of nestedParamKeys) {
           const nested = url.searchParams.get(key);
           if (!nested) continue;
@@ -43,7 +52,9 @@ export class SendgridTokenHelper {
           }
 
           if (/https?-3A__/i.test(candidate)) {
-            const scheme = candidate.toLowerCase().startsWith('https-3a__') ? 'https://' : 'http://';
+            const scheme = candidate.toLowerCase().startsWith('https-3a__')
+              ? 'https://'
+              : 'http://';
             const afterScheme = candidate.replace(/^https?-3A__?/i, '');
             const decodedRest = afterScheme.replace(/-([0-9A-F]{2})/gi, (_m, h) =>
               String.fromCharCode(parseInt(h, 16))

--- a/server/src/libs/email/sendgridToken.helper.ts
+++ b/server/src/libs/email/sendgridToken.helper.ts
@@ -1,0 +1,119 @@
+export class SendgridTokenHelper {
+  static extractTokenFromUrlOrToken(input: string): string | null {
+    try {
+      const trimmed = input?.trim();
+      if (!trimmed) return null;
+
+      if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+        const url = new URL(trimmed);
+
+        // 1) Direct token on the URL
+        const directToken = url.searchParams.get('token');
+        if (directToken) return directToken;
+
+        // 2) Nested URL inside common wrapper params (Safe Links, redirectors, etc.)
+        const nestedParamKeys = ['url', 'u', 'target', 'destination', 'redirect', 'redir', 'r', 'd'];
+        for (const key of nestedParamKeys) {
+          const nested = url.searchParams.get(key);
+          if (!nested) continue;
+
+          let candidate = nested;
+          // Try decoding a couple times to unwrap percent-encoding
+          for (let i = 0; i < 2; i++) {
+            try {
+              candidate = decodeURIComponent(candidate);
+            } catch {
+              break;
+            }
+          }
+
+          // If text contains a token query, extract via regex
+          const tokenFromTextMatch =
+            candidate.match(/[?&]token=([^&]+)/) || candidate.match(/token=([^&]+)/);
+          if (tokenFromTextMatch) return tokenFromTextMatch[1]!;
+
+          // Proofpoint-style encodings handling inside nested param
+          const proofpointTokenMatch = candidate.match(/token-3D([^\s]+?)(?:-26|$)/i);
+          if (proofpointTokenMatch) {
+            const encoded = proofpointTokenMatch[1]!;
+            const decoded = encoded.replace(/-([0-9A-F]{2})/gi, (_m, h) =>
+              String.fromCharCode(parseInt(h, 16))
+            );
+            return decoded;
+          }
+
+          if (/https?-3A__/i.test(candidate)) {
+            const scheme = candidate.toLowerCase().startsWith('https-3a__') ? 'https://' : 'http://';
+            const afterScheme = candidate.replace(/^https?-3A__?/i, '');
+            const decodedRest = afterScheme.replace(/-([0-9A-F]{2})/gi, (_m, h) =>
+              String.fromCharCode(parseInt(h, 16))
+            );
+            const rebuilt = scheme + decodedRest.replace(/_+/g, '/');
+            try {
+              const inner = new URL(rebuilt);
+              const innerToken = inner.searchParams.get('token');
+              if (innerToken) return innerToken;
+            } catch {
+              // ignore
+            }
+          }
+
+          // Else, if it looks like a URL, parse and read its search params
+          if (/^https?:\/\//i.test(candidate)) {
+            try {
+              const inner = new URL(candidate);
+              const innerToken = inner.searchParams.get('token');
+              if (innerToken) return innerToken;
+            } catch {
+              // ignore and continue
+            }
+          }
+        }
+
+        // 3) Last resort: regex over the entire original input
+        const tokenMatch = trimmed.match(/[?&]token=([^&]+)/) || trimmed.match(/token=([^&]+)/);
+        if (tokenMatch) return tokenMatch[1]!;
+
+        return null;
+      }
+
+      // Non-URL input handling
+      // a) token=<value> pattern in raw text
+      const rawTokenMatch = trimmed.match(/(?:\b|[?&])token=([^&\s]+)/i);
+      if (rawTokenMatch) return rawTokenMatch[1]!;
+
+      // b) Proofpoint token-3D<value> pattern
+      const ppTokenMatch = trimmed.match(/token-3D([^\s]+?)(?:-26|$)/i);
+      if (ppTokenMatch) {
+        const encoded = ppTokenMatch[1]!;
+        const decoded = encoded.replace(/-([0-9A-F]{2})/gi, (_m, h) =>
+          String.fromCharCode(parseInt(h, 16))
+        );
+        return decoded;
+      }
+
+      // c) Proofpoint full URL-like string e.g., https-3A__...
+      if (/https?-3A__/i.test(trimmed)) {
+        const scheme = trimmed.toLowerCase().startsWith('https-3a__') ? 'https://' : 'http://';
+        const afterScheme = trimmed.replace(/^https?-3A__?/i, '');
+        const decodedRest = afterScheme.replace(/-([0-9A-F]{2})/gi, (_m, h) =>
+          String.fromCharCode(parseInt(h, 16))
+        );
+        const rebuilt = scheme + decodedRest.replace(/_+/g, '/');
+        try {
+          const inner = new URL(rebuilt);
+          const innerToken = inner.searchParams.get('token');
+          if (innerToken) return innerToken;
+        } catch {
+          // ignore
+        }
+      }
+
+      // If not a URL and no patterns matched, assume the input is the token itself
+      return trimmed;
+    } catch {
+      const tokenMatch = input.match(/token=([^&]+)/);
+      return tokenMatch ? tokenMatch[1]! : null;
+    }
+  }
+}

--- a/server/src/modules/email/senderIdentity.service.ts
+++ b/server/src/modules/email/senderIdentity.service.ts
@@ -1,6 +1,7 @@
 import { emailSenderIdentityRepository } from '@/repositories';
 import { EmailSenderIdentity, NewEmailSenderIdentity } from '@/db/schema';
 import { sendgridClient } from '@/libs/email/sendgrid.client';
+import { SendgridTokenHelper } from '@/libs/email/sendgridToken.helper';
 
 function normalizeDomainFromEmail(email: string): string {
   const parts = email.split('@');
@@ -8,75 +9,7 @@ function normalizeDomainFromEmail(email: string): string {
   return parts[1]!.toLowerCase();
 }
 
-function extractTokenFromUrlOrToken(input: string): string | null {
-  try {
-    const trimmed = input?.trim();
-    if (!trimmed) return null;
-
-    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-      const url = new URL(trimmed);
-
-      // 1) Direct token on the URL
-      const directToken = url.searchParams.get('token');
-      if (directToken) return directToken;
-
-      // 2) Nested URL inside common wrapper params (Safe Links, redirectors, etc.)
-      const nestedParamKeys = ['url', 'u', 'target', 'destination', 'redirect', 'redir', 'r', 'd'];
-      for (const key of nestedParamKeys) {
-        const nested = url.searchParams.get(key);
-        if (!nested) continue;
-
-        let candidate = nested;
-        // Try decoding a couple times to unwrap percent-encoding
-        for (let i = 0; i < 2; i++) {
-          try {
-            candidate = decodeURIComponent(candidate);
-          } catch {
-            break;
-          }
-        }
-
-        // Handle Proofpoint-like encodings (e.g., https-3A__...) to reconstruct a URL
-        if (!/^https?:\/\//i.test(candidate) && /https?-3A/i.test(candidate)) {
-          candidate = candidate
-            .replace(/https?-3A__/i, (m) =>
-              m.toLowerCase().startsWith('https') ? 'https://' : 'http://'
-            )
-            .replace(/-2F/g, '/')
-            .replace(/_+/g, '/');
-        }
-
-        // If text contains a token query, extract via regex
-        const tokenFromTextMatch =
-          candidate.match(/[?&]token=([^&]+)/) || candidate.match(/token=([^&]+)/);
-        if (tokenFromTextMatch) return tokenFromTextMatch[1]!;
-
-        // Else, if it looks like a URL, parse and read its search params
-        if (/^https?:\/\//i.test(candidate)) {
-          try {
-            const inner = new URL(candidate);
-            const innerToken = inner.searchParams.get('token');
-            if (innerToken) return innerToken;
-          } catch {
-            // ignore and continue
-          }
-        }
-      }
-
-      // 3) Last resort: regex over the entire original input
-      const tokenMatch = trimmed.match(/[?&]token=([^&]+)/) || trimmed.match(/token=([^&]+)/);
-      if (tokenMatch) return tokenMatch[1]!;
-
-      return null;
-    }
-
-    // If not a URL, assume the input is the token itself
-    return trimmed;
-  } catch {
-    const tokenMatch = input.match(/token=([^&]+)/);
-    return tokenMatch ? tokenMatch[1]! : null;
-  }
-}
+// Extractor moved to SendgridTokenHelper
 
 function extractSendgridIdFromBody(body: unknown): string | undefined {
   if (body && typeof body === 'object' && 'id' in body) {
@@ -233,7 +166,7 @@ export class SenderIdentityService {
     if (!identity)
       throw new Error('No email sender identity found for the specified user and tenant');
 
-    const token = extractTokenFromUrlOrToken(sendgridValidationUrl);
+    const token = SendgridTokenHelper.extractTokenFromUrlOrToken(sendgridValidationUrl);
     if (!token) {
       const error: any = new Error('Invalid SendGrid validation URL provided');
       error.statusCode = 422;


### PR DESCRIPTION
Enhance token extraction to correctly parse SendGrid verification tokens from wrapped URLs, such as Outlook Safe Links, improving the reliability of sender identity verification.

---
<a href="https://cursor.com/background-agent?bcId=bc-f37e2caf-f3e1-4a88-8695-2d74b12c1857">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f37e2caf-f3e1-4a88-8695-2d74b12c1857">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

