### PR TITLE
Create timeout worker for synthetic events - gpt

### DIFF
--- a/server/src/repositories/entities/MessageEventRepository.ts
+++ b/server/src/repositories/entities/MessageEventRepository.ts
@@ -148,4 +148,27 @@ export class MessageEventRepository extends TenantAwareRepository<
       .limit(1);
     return results[0];
   }
+
+  /**
+   * Find a message event by messageId and event type for a tenant
+   * Used by timeout worker to detect real engagement before emitting synthetic events
+   */
+  async findByMessageAndTypeForTenant(
+    tenantId: string,
+    messageId: string,
+    eventType: string
+  ): Promise<MessageEvent | undefined> {
+    const results = await this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.tenantId, tenantId),
+          eq(this.table.messageId, messageId),
+          eq(this.table.type, eventType)
+        )
+      )
+      .limit(1);
+    return results[0];
+  }
 }

--- a/server/src/types/timeout.types.ts
+++ b/server/src/types/timeout.types.ts
@@ -1,4 +1,5 @@
 export interface TimeoutJobParams {
+  tenantId: string;
   campaignId: string;
   nodeId: string;
   messageId: string;

--- a/server/src/workers/index.ts
+++ b/server/src/workers/index.ts
@@ -2,6 +2,7 @@
 export { default as leadAnalysisWorker } from './lead-analysis/lead-analysis.worker';
 export { default as campaignCreationWorker } from './campaign-creation/campaign-creation.worker';
 export { default as campaignExecutionWorker } from './campaign-execution/campaign-execution.worker';
+export { default as timeoutWorker } from './timeout/timeout.worker';
 
 // Export worker runner functions
 export { startWorkers, gracefulShutdown } from './worker.run';

--- a/server/src/workers/timeout/timeout.worker.ts
+++ b/server/src/workers/timeout/timeout.worker.ts
@@ -1,0 +1,128 @@
+import type { Job } from 'bullmq';
+import { getWorker } from '@/libs/bullmq';
+import { logger } from '@/libs/logger';
+import { QUEUE_NAMES } from '@/constants/queues';
+import { messageEventRepository, contactCampaignRepository } from '@/repositories';
+import { campaignPlanExecutionService } from '@/modules/campaign/campaignPlanExecution.service';
+import type { TimeoutJobParams } from '@/types/timeout.types';
+
+export interface TimeoutJobResult {
+  success?: boolean;
+  skipped?: boolean;
+  reason?: string;
+  syntheticEventId?: string;
+}
+
+export async function processTimeout(job: Job<TimeoutJobParams>): Promise<TimeoutJobResult> {
+  const { tenantId, campaignId, nodeId, messageId, eventType, scheduledAt } = job.data;
+
+  logger.info('[TimeoutWorker] Processing timeout job', {
+    jobId: job.id,
+    tenantId,
+    campaignId,
+    nodeId,
+    messageId,
+    eventType,
+    scheduledAt,
+  });
+
+  try {
+    // Check if real event already happened (e.g., open for no_open, click for no_click)
+    const realEventType = eventType.replace('no_', '');
+    const realEventExists = await messageEventRepository.findByMessageAndTypeForTenant(
+      tenantId,
+      messageId,
+      realEventType
+    );
+
+    if (realEventExists) {
+      logger.info('[TimeoutWorker] Real event found, skipping synthetic event', {
+        jobId: job.id,
+        tenantId,
+        messageId,
+        eventType,
+        realEventId: realEventExists.id,
+      });
+      return { skipped: true, reason: 'real_event_exists' };
+    }
+
+    // Generate synthetic event
+    const now = new Date();
+    const syntheticEvent = await messageEventRepository.createForTenant(tenantId, {
+      messageId,
+      type: eventType,
+      eventAt: now,
+      data: {
+        synthetic: true,
+        triggeredBy: 'timeout',
+        originalJobId: job.id,
+        scheduledAt,
+        actualFiredAt: now.toISOString(),
+      },
+    } as any);
+
+    logger.info('[TimeoutWorker] Created synthetic event', {
+      jobId: job.id,
+      tenantId,
+      eventId: syntheticEvent.id,
+      eventType,
+      messageId,
+    });
+
+    // Load campaign plan to process transition
+    const campaign = await contactCampaignRepository.findByIdForTenant(campaignId, tenantId);
+    if (!campaign || !campaign.planJson) {
+      const reason = `Campaign or plan not found for campaignId=${campaignId}`;
+      logger.error('[TimeoutWorker] Cannot process transition - missing campaign/plan', {
+        jobId: job.id,
+        tenantId,
+        campaignId,
+      });
+      throw new Error(reason);
+    }
+
+    await campaignPlanExecutionService.processTransition({
+      tenantId,
+      campaignId,
+      eventType,
+      currentNodeId: nodeId,
+      plan: campaign.planJson as any,
+      eventRef: syntheticEvent.id,
+    });
+
+    logger.info('[TimeoutWorker] Timeout processed and transition triggered', {
+      jobId: job.id,
+      tenantId,
+      campaignId,
+      nodeId,
+      eventType,
+      syntheticEventId: syntheticEvent.id,
+    });
+
+    return { success: true, syntheticEventId: syntheticEvent.id };
+  } catch (error) {
+    logger.error('[TimeoutWorker] Timeout processing failed', {
+      jobId: job.id,
+      tenantId,
+      campaignId,
+      nodeId,
+      messageId,
+      eventType,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    throw error;
+  }
+}
+
+const timeoutWorker = getWorker<TimeoutJobParams, TimeoutJobResult>(
+  QUEUE_NAMES.campaign_execution,
+  async (job) => {
+    if (job.name === 'timeout') {
+      return await processTimeout(job);
+    }
+    throw new Error(`Unknown job type for TimeoutWorker: ${job.name}`);
+  }
+);
+
+export default timeoutWorker;

--- a/server/src/workers/worker.run.ts
+++ b/server/src/workers/worker.run.ts
@@ -13,10 +13,20 @@
 
 import { logger } from '@/libs/logger';
 import { createRedisConnection } from '@/libs/bullmq';
-import { leadAnalysisWorker, campaignCreationWorker, campaignExecutionWorker } from './index';
+import {
+  leadAnalysisWorker,
+  campaignCreationWorker,
+  campaignExecutionWorker,
+  timeoutWorker,
+} from './index';
 
 // Track active workers for graceful shutdown
-const activeWorkers = [leadAnalysisWorker, campaignCreationWorker, campaignExecutionWorker];
+const activeWorkers = [
+  leadAnalysisWorker,
+  campaignCreationWorker,
+  campaignExecutionWorker,
+  timeoutWorker,
+];
 
 async function startWorkers() {
   try {
@@ -27,7 +37,7 @@ async function startWorkers() {
 
     // Log worker startup
     logger.info('🚀 Starting BullMQ workers...', {
-      workers: ['lead-analysis', 'campaign-creation', 'campaign-execution'],
+      workers: ['lead-analysis', 'campaign-creation', 'campaign-execution', 'timeout'],
       timestamp: new Date().toISOString(),
     });
 
@@ -37,6 +47,7 @@ async function startWorkers() {
       leadAnalysisWorker: leadAnalysisWorker.isRunning(),
       campaignCreationWorker: campaignCreationWorker.isRunning(),
       campaignExecutionWorker: campaignExecutionWorker.isRunning(),
+      timeoutWorker: timeoutWorker.isRunning(),
     });
 
     // Keep the process alive
@@ -58,7 +69,7 @@ async function gracefulShutdown(signal: string) {
     // Close all workers
     await Promise.all(
       activeWorkers.map(async (worker, index) => {
-        const workerNames = ['lead-analysis', 'campaign-creation', 'campaign-execution'];
+        const workerNames = ['lead-analysis', 'campaign-creation', 'campaign-execution', 'timeout'];
         logger.info(`🛑 Closing ${workerNames[index]} worker...`);
         await worker.close();
         logger.info(`✅ ${workerNames[index]} worker closed`);


### PR DESCRIPTION
Introduce a timeout worker to generate synthetic `no_open` and `no_click` events, enabling campaigns to progress when recipients don't engage.

---
<a href="https://cursor.com/background-agent?bcId=bc-adaf2b06-f6df-46fb-8215-7c55576c7bbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-adaf2b06-f6df-46fb-8215-7c55576c7bbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

