### PR TITLE
Process campaign plan emails

### DIFF
--- a/server/src/workers/campaign-execution/__tests__/email-execution.service.test.ts
+++ b/server/src/workers/campaign-execution/__tests__/email-execution.service.test.ts
@@ -1,0 +1,511 @@
+import { EmailExecutionService } from '../email-execution.service';
+import {
+  outboundMessageRepository,
+  emailSenderIdentityRepository,
+  scheduledActionRepository,
+} from '@/repositories';
+import { unsubscribeService } from '@/modules/unsubscribe';
+import { sendgridClient } from '@/libs/email/sendgrid.client';
+import { parseIsoDuration } from '@/modules/campaign/scheduleUtils';
+import type { CampaignPlanOutput } from '@/modules/ai/schemas/contactCampaignStrategySchema';
+
+// Mock dependencies
+jest.mock('@/repositories', () => ({
+  outboundMessageRepository: {
+    createForTenant: jest.fn(),
+    findByDedupeKeyForTenant: jest.fn(),
+  },
+  emailSenderIdentityRepository: {
+    findByLeadIdForTenant: jest.fn(),
+  },
+  scheduledActionRepository: {
+    createForTenant: jest.fn(),
+  },
+}));
+
+jest.mock('@/modules/unsubscribe', () => ({
+  unsubscribeService: {
+    isChannelUnsubscribed: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/email/sendgrid.client', () => ({
+  sendgridClient: {
+    send: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/bullmq', () => ({
+  getQueue: jest.fn(() => ({
+    add: jest.fn(),
+  })),
+}));
+
+jest.mock('@/modules/campaign/scheduleUtils', () => ({
+  parseIsoDuration: jest.fn(),
+}));
+
+jest.mock('@/db', () => ({
+  db: {
+    transaction: jest.fn((callback) => callback({})),
+  },
+}));
+
+jest.mock('@/libs/calendar/calendarUrlWrapper', () => ({
+  calendarUrlWrapper: {
+    wrapUrl: jest.fn((url) => url),
+  },
+}));
+
+jest.mock('@/constants/timeout-jobs', () => ({
+  DEFAULT_NO_OPEN_TIMEOUT: 'PT72H',
+  DEFAULT_NO_CLICK_TIMEOUT: 'PT24H',
+  TIMEOUT_JOB_OPTIONS: {},
+}));
+
+jest.mock('@/constants/queues', () => ({
+  JOB_NAMES: {
+    campaign_execution: {
+      timeout: 'timeout',
+    },
+  },
+}));
+
+describe('EmailExecutionService', () => {
+  let service: EmailExecutionService;
+  const mockTenantId = 'tenant-123';
+  const mockCampaignId = 'campaign-456';
+  const mockNodeId = 'node-789';
+  const mockMessageId = 'message-abc';
+
+  const mockOutboundMessageRepo = outboundMessageRepository as jest.Mocked<
+    typeof outboundMessageRepository
+  >;
+  const mockEmailSenderIdentityRepo = emailSenderIdentityRepository as jest.Mocked<
+    typeof emailSenderIdentityRepository
+  >;
+  const mockScheduledActionRepo = scheduledActionRepository as jest.Mocked<
+    typeof scheduledActionRepository
+  >;
+  const mockUnsubscribeService = unsubscribeService as jest.Mocked<typeof unsubscribeService>;
+  const mockSendgridClient = sendgridClient as jest.Mocked<typeof sendgridClient>;
+  const mockParseIsoDuration = parseIsoDuration as jest.MockedFunction<typeof parseIsoDuration>;
+
+  beforeEach(() => {
+    service = new EmailExecutionService(mockTenantId);
+    jest.clearAllMocks();
+  });
+
+  describe('scheduleTimeoutJobs', () => {
+    const createMockPlan = (nodeTransitions: any[] = []): CampaignPlanOutput => ({
+      version: '1.0',
+      timezone: 'UTC',
+      defaults: {
+        timers: {
+          no_open_after: 'PT72H',
+          no_click_after: 'PT24H',
+        },
+      },
+      startNodeId: mockNodeId,
+      nodes: [
+        {
+          id: mockNodeId,
+          channel: 'email' as const,
+          action: 'send' as const,
+          subject: 'Test Subject',
+          body: 'Test Body',
+          schedule: { delay: 'PT0S' },
+          transitions: nodeTransitions,
+        },
+      ],
+    });
+
+    it('should schedule timeout jobs based on specific node transitions', async () => {
+      // Setup: Plan with specific transition timing
+      const plan = createMockPlan([
+        { on: 'no_open', to: 'next-node', after: 'PT10M' }, // 10 minutes
+        { on: 'no_click', to: 'other-node', after: 'PT2H' }, // 2 hours
+      ]);
+
+      // Mock parseIsoDuration to return specific values
+      mockParseIsoDuration
+        .mockReturnValueOnce(10 * 60 * 1000) // PT10M = 10 minutes
+        .mockReturnValueOnce(2 * 60 * 60 * 1000); // PT2H = 2 hours
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify parseIsoDuration was called with specific transition timing
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT10M');
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT2H');
+
+      // Verify scheduled actions were created with correct timing
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+
+      // Verify no_open timeout job
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledWith(mockTenantId, {
+        campaignId: mockCampaignId,
+        actionType: 'timeout',
+        scheduledAt: expect.any(Date),
+        payload: {
+          nodeId: mockNodeId,
+          messageId: mockMessageId,
+          eventType: 'no_open',
+        },
+        bullmqJobId: expect.any(String),
+      });
+
+      // Verify no_click timeout job
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledWith(mockTenantId, {
+        campaignId: mockCampaignId,
+        actionType: 'timeout',
+        scheduledAt: expect.any(Date),
+        payload: {
+          nodeId: mockNodeId,
+          messageId: mockMessageId,
+          eventType: 'no_click',
+        },
+        bullmqJobId: expect.any(String),
+      });
+    });
+
+    it('should fall back to default timeout values when no specific transitions', async () => {
+      // Setup: Plan with no timeout transitions
+      const plan = createMockPlan([
+        { on: 'opened', to: 'next-node', within: 'PT24H' }, // Not a timeout transition
+      ]);
+
+      // Mock parseIsoDuration for default values
+      mockParseIsoDuration
+        .mockReturnValueOnce(72 * 60 * 60 * 1000) // PT72H = 72 hours (no_open default)
+        .mockReturnValueOnce(24 * 60 * 60 * 1000); // PT24H = 24 hours (no_click default)
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify parseIsoDuration was called with default values
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT72H'); // Default no_open
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT24H'); // Default no_click
+
+      // Verify both default timeout jobs were scheduled
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+
+    it('should schedule specific transitions and fall back for missing ones', async () => {
+      // Setup: Plan with only no_open transition, missing no_click
+      const plan = createMockPlan([
+        { on: 'no_open', to: 'next-node', after: 'PT5M' }, // 5 minutes
+        { on: 'opened', to: 'other-node', within: 'PT1H' }, // Not a timeout
+      ]);
+
+      // Mock parseIsoDuration
+      mockParseIsoDuration
+        .mockReturnValueOnce(5 * 60 * 1000) // PT5M = 5 minutes (specific)
+        .mockReturnValueOnce(24 * 60 * 60 * 1000); // PT24H = 24 hours (default for no_click)
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify specific transition timing was used for no_open
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT5M');
+      // Verify default was used for missing no_click
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT24H');
+
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip non-timeout event types in transitions', async () => {
+      // Setup: Plan with non-timeout transitions that have 'after'
+      const plan = createMockPlan([
+        { on: 'delivered', to: 'next-node', after: 'PT0S' }, // Not a timeout event
+        { on: 'opened', to: 'other-node', after: 'PT1H' }, // Not a timeout event
+      ]);
+
+      // Mock parseIsoDuration for defaults only
+      mockParseIsoDuration
+        .mockReturnValueOnce(72 * 60 * 60 * 1000) // Default no_open
+        .mockReturnValueOnce(24 * 60 * 60 * 1000); // Default no_click
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify only default values were used (non-timeout events ignored)
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT72H');
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT24H');
+      expect(mockParseIsoDuration).not.toHaveBeenCalledWith('PT0S');
+      expect(mockParseIsoDuration).not.toHaveBeenCalledWith('PT1H');
+
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle multiple transitions of the same timeout type', async () => {
+      // Setup: Plan with multiple no_open transitions
+      const plan = createMockPlan([
+        { on: 'no_open', to: 'node-1', after: 'PT10M' }, // First no_open
+        { on: 'no_open', to: 'node-2', after: 'PT30M' }, // Second no_open (should be skipped)
+        { on: 'no_click', to: 'node-3', after: 'PT1H' },
+      ]);
+
+      mockParseIsoDuration
+        .mockReturnValueOnce(10 * 60 * 1000) // PT10M (first no_open)
+        .mockReturnValueOnce(60 * 60 * 1000); // PT1H (no_click)
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify only first no_open transition was used
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT10M');
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT1H');
+      expect(mockParseIsoDuration).not.toHaveBeenCalledWith('PT30M'); // Second no_open skipped
+
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle nodes with no transitions', async () => {
+      // Setup: Plan with no transitions at all
+      const plan = createMockPlan([]); // Empty transitions
+
+      mockParseIsoDuration
+        .mockReturnValueOnce(72 * 60 * 60 * 1000) // Default no_open
+        .mockReturnValueOnce(24 * 60 * 60 * 1000); // Default no_click
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify default values were used
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT72H');
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT24H');
+
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle missing node in plan', async () => {
+      // Setup: Plan without the target node
+      const plan: CampaignPlanOutput = {
+        version: '1.0',
+        timezone: 'UTC',
+        defaults: {
+          timers: {
+            no_open_after: 'PT72H',
+            no_click_after: 'PT24H',
+          },
+        },
+        startNodeId: 'different-node',
+        nodes: [
+          {
+            id: 'different-node',
+            channel: 'email' as const,
+            action: 'send' as const,
+            subject: 'Test',
+            body: 'Test',
+            schedule: { delay: 'PT0S' },
+            transitions: [],
+          },
+        ],
+      };
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify no scheduling occurred
+      expect(mockScheduledActionRepo.createForTenant).not.toHaveBeenCalled();
+      expect(mockParseIsoDuration).not.toHaveBeenCalled();
+    });
+
+    it('should handle transitions with within constraint (not after)', async () => {
+      // Setup: Plan with only 'within' transitions (no 'after')
+      const plan = createMockPlan([
+        { on: 'opened', to: 'next-node', within: 'PT24H' },
+        { on: 'clicked', to: 'other-node', within: 'PT72H' },
+      ]);
+
+      mockParseIsoDuration
+        .mockReturnValueOnce(72 * 60 * 60 * 1000) // Default no_open
+        .mockReturnValueOnce(24 * 60 * 60 * 1000); // Default no_click
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(mockCampaignId, mockNodeId, plan, mockMessageId);
+
+      // Verify only defaults were used (no 'after' transitions found)
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT72H');
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT24H');
+
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use plan defaults when no defaults.timers is provided', async () => {
+      // Setup: Plan without defaults.timers
+      const planWithoutDefaults: CampaignPlanOutput = {
+        version: '1.0',
+        timezone: 'UTC',
+        defaults: {
+          timers: {},
+        },
+        startNodeId: mockNodeId,
+        nodes: [
+          {
+            id: mockNodeId,
+            channel: 'email' as const,
+            action: 'send' as const,
+            subject: 'Test',
+            body: 'Test',
+            schedule: { delay: 'PT0S' },
+            transitions: [],
+          },
+        ],
+      };
+
+      // Mock constants from timeout-jobs.ts
+      mockParseIsoDuration
+        .mockReturnValueOnce(72 * 60 * 60 * 1000) // DEFAULT_NO_OPEN_TIMEOUT = PT72H
+        .mockReturnValueOnce(24 * 60 * 60 * 1000); // DEFAULT_NO_CLICK_TIMEOUT = PT24H
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJobs(
+        mockCampaignId,
+        mockNodeId,
+        planWithoutDefaults,
+        mockMessageId
+      );
+
+      // Verify hardcoded constants were used
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT72H');
+      expect(mockParseIsoDuration).toHaveBeenCalledWith('PT24H');
+
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('scheduleTimeoutJob', () => {
+    it('should skip jobs with negative delay', async () => {
+      const pastTime = new Date(Date.now() - 10000); // 10 seconds ago
+      const params = {
+        campaignId: mockCampaignId,
+        nodeId: mockNodeId,
+        messageId: mockMessageId,
+        eventType: 'no_open' as const,
+        scheduledAt: pastTime,
+      };
+
+      // Execute
+      await (service as any).scheduleTimeoutJob(params);
+
+      // Verify no database record or BullMQ job was created
+      expect(mockScheduledActionRepo.createForTenant).not.toHaveBeenCalled();
+    });
+
+    it('should schedule job with positive delay', async () => {
+      const futureTime = new Date(Date.now() + 60000); // 1 minute from now
+      const params = {
+        campaignId: mockCampaignId,
+        nodeId: mockNodeId,
+        messageId: mockMessageId,
+        eventType: 'no_open' as const,
+        scheduledAt: futureTime,
+      };
+
+      mockScheduledActionRepo.createForTenant.mockResolvedValue({
+        id: 'scheduled-action-123',
+      } as any);
+
+      // Execute
+      await (service as any).scheduleTimeoutJob(params);
+
+      // Verify database record was created
+      expect(mockScheduledActionRepo.createForTenant).toHaveBeenCalledWith(mockTenantId, {
+        campaignId: mockCampaignId,
+        actionType: 'timeout',
+        scheduledAt: futureTime,
+        payload: {
+          nodeId: mockNodeId,
+          messageId: mockMessageId,
+          eventType: 'no_open',
+        },
+        bullmqJobId: expect.any(String),
+      });
+    });
+  });
+
+  describe('generateTimeoutJobId', () => {
+    it('should generate unique job IDs for different parameters', () => {
+      const params1 = {
+        campaignId: 'campaign-1',
+        nodeId: 'node-1',
+        messageId: 'message-1',
+        eventType: 'no_open' as const,
+        scheduledAt: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const params2 = {
+        campaignId: 'campaign-2',
+        nodeId: 'node-1',
+        messageId: 'message-1',
+        eventType: 'no_open' as const,
+        scheduledAt: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const jobId1 = (service as any).generateTimeoutJobId(params1);
+      const jobId2 = (service as any).generateTimeoutJobId(params2);
+
+      expect(jobId1).not.toBe(jobId2);
+      expect(jobId1).toMatch(/^timeout_campaign-1_node-1_no_open_message-1_[a-f0-9]{8}$/);
+      expect(jobId2).toMatch(/^timeout_campaign-2_node-1_no_open_message-1_[a-f0-9]{8}$/);
+    });
+
+    it('should generate same job ID for identical parameters', () => {
+      const params = {
+        campaignId: 'campaign-1',
+        nodeId: 'node-1',
+        messageId: 'message-1',
+        eventType: 'no_open' as const,
+        scheduledAt: new Date('2024-01-01T00:00:00Z'),
+      };
+
+      const jobId1 = (service as any).generateTimeoutJobId(params);
+      const jobId2 = (service as any).generateTimeoutJobId(params);
+
+      expect(jobId1).toBe(jobId2);
+    });
+  });
+});

--- a/server/src/workers/campaign-execution/__tests__/timeout-scheduling.integration.test.ts
+++ b/server/src/workers/campaign-execution/__tests__/timeout-scheduling.integration.test.ts
@@ -1,0 +1,234 @@
+import { EmailExecutionService } from '../email-execution.service';
+import { parseIsoDuration } from '@/modules/campaign/scheduleUtils';
+import type { CampaignPlanOutput } from '@/modules/ai/schemas/contactCampaignStrategySchema';
+
+// Mock only the external dependencies, not the core logic we're testing
+jest.mock('@/repositories', () => ({
+  outboundMessageRepository: {
+    createForTenant: jest.fn(),
+    findByDedupeKeyForTenant: jest.fn(),
+  },
+  emailSenderIdentityRepository: {
+    findByLeadIdForTenant: jest.fn(),
+  },
+  scheduledActionRepository: {
+    createForTenant: jest.fn(),
+  },
+}));
+
+jest.mock('@/modules/unsubscribe', () => ({
+  unsubscribeService: {
+    isChannelUnsubscribed: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/email/sendgrid.client', () => ({
+  sendgridClient: {
+    send: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/bullmq', () => ({
+  getQueue: jest.fn(() => ({
+    add: jest.fn(),
+  })),
+}));
+
+jest.mock('@/db', () => ({
+  db: {
+    transaction: jest.fn((callback) => callback({})),
+  },
+}));
+
+jest.mock('@/libs/calendar/calendarUrlWrapper', () => ({
+  calendarUrlWrapper: {
+    wrapUrl: jest.fn((url) => url),
+  },
+}));
+
+jest.mock('@/constants/timeout-jobs', () => ({
+  DEFAULT_NO_OPEN_TIMEOUT: 'PT72H',
+  DEFAULT_NO_CLICK_TIMEOUT: 'PT24H',
+  TIMEOUT_JOB_OPTIONS: {},
+}));
+
+jest.mock('@/constants/queues', () => ({
+  JOB_NAMES: {
+    campaign_execution: {
+      timeout: 'timeout',
+    },
+  },
+}));
+
+// Don't mock parseIsoDuration - use the real implementation
+jest.unmock('@/modules/campaign/scheduleUtils');
+
+describe('Timeout Scheduling Integration', () => {
+  let service: EmailExecutionService;
+  const mockTenantId = 'tenant-123';
+
+  beforeEach(() => {
+    service = new EmailExecutionService(mockTenantId);
+    jest.clearAllMocks();
+  });
+
+  it('should correctly schedule timeouts for the user provided campaign plan', async () => {
+    // This is the actual campaign plan from the user's query
+    const userCampaignPlan: CampaignPlanOutput = {
+      version: '1.0',
+      timezone: 'America/Los_Angeles',
+      quietHours: { end: '08:00', start: '18:00' },
+      defaults: { timers: { no_open_after: 'PT10M', no_click_after: 'PT24H' } },
+      startNodeId: 'wuu9ajq553bu6w9d9l7ymx8t',
+      nodes: [
+        {
+          id: 'wuu9ajq553bu6w9d9l7ymx8t',
+          body: 'Hi Tim,\n\nI know Valiente Mott handles high value, complex injury cases...',
+          action: 'send' as const,
+          channel: 'email' as const,
+          subject: 'Tim, faster depo prep for Valiente Mott',
+          schedule: { delay: 'PT0S' },
+          transitions: [
+            { on: 'opened' as const, to: 'c0x44yz2omlxpvoef3hjid4m', within: 'PT48H' },
+            { on: 'no_open' as const, to: 'a0vt35r56dwzk68mm29ubhbk', after: 'PT10M' }, // 10 minutes!
+            { on: 'delivered' as const, to: 'b1i0j4dlb8d9eleilyq8371l', after: 'PT0S' },
+          ],
+        },
+        {
+          id: 'c0x44yz2omlxpvoef3hjid4m',
+          action: 'wait' as const,
+          channel: 'email' as const,
+          transitions: [
+            { on: 'clicked' as const, to: 'tmg2aj05iem9i3sl9oups7lz', within: 'PT10M' },
+            { on: 'no_click' as const, to: 'a0vt35r56dwzk68mm29ubhbk', after: 'PT24H' }, // 24 hours
+          ],
+        },
+        {
+          id: 'a0vt35r56dwzk68mm29ubhbk',
+          action: 'send' as const,
+          channel: 'email' as const,
+          subject: 'Quick follow up on depositions',
+          body: 'Tim,\n\nFollowing up in case my last note got buried...',
+          schedule: { delay: 'PT0S' },
+          transitions: [],
+        },
+        {
+          id: 'b1i0j4dlb8d9eleilyq8371l',
+          action: 'stop' as const,
+          channel: 'email' as const,
+          transitions: [],
+        },
+        {
+          id: 'tmg2aj05iem9i3sl9oups7lz',
+          action: 'send' as const,
+          channel: 'email' as const,
+          subject: 'Speed up expert prep and med chron work',
+          body: 'Tim,\n\nTwo things firms like yours tell me help most...',
+          schedule: { delay: 'PT0S' },
+          transitions: [],
+        },
+      ],
+    };
+
+    const { scheduledActionRepository } = require('@/repositories');
+    scheduledActionRepository.createForTenant.mockResolvedValue({ id: 'action-123' });
+
+    // Test first node - should use specific PT10M timing for no_open
+    const mockCampaignId = 'campaign-123';
+    const mockMessageId = 'message-abc';
+    const firstNodeId = 'wuu9ajq553bu6w9d9l7ymx8t';
+
+    const startTime = Date.now();
+    await (service as any).scheduleTimeoutJobs(
+      mockCampaignId,
+      firstNodeId,
+      userCampaignPlan,
+      mockMessageId
+    );
+
+    // Verify that scheduling was called
+    expect(scheduledActionRepository.createForTenant).toHaveBeenCalled();
+
+    // Extract the scheduled times from the mock calls
+    const scheduledCalls = scheduledActionRepository.createForTenant.mock.calls;
+    
+    // Find the no_open timeout call
+    const noOpenCall = scheduledCalls.find(
+      (call: any) => call[1].payload.eventType === 'no_open'
+    );
+    
+    expect(noOpenCall).toBeDefined();
+    
+    // Verify the no_open timeout is scheduled for 10 minutes (600,000 ms) from now
+    const scheduledTime = new Date(noOpenCall[1].scheduledAt).getTime();
+    const expectedTime = startTime + parseIsoDuration('PT10M'); // 10 minutes
+    const tolerance = 5000; // 5 second tolerance for test execution time
+    
+    expect(scheduledTime).toBeGreaterThanOrEqual(expectedTime - tolerance);
+    expect(scheduledTime).toBeLessThanOrEqual(expectedTime + tolerance);
+
+    // Test wait node - should use specific PT24H timing for no_click  
+    jest.clearAllMocks();
+    scheduledActionRepository.createForTenant.mockResolvedValue({ id: 'action-456' });
+    
+    const waitNodeId = 'c0x44yz2omlxpvoef3hjid4m';
+    const startTime2 = Date.now();
+    
+    await (service as any).scheduleTimeoutJobs(
+      mockCampaignId,
+      waitNodeId,
+      userCampaignPlan,
+      mockMessageId
+    );
+
+    const scheduledCalls2 = scheduledActionRepository.createForTenant.mock.calls;
+    
+    // Find the no_click timeout call
+    const noClickCall = scheduledCalls2.find(
+      (call: any) => call[1].payload.eventType === 'no_click'
+    );
+    
+    expect(noClickCall).toBeDefined();
+    
+    // Verify the no_click timeout is scheduled for 24 hours from now
+    const scheduledTime2 = new Date(noClickCall[1].scheduledAt).getTime();
+    const expectedTime2 = startTime2 + parseIsoDuration('PT24H'); // 24 hours
+    
+    expect(scheduledTime2).toBeGreaterThanOrEqual(expectedTime2 - tolerance);
+    expect(scheduledTime2).toBeLessThanOrEqual(expectedTime2 + tolerance);
+  });
+
+  it('should validate specific ISO duration parsing for user campaign timing', () => {
+    // Test the exact durations from the user's campaign plan
+    expect(parseIsoDuration('PT10M')).toBe(10 * 60 * 1000); // 10 minutes = 600,000 ms
+    expect(parseIsoDuration('PT24H')).toBe(24 * 60 * 60 * 1000); // 24 hours = 86,400,000 ms
+    expect(parseIsoDuration('PT48H')).toBe(48 * 60 * 60 * 1000); // 48 hours = 172,800,000 ms
+    expect(parseIsoDuration('PT0S')).toBe(0); // Immediate
+  });
+
+  it('should handle the specific transition structure from user campaign', () => {
+    const transitions: any[] = [
+      { on: 'opened', to: 'next-node', within: 'PT48H' },
+      { on: 'no_open', to: 'other-node', after: 'PT10M' },
+      { on: 'delivered', to: 'stop-node', after: 'PT0S' },
+    ];
+
+    // Verify our logic correctly identifies timeout transitions
+    const timeoutTransitions = transitions.filter(
+      (t: any) => 'after' in t && (t.on === 'no_open' || t.on === 'no_click')
+    );
+
+    expect(timeoutTransitions).toHaveLength(1);
+    expect(timeoutTransitions[0]?.on).toBe('no_open');
+    expect(timeoutTransitions[0]?.after).toBe('PT10M');
+  });
+});

--- a/server/src/workers/campaign-execution/__tests__/timeout-scheduling.integration.test.ts
+++ b/server/src/workers/campaign-execution/__tests__/timeout-scheduling.integration.test.ts
@@ -160,29 +160,27 @@ describe('Timeout Scheduling Integration', () => {
 
     // Extract the scheduled times from the mock calls
     const scheduledCalls = scheduledActionRepository.createForTenant.mock.calls;
-    
+
     // Find the no_open timeout call
-    const noOpenCall = scheduledCalls.find(
-      (call: any) => call[1].payload.eventType === 'no_open'
-    );
-    
+    const noOpenCall = scheduledCalls.find((call: any) => call[1].payload.eventType === 'no_open');
+
     expect(noOpenCall).toBeDefined();
-    
+
     // Verify the no_open timeout is scheduled for 10 minutes (600,000 ms) from now
     const scheduledTime = new Date(noOpenCall[1].scheduledAt).getTime();
     const expectedTime = startTime + parseIsoDuration('PT10M'); // 10 minutes
     const tolerance = 5000; // 5 second tolerance for test execution time
-    
+
     expect(scheduledTime).toBeGreaterThanOrEqual(expectedTime - tolerance);
     expect(scheduledTime).toBeLessThanOrEqual(expectedTime + tolerance);
 
-    // Test wait node - should use specific PT24H timing for no_click  
+    // Test wait node - should use specific PT24H timing for no_click
     jest.clearAllMocks();
     scheduledActionRepository.createForTenant.mockResolvedValue({ id: 'action-456' });
-    
+
     const waitNodeId = 'c0x44yz2omlxpvoef3hjid4m';
     const startTime2 = Date.now();
-    
+
     await (service as any).scheduleTimeoutJobs(
       mockCampaignId,
       waitNodeId,
@@ -191,18 +189,18 @@ describe('Timeout Scheduling Integration', () => {
     );
 
     const scheduledCalls2 = scheduledActionRepository.createForTenant.mock.calls;
-    
+
     // Find the no_click timeout call
     const noClickCall = scheduledCalls2.find(
       (call: any) => call[1].payload.eventType === 'no_click'
     );
-    
+
     expect(noClickCall).toBeDefined();
-    
+
     // Verify the no_click timeout is scheduled for 24 hours from now
     const scheduledTime2 = new Date(noClickCall[1].scheduledAt).getTime();
     const expectedTime2 = startTime2 + parseIsoDuration('PT24H'); // 24 hours
-    
+
     expect(scheduledTime2).toBeGreaterThanOrEqual(expectedTime2 - tolerance);
     expect(scheduledTime2).toBeLessThanOrEqual(expectedTime2 + tolerance);
   });

--- a/server/src/workers/campaign-execution/email-execution.service.ts
+++ b/server/src/workers/campaign-execution/email-execution.service.ts
@@ -27,7 +27,7 @@ import { JOB_NAMES } from '@/constants/queues';
 
 // Timeout event types that should trigger timeout jobs
 const TIMEOUT_EVENT_TYPES = ['no_open', 'no_click'] as const;
-type TimeoutEventType = typeof TIMEOUT_EVENT_TYPES[number];
+type TimeoutEventType = (typeof TIMEOUT_EVENT_TYPES)[number];
 
 export interface EmailExecutionParams {
   tenantId: string;
@@ -441,15 +441,18 @@ export class EmailExecutionService {
             scheduledAt: new Date(Date.now() + afterDelayMs).toISOString(),
           });
         } catch (error) {
-          logger.error('[EmailExecutionService] Failed to parse transition timing, skipping timeout job', {
-            tenantId: this.tenantId,
-            campaignId,
-            nodeId,
-            messageId,
-            eventType: eventType as TimeoutEventType,
-            after: transition.after,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
+          logger.error(
+            '[EmailExecutionService] Failed to parse transition timing, skipping timeout job',
+            {
+              tenantId: this.tenantId,
+              campaignId,
+              nodeId,
+              messageId,
+              eventType: eventType as TimeoutEventType,
+              after: transition.after,
+              error: error instanceof Error ? error.message : 'Unknown error',
+            }
+          );
           // Continue to next transition instead of failing completely
         }
       }


### PR DESCRIPTION
Fix campaign timeout scheduling to respect specific transition timings in the campaign plan instead of always using default values.

The `scheduleTimeoutJobs` method incorrectly applied global default `no_open` and `no_click` timeouts (e.g., `PT24H`) to all jobs, ignoring the `after` duration specified in individual node transitions within the campaign plan. This led to all timeout jobs being scheduled with the wrong delay. The fix now correctly reads and applies the `after` duration from the node's transitions for `no_open` and `no_click` events, falling back to defaults only when no specific transition timing is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-081fa3bd-7da0-443a-8443-95adf68b13f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-081fa3bd-7da0-443a-8443-95adf68b13f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

