### PR TITLE
Integrate server logs with highlight io

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,6 @@
+# Highlight.io Configuration
+HIGHLIGHT_PROJECT_ID=your_highlight_project_id_here
+SERVICE_NAME=dripiq-backend
+SERVICE_VERSION=1.0.0
+
+# ... existing environment variables ...

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,8 @@
         "@fastify/swagger": "^9.5.1",
         "@fastify/swagger-ui": "^5.2.2",
         "@fastify/type-provider-typebox": "^5.1.0",
+        "@highlight-run/node": "^3.12.21",
+        "@highlight-run/pino": "^0.1.6",
         "@langchain/core": "^0.3.66",
         "@langchain/openai": "^0.6.2",
         "@mendable/firecrawl-js": "^1.29.3",
@@ -2081,6 +2083,26 @@
         "@sinclair/typebox": ">=0.26 <=0.34"
       }
     },
+    "node_modules/@highlight-run/node": {
+      "version": "3.12.21",
+      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-3.12.21.tgz",
+      "integrity": "sha512-HM2WNzIXHOh2GILOclUe6LrqcHg0GoqZ32HwxZTrCjULXVUzWR+S1g0UzE0VSjXmIB4SO++3K2z4nwubfo5DGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/instrumentation": ">=5.0.0",
+        "highlight.run": "9.19.1",
+        "require-in-the-middle": "^7.4.0"
+      }
+    },
+    "node_modules/@highlight-run/pino": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@highlight-run/pino/-/pino-0.1.6.tgz",
+      "integrity": "sha512-7+XuTDS9+MJZKouRHnu7dNpJ0fd5SMMu39Cq8sKbuDCFAEFY7kk72JZvmfprbb4KVLsNWbz3hU1yN/knwTL+oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@highlight-run/node": " *"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2913,6 +2935,30 @@
         "@langchain/core": ">=0.2.21 <0.4.0"
       }
     },
+    "node_modules/@launchdarkly/js-client-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-client-sdk/-/js-client-sdk-0.6.0.tgz",
+      "integrity": "sha512-9aBgpGKXxaiPudNuQ9MoS8wFSIR1h0P2EFDP2veNJG7tBuxzDKfH3hzjW01C4/WyWN6bk7P7XKwisxw775klBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/js-client-sdk-common": "1.13.0"
+      }
+    },
+    "node_modules/@launchdarkly/js-client-sdk-common": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-client-sdk-common/-/js-client-sdk-common-1.13.0.tgz",
+      "integrity": "sha512-3u3nWLKfu7ADbrBlbYq1rDROXG1WcRGRGhHFyAjtDPCCh783sPIb1frC1n4tj6b64bustVrZvLR9dGrQlp6tJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/js-sdk-common": "2.17.0"
+      }
+    },
+    "node_modules/@launchdarkly/js-sdk-common": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.17.0.tgz",
+      "integrity": "sha512-HYQNc4xbE58hBOO1yZsqE+BHOC36AYrHPZ5hwvlHoZRSsaoYCPM+Q/n+O+N3JhWXTqGsu6SwUzqUzTyxg8prGg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -3234,6 +3280,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.14.0.tgz",
+      "integrity": "sha512-Po/Hry5bAeunRDq0yAQueKookW3glpP+qjjvvyOfm6dI2KG5/Y6Bgg3ahyWd7B0u2E+Wf9xRk2rtdda7ySgK1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -7837,6 +7895,16 @@
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
     },
+    "node_modules/highlight.run": {
+      "version": "9.19.1",
+      "resolved": "https://registry.npmjs.org/highlight.run/-/highlight.run-9.19.1.tgz",
+      "integrity": "sha512-RdoSvvxtkz6JKksap3DLA6kr7nJbtN3bn63aoVVQCL057MJ/Q1ZqTqsrewQqJ8zZ/d3cgufAlX8CkIziRgC1VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/js-client-sdk": "^0.6.0",
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7983,7 +8051,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,8 @@
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.2",
     "@fastify/type-provider-typebox": "^5.1.0",
+    "@highlight-run/node": "^3.12.21",
+    "@highlight-run/pino": "^0.1.6",
     "@langchain/core": "^0.3.66",
     "@langchain/openai": "^0.6.2",
     "@mendable/firecrawl-js": "^1.29.3",

--- a/server/src/libs/logger.ts
+++ b/server/src/libs/logger.ts
@@ -1,5 +1,13 @@
 import pino, { Logger, LoggerOptions } from 'pino';
 
+// highlight.io configuration
+const highlightConfig = {
+  projectID: process.env.HIGHLIGHT_PROJECT_ID || '', // You'll need to set this in your environment
+  serviceName: process.env.SERVICE_NAME || 'dripiq-backend',
+  serviceVersion: process.env.SERVICE_VERSION || 'latest',
+  environment: process.env.NODE_ENV || 'development',
+};
+
 export const loggerOptions: LoggerOptions = {
   level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
   formatters: {
@@ -8,52 +16,72 @@ export const loggerOptions: LoggerOptions = {
     },
   },
   timestamp: pino.stdTimeFunctions.isoTime,
-  // Remove serializers to prevent nested structures - we'll handle flattening manually
-  serializers: {},
+  // Use highlight.io transport in production, pretty printing in development
+  transport:
+    process.env.NODE_ENV === 'production'
+      ? {
+          target: '@highlight-run/pino',
+          options: highlightConfig,
+        }
+      : {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'SYS:standard',
+            ignore: 'pid,hostname',
+          },
+        },
+  // Configure request/response serializers for structured logging
+  serializers: {
+    req: (request: any) => ({
+      method: request.method,
+      url: request.url,
+      host: request.headers?.host,
+      userAgent: request.headers?.['user-agent'],
+      remoteAddress: request.ip || request.socket?.remoteAddress,
+      remotePort: request.socket?.remotePort,
+      reqId: request.id,
+    }),
+    res: (response: any) => ({
+      statusCode: response.statusCode,
+      contentLength: response.headers?.['content-length'],
+    }),
+    err: pino.stdSerializers.err,
+  },
 };
 
 export const baseLogger = pino(loggerOptions);
 
-const flattenObject = (obj: any, prefix: string = ''): any => {
-  const flattened: any = {};
-
-  for (const [key, value] of Object.entries(obj)) {
-    const newKey = prefix ? `${prefix}_${key}` : key;
-
-    if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
-      // Recursively flatten nested objects
-      Object.assign(flattened, flattenObject(value, newKey));
-    } else {
-      flattened[newKey] = value;
+// Initialize highlight.io SDK if in Node.js environment
+if (typeof process.env.NEXT_RUNTIME === 'undefined' || process.env.NEXT_RUNTIME === 'nodejs') {
+  if (process.env.NODE_ENV === 'production' && highlightConfig.projectID) {
+    try {
+      const { H } = require('@highlight-run/node');
+      H.init(highlightConfig);
+    } catch (error) {
+      console.warn('Failed to initialize highlight.io:', error);
     }
   }
+}
 
-  return flattened;
-};
-
+// Create a logger interface that maintains compatibility with your existing code
 const createLoggerWithOverride = (logger: Logger) => {
   return {
     warn: (message: string, arg?: any, ...args: any[]) => {
-      const flattenedArg = arg ? flattenObject(arg) : {};
-      const flattenedArgs = args.length > 0 ? flattenObject({ extraData: args }) : {};
-      const logObj = { ...flattenedArg, ...flattenedArgs, msg: message };
-      logger.warn(logObj);
+      const logObj = arg ? { payload: arg, ...args } : { ...args };
+      logger.warn(logObj, message);
     },
     info: (message: string, arg?: any) => {
-      const flattenedArg = arg ? flattenObject(arg) : {};
-      const logObj = { ...flattenedArg, msg: message };
-      logger.info(logObj);
+      const logObj = arg ? { payload: arg } : {};
+      logger.info(logObj, message);
     },
     error: (message: string, arg?: any, ...args: any[]) => {
-      const flattenedArg = arg ? flattenObject(arg) : {};
-      const flattenedArgs = args.length > 0 ? flattenObject({ extraData: args }) : {};
-      const logObj = { ...flattenedArg, ...flattenedArgs, msg: message };
-      logger.error(logObj);
+      const logObj = arg ? { payload: arg, ...args } : { ...args };
+      logger.error(logObj, message);
     },
     debug: (message: string, arg?: any) => {
-      const flattenedArg = arg ? flattenObject(arg) : {};
-      const logObj = { ...flattenedArg, msg: message };
-      logger.debug(logObj);
+      const logObj = arg ? { payload: arg } : {};
+      logger.debug(logObj, message);
     },
   };
 };

--- a/server/src/plugins/logging.plugin.ts
+++ b/server/src/plugins/logging.plugin.ts
@@ -5,30 +5,28 @@ import fp from 'fastify-plugin';
 const requestStartTimes = new Map<string, number>();
 
 const loggingPlugin = async (fastify: FastifyInstance) => {
-  // Log incoming requests with flattened properties
+  // Log incoming requests with structured data
   fastify.addHook('onRequest', async (request: FastifyRequest, _reply: FastifyReply) => {
     // Store request start time for response time calculation
     requestStartTimes.set(request.id, Date.now());
 
     const logData = {
       reqId: request.id,
-      method: request.method,
-      url: request.url,
-      host: request.headers.host,
-      userAgent: request.headers['user-agent'],
-      remoteAddress: request.ip,
-      remotePort: (request.socket as any)?.remotePort,
-      // Flatten query params to top level with prefix
-      ...(Object.keys(request.query as object).length > 0 &&
-        Object.fromEntries(
-          Object.entries(request.query as object).map(([key, value]) => [`query_${key}`, value])
-        )),
+      req: {
+        method: request.method,
+        url: request.url,
+        host: request.headers.host,
+        userAgent: request.headers['user-agent'],
+        remoteAddress: request.ip,
+        remotePort: (request.socket as any)?.remotePort,
+        queryParams: Object.keys(request.query as object).length > 0 ? request.query : undefined,
+      },
     };
 
-    fastify.log.info('incoming request', logData);
+    fastify.log.info(logData, 'incoming request');
   });
 
-  // Log outgoing responses with flattened properties
+  // Log outgoing responses with structured data
   fastify.addHook('onResponse', async (request: FastifyRequest, reply: FastifyReply) => {
     const startTime = requestStartTimes.get(request.id);
     const responseTime = startTime ? Date.now() - startTime : undefined;
@@ -38,18 +36,22 @@ const loggingPlugin = async (fastify: FastifyInstance) => {
 
     const logData = {
       reqId: request.id,
-      method: request.method,
-      url: request.url,
-      statusCode: reply.statusCode,
-      responseTime,
-      contentLength: reply.getHeader('content-length'),
+      req: {
+        method: request.method,
+        url: request.url,
+      },
+      res: {
+        statusCode: reply.statusCode,
+        responseTime,
+        contentLength: reply.getHeader('content-length'),
+      },
     };
 
     const level = reply.statusCode >= 400 ? 'warn' : 'info';
-    fastify.log[level]('request completed', logData);
+    fastify.log[level](logData, 'request completed');
   });
 
-  // Log errors with flattened properties
+  // Log errors with structured data
   fastify.addHook(
     'onError',
     async (request: FastifyRequest, _reply: FastifyReply, error: Error) => {
@@ -58,14 +60,18 @@ const loggingPlugin = async (fastify: FastifyInstance) => {
 
       const logData = {
         reqId: request.id,
-        method: request.method,
-        url: request.url,
-        errorName: error.name,
-        errorMessage: error.message,
-        stack: error.stack,
+        req: {
+          method: request.method,
+          url: request.url,
+        },
+        err: {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        },
       };
 
-      fastify.log.error('request error', logData);
+      fastify.log.error(logData, 'request error');
     }
   );
 };


### PR DESCRIPTION
Integrate highlight.io's official Pino transport to properly structure server logs.

This PR replaces manual log flattening with highlight.io's recommended `@highlight-run/pino` transport, which automatically formats logs for OpenTelemetry ingestion, resolving the issue of nested JSON strings in the `message` field.

---
<a href="https://cursor.com/background-agent?bcId=bc-17b9261a-f172-4e1c-9d01-cd5bfda163f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17b9261a-f172-4e1c-9d01-cd5bfda163f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

