### PR TITLE
Schedule daily render deployment

### DIFF
--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -1,0 +1,27 @@
+name: Daily Deploy to Render
+
+on:
+  schedule:
+    # Runs every day at 2:00 AM Central Time (7:00 AM UTC)
+    - cron: '0 7 * * *'
+  workflow_dispatch: # Allow manual triggering for testing
+
+jobs:
+  deploy:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Trigger Render Deploy Hook
+        run: |
+          echo "Triggering Render deployment..."
+          response=$(curl -s -w "HTTP_STATUS:%{http_code}" -X POST "${{ secrets.RENDER_DEPLOY_URL }}")
+          http_status=$(echo "$response" | grep -o "HTTP_STATUS:[0-9]*" | cut -d: -f2)
+          
+          if [[ "$http_status" -ge 200 && "$http_status" -lt 300 ]]; then
+            echo "✅ Deploy hook triggered successfully (HTTP $http_status)"
+          else
+            echo "❌ Deploy hook failed (HTTP $http_status)"
+            echo "Response: $response"
+            exit 1
+          fi


### PR DESCRIPTION
Add a GitHub Actions workflow to trigger daily Render.com deployments at 2 AM Central Time.

---
<a href="https://cursor.com/background-agent?bcId=bc-b39d15ec-830d-4192-9946-e96552f70b61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b39d15ec-830d-4192-9946-e96552f70b61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

