### PR TITLE
Fix duplicate workflow definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
       - name: Check
         run: npm run check
 
+  landing-test:
     name: Landing Test
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,26 +162,6 @@ jobs:
       - name: Check
         run: npm run check
 
-  landing-test:
-    name: Landing Test
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: landing
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: landing/package-lock.json
-      - name: Install dependencies
-        run: npm ci
-      - name: Test
-        run: npm run test
-
   landing-build:
     name: Landing Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add missing `landing-test` job key to resolve duplicate key errors in the CI workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bdd6a84-28ce-497d-abd7-1331fa53dda8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bdd6a84-28ce-497d-abd7-1331fa53dda8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

