### PR TITLE
Handle email invocation timeout error

### DIFF
--- a/server/src/workers/campaign-execution/email-execution.service.ts
+++ b/server/src/workers/campaign-execution/email-execution.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@/repositories';
 import { unsubscribeService } from '@/modules/unsubscribe';
 import { getQueue } from '@/libs/bullmq';
+import { JOB_NAMES } from '@/constants/queues';
 import { parseIsoDuration } from '@/modules/campaign/scheduleUtils';
 import { db } from '@/db';
 import {
@@ -394,7 +395,7 @@ export class EmailExecutionService {
       try {
         // Enqueue BullMQ job
         const timeoutQueue = getQueue('campaign_execution');
-        await timeoutQueue.add('timeout', params, {
+        await timeoutQueue.add(JOB_NAMES.campaign_execution.timeout, params, {
           delay: delayMs,
           jobId,
           ...TIMEOUT_JOB_OPTIONS,


### PR DESCRIPTION
Correctly name timeout jobs as `campaign_execution.timeout` to resolve 'Unexpected job name: timeout' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-97aa4bf9-a3cd-4b42-b1c4-4aa45d91c652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97aa4bf9-a3cd-4b42-b1c4-4aa45d91c652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

