### PR TITLE
Run lint and test jobs in parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+stages:
+  - verify
+
+default:
+  image: node:20
+  variables:
+    CI: "true"
+  cache:
+    key:
+      files:
+        - client/package-lock.json
+        - server/package-lock.json
+    paths:
+      - client/node_modules/
+      - server/node_modules/
+    policy: pull-push
+
+frontend:lint:
+  stage: verify
+  script:
+    - npm ci --prefix client
+    - npm run --prefix client lint
+
+frontend:test:
+  stage: verify
+  script:
+    - npm ci --prefix client
+    - npm run --prefix client test
+
+backend:lint:
+  stage: verify
+  script:
+    - npm ci --prefix server
+    - npm run --prefix server lint
+
+backend:test:
+  stage: verify
+  script:
+    - npm ci --prefix server
+    - mkdir -p server/config && [ -f server/config/.env.test ] || touch server/config/.env.test
+    - npm run --prefix server test


### PR DESCRIPTION
Add GitLab CI pipeline to run parallel frontend/backend lint and test jobs, failing the pipeline if any job fails while allowing others to complete.

---
<a href="https://cursor.com/background-agent?bcId=bc-059664da-4ad5-4fe8-8ef8-5f05c7da9fe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-059664da-4ad5-4fe8-8ef8-5f05c7da9fe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

