### PR TITLE
Investigate and fix email formatting loss

### DIFF
--- a/server/src/utils/__tests__/emailFormatting.integration.test.ts
+++ b/server/src/utils/__tests__/emailFormatting.integration.test.ts
@@ -1,0 +1,57 @@
+import { formatEmailBodyForHtml } from '../emailFormatting';
+
+describe('Email Formatting Integration Test', () => {
+  it('should fix the exact formatting issue from the user report', () => {
+    // This is the exact email body from the user's campaign plan
+    const originalEmail = `Hi Ryan,
+
+Valiente Mott handles high stakes, trial ready injury cases. Depositions often make or break those files, but they also create a lot of admin work and slow down expert prep.
+
+I work with Filevine on Depositions by Filevine. It gives same day rough drafts, AI summaries, and transcript audio and video synced directly into the case file, so your team spends less time chasing vendors and more time on strategy.
+
+Would you be open to a brief call to see how this could fit with your intake and trial workflow?`;
+
+    // Before the fix, this would have been sent as raw HTML without line breaks
+    // Now it should be properly formatted with <br> tags
+    const result = formatEmailBodyForHtml(originalEmail);
+
+    // Verify the formatting is preserved with proper HTML breaks
+    expect(result).toContain('Hi Ryan,<br><br>Valiente Mott handles');
+    expect(result).toContain('expert prep.<br><br>I work with Filevine');
+    expect(result).toContain('time on strategy.<br><br>Would you be open');
+
+    // Verify no raw newlines remain (which would be ignored in HTML)
+    expect(result).not.toContain('\n');
+
+    // Verify the content is still there (nothing lost in translation)
+    expect(result).toContain('Valiente Mott handles high stakes');
+    expect(result).toContain('Depositions by Filevine');
+    expect(result).toContain('intake and trial workflow');
+
+    // Log the before and after for documentation
+    console.log('BEFORE (problematic):', JSON.stringify(originalEmail));
+    console.log('AFTER (fixed):', JSON.stringify(result));
+  });
+
+  it('should demonstrate the difference in email rendering behavior', () => {
+    const testEmail = 'Line 1\n\nLine 2\n\nLine 3';
+
+    // Without formatting (old behavior) - newlines would be ignored in HTML
+    const unformattedHtml = testEmail; // This is what was happening before
+
+    // With formatting (new behavior) - newlines become proper HTML breaks
+    const formattedHtml = formatEmailBodyForHtml(testEmail);
+
+    expect(unformattedHtml).toBe('Line 1\n\nLine 2\n\nLine 3');
+    expect(formattedHtml).toBe('Line 1<br><br>Line 2<br><br>Line 3');
+
+    // When rendered in an email client:
+    // - unformattedHtml would display as: "Line 1 Line 2 Line 3" (no breaks)
+    // - formattedHtml would display as:
+    //   Line 1
+    //
+    //   Line 2
+    //
+    //   Line 3
+  });
+});

--- a/server/src/utils/__tests__/emailFormatting.test.ts
+++ b/server/src/utils/__tests__/emailFormatting.test.ts
@@ -1,0 +1,107 @@
+import { convertTextToHtml, isHtmlFormatted, formatEmailBodyForHtml } from '../emailFormatting';
+
+describe('emailFormatting', () => {
+  describe('convertTextToHtml', () => {
+    it('should convert newlines to HTML breaks', () => {
+      const input = 'Hi Ryan,\n\nValiente Mott handles high stakes cases.';
+      const expected = 'Hi Ryan,<br><br>Valiente Mott handles high stakes cases.';
+      expect(convertTextToHtml(input)).toBe(expected);
+    });
+
+    it('should handle Windows line endings', () => {
+      const input = 'Line 1\r\nLine 2\r\nLine 3';
+      const expected = 'Line 1<br>Line 2<br>Line 3';
+      expect(convertTextToHtml(input)).toBe(expected);
+    });
+
+    it('should escape HTML special characters', () => {
+      const input = 'Price: <$100 & "free" shipping\'s great>';
+      const expected = 'Price: &lt;$100 &amp; &quot;free&quot; shipping&#39;s great&gt;';
+      expect(convertTextToHtml(input)).toBe(expected);
+    });
+
+    it('should handle empty string', () => {
+      expect(convertTextToHtml('')).toBe('');
+    });
+
+    it('should handle null/undefined', () => {
+      expect(convertTextToHtml(null as any)).toBe('');
+      expect(convertTextToHtml(undefined as any)).toBe('');
+    });
+
+    it('should convert the original email example correctly', () => {
+      const input = `Hi Ryan,
+
+Valiente Mott handles high stakes, trial ready injury cases. Depositions often make or break those files, but they also create a lot of admin work and slow down expert prep.
+
+I work with Filevine on Depositions by Filevine. It gives same day rough drafts, AI summaries, and transcript audio and video synced directly into the case file, so your team spends less time chasing vendors and more time on strategy.
+
+Would you be open to a brief call to see how this could fit with your intake and trial workflow?`;
+
+      const result = convertTextToHtml(input);
+
+      // Should contain HTML breaks
+      expect(result).toContain('<br><br>');
+      expect(result).toContain('Hi Ryan,<br><br>Valiente Mott');
+
+      // Should not contain raw newlines
+      expect(result).not.toContain('\n');
+    });
+  });
+
+  describe('isHtmlFormatted', () => {
+    it('should detect HTML tags', () => {
+      expect(isHtmlFormatted('<p>Hello</p>')).toBe(true);
+      expect(isHtmlFormatted('Hello <br> World')).toBe(true);
+      expect(isHtmlFormatted('<div>Content</div>')).toBe(true);
+    });
+
+    it('should return false for plain text', () => {
+      expect(isHtmlFormatted('Hello\nWorld')).toBe(false);
+      expect(isHtmlFormatted('Plain text email')).toBe(false);
+      expect(isHtmlFormatted('')).toBe(false);
+    });
+
+    it('should handle null/undefined', () => {
+      expect(isHtmlFormatted(null as any)).toBe(false);
+      expect(isHtmlFormatted(undefined as any)).toBe(false);
+    });
+  });
+
+  describe('formatEmailBodyForHtml', () => {
+    it('should convert plain text to HTML', () => {
+      const input = 'Line 1\nLine 2';
+      const expected = 'Line 1<br>Line 2';
+      expect(formatEmailBodyForHtml(input)).toBe(expected);
+    });
+
+    it('should leave HTML content unchanged', () => {
+      const input = '<p>Already <br> formatted</p>';
+      expect(formatEmailBodyForHtml(input)).toBe(input);
+    });
+
+    it('should handle empty string', () => {
+      expect(formatEmailBodyForHtml('')).toBe('');
+    });
+
+    it('should handle the campaign email example', () => {
+      const input = `Hi Ryan,
+
+Valiente Mott handles high stakes, trial ready injury cases. Depositions often make or break those files, but they also create a lot of admin work and slow down expert prep.
+
+I work with Filevine on Depositions by Filevine. It gives same day rough drafts, AI summaries, and transcript audio and video synced directly into the case file, so your team spends less time chasing vendors and more time on strategy.
+
+Would you be open to a brief call to see how this could fit with your intake and trial workflow?`;
+
+      const result = formatEmailBodyForHtml(input);
+
+      // Should be properly formatted for HTML
+      expect(result).toContain('Hi Ryan,<br><br>Valiente Mott');
+      expect(result).toContain('admin work and slow down expert prep.<br><br>I work with Filevine');
+      expect(result).toContain('time on strategy.<br><br>Would you be open');
+
+      // Should not contain raw newlines
+      expect(result).not.toContain('\n');
+    });
+  });
+});

--- a/server/src/utils/emailFormatting.ts
+++ b/server/src/utils/emailFormatting.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility functions for email formatting
+ */
+
+/**
+ * Converts plain text to HTML-formatted text for email display.
+ * This preserves line breaks and paragraphs while keeping the text safe for HTML.
+ *
+ * @param text - Plain text with newlines
+ * @returns HTML-formatted text with proper line breaks
+ */
+export function convertTextToHtml(text: string): string {
+  if (!text) {
+    return '';
+  }
+
+  // Escape HTML special characters first
+  const escapedText = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  // Convert newlines to HTML breaks
+  // Handle both Windows (\r\n) and Unix (\n) line endings
+  return escapedText.replace(/\r\n/g, '<br>').replace(/\n/g, '<br>');
+}
+
+/**
+ * Checks if a string is already HTML formatted
+ *
+ * @param text - Text to check
+ * @returns true if the text appears to contain HTML tags
+ */
+export function isHtmlFormatted(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+
+  // Simple check for common HTML tags
+  const htmlTagPattern = /<[^>]+>/;
+  return htmlTagPattern.test(text);
+}
+
+/**
+ * Formats email body text for HTML email delivery.
+ * If the text is already HTML, returns as-is.
+ * If it's plain text, converts newlines to HTML breaks.
+ *
+ * @param bodyText - Email body text (plain text or HTML)
+ * @returns HTML-formatted email body
+ */
+export function formatEmailBodyForHtml(bodyText: string): string {
+  if (!bodyText) {
+    return '';
+  }
+
+  // If it's already HTML-formatted, return as-is
+  if (isHtmlFormatted(bodyText)) {
+    return bodyText;
+  }
+
+  // Convert plain text to HTML
+  return convertTextToHtml(bodyText);
+}

--- a/server/src/workers/campaign-execution/email-execution.service.ts
+++ b/server/src/workers/campaign-execution/email-execution.service.ts
@@ -19,6 +19,7 @@ import {
   TIMEOUT_JOB_OPTIONS,
 } from '@/constants/timeout-jobs';
 import { calendarUrlWrapper } from '@/libs/calendar/calendarUrlWrapper';
+import { formatEmailBodyForHtml } from '@/utils/emailFormatting';
 import type { SendBase } from '@/libs/email/sendgrid.types';
 import type { ContactCampaign, LeadPointOfContact } from '@/db/schema';
 import type { CampaignPlanOutput } from '@/modules/ai/schemas/contactCampaignStrategySchema';
@@ -218,7 +219,7 @@ export class EmailExecutionService {
         },
         to: contact.email,
         subject: node.subject,
-        html: emailBody,
+        html: formatEmailBodyForHtml(emailBody),
         categories: ['campaign', `tenant:${tenantId}`],
       };
 


### PR DESCRIPTION
Convert plain text newlines to HTML `<br>` tags in email bodies to preserve formatting when sent via SendGrid.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6d8897e-82b8-4f6e-8691-44e6a0e8cc32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6d8897e-82b8-4f6e-8691-44e6a0e8cc32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

