### PR TITLE
Update campaign plan execution on button click

### DIFF
--- a/server/src/constants/queues.ts
+++ b/server/src/constants/queues.ts
@@ -1,6 +1,7 @@
 export const QUEUE_NAMES = {
   lead_analysis: 'lead_analysis',
   campaign_creation: 'campaign_creation',
+  campaign_execution: 'campaign_execution',
 } as const;
 
 export const JOB_NAMES = {
@@ -9,5 +10,8 @@ export const JOB_NAMES = {
   },
   campaign_creation: {
     create: 'campaign_creation.create',
+  },
+  campaign_execution: {
+    initialize: 'campaign_execution.initialize',
   },
 } as const;

--- a/server/src/modules/messages/campaignExecution.publisher.service.ts
+++ b/server/src/modules/messages/campaignExecution.publisher.service.ts
@@ -1,0 +1,74 @@
+import { getQueue } from '@/libs/bullmq';
+import { QUEUE_NAMES, JOB_NAMES } from '@/constants/queues';
+import { logger } from '@/libs/logger';
+import type { CampaignPlanOutput } from '@/modules/ai/schemas/contactCampaignStrategySchema';
+
+export type CampaignExecutionJobPayload = {
+  tenantId: string;
+  campaignId: string;
+  contactId: string;
+  plan: CampaignPlanOutput;
+  userId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export class CampaignExecutionPublisher {
+  private static queue = getQueue(QUEUE_NAMES.campaign_execution);
+
+  static async publish(payload: CampaignExecutionJobPayload) {
+    try {
+      logger.info('Publishing campaign execution job', {
+        tenantId: payload.tenantId,
+        campaignId: payload.campaignId,
+        contactId: payload.contactId,
+      });
+
+      return this.queue.add(JOB_NAMES.campaign_execution.initialize, payload, {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 2000 },
+        removeOnComplete: 10,
+        removeOnFail: 5,
+        delay: Math.random() * 2000, // Random delay 0-2 seconds
+      });
+    } catch (error) {
+      logger.error('Failed to publish campaign execution job', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        payload: {
+          tenantId: payload.tenantId,
+          campaignId: payload.campaignId,
+          contactId: payload.contactId,
+        },
+      });
+      throw error;
+    }
+  }
+
+  static async publishBatch(payloads: CampaignExecutionJobPayload[]) {
+    try {
+      logger.info('Publishing batch of campaign execution jobs', {
+        count: payloads.length,
+        tenantId: payloads[0]?.tenantId,
+      });
+
+      const jobs = payloads.map((payload, index) => ({
+        name: JOB_NAMES.campaign_execution.initialize,
+        data: payload,
+        opts: {
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 2000 },
+          removeOnComplete: 10,
+          removeOnFail: 5,
+          delay: index * 500, // 500ms between each job
+        },
+      }));
+
+      return this.queue.addBulk(jobs);
+    } catch (error) {
+      logger.error('Failed to publish batch of campaign execution jobs', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        count: payloads.length,
+      });
+      throw error;
+    }
+  }
+}

--- a/server/src/modules/messages/index.ts
+++ b/server/src/modules/messages/index.ts
@@ -1,10 +1,12 @@
 // Publishers
 export { LeadAnalysisPublisher } from './leadAnalysis.publisher.service';
 export { CampaignCreationPublisher } from './campaignCreation.publisher.service';
+export { CampaignExecutionPublisher } from './campaignExecution.publisher.service';
 
 // Types
 export type { LeadAnalysisJobPayload } from './leadAnalysis.publisher.service';
 export type { CampaignCreationJobPayload } from './campaignCreation.publisher.service';
+export type { CampaignExecutionJobPayload } from './campaignExecution.publisher.service';
 
 // Worker result types (workers are now in @/workers/)
 export type { LeadAnalysisJobResult } from '@/workers/lead-analysis/lead-analysis.worker';


### PR DESCRIPTION
Integrate campaign execution and queue publishing when a contact is marked as manually reviewed.

This enables asynchronous processing of campaign plans for contacts that are manually reviewed, ensuring relevant campaigns are initiated without blocking the UI or the immediate contact status update.

---
<a href="https://cursor.com/background-agent?bcId=bc-e19e4b78-4c26-4c34-ba61-6f189dd8e746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e19e4b78-4c26-4c34-ba61-6f189dd8e746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

