### PR TITLE
Make calendar links clickable in emails

### DIFF
--- a/server/src/libs/calendar/__tests__/calendarUrlWrapper.test.ts
+++ b/server/src/libs/calendar/__tests__/calendarUrlWrapper.test.ts
@@ -1,0 +1,125 @@
+// Mock the environment variable before importing
+process.env.API_URL = 'https://test-api.example.com';
+
+import { CalendarUrlWrapper } from '../calendarUrlWrapper';
+
+describe('CalendarUrlWrapper', () => {
+  let wrapper: CalendarUrlWrapper;
+  const baseUrl = 'https://api.example.com';
+
+  beforeEach(() => {
+    wrapper = new CalendarUrlWrapper(baseUrl);
+  });
+
+  describe('generateTrackedCalendarUrl', () => {
+    it('should generate a tracking URL with basic context', () => {
+      const context = {
+        tenantId: 'tenant-123',
+        leadId: 'lead-456',
+        contactId: 'contact-789',
+      };
+
+      const result = wrapper.generateTrackedCalendarUrl(context);
+
+      expect(result).toBe(
+        'https://api.example.com/api/calendar/track/tenant-123/lead-456/contact-789'
+      );
+    });
+
+    it('should include query parameters when additional context is provided', () => {
+      const context = {
+        tenantId: 'tenant-123',
+        leadId: 'lead-456',
+        contactId: 'contact-789',
+        campaignId: 'campaign-abc',
+        nodeId: 'node-def',
+        outboundMessageId: 'message-ghi',
+      };
+
+      const result = wrapper.generateTrackedCalendarUrl(context);
+
+      expect(result).toContain(
+        'https://api.example.com/api/calendar/track/tenant-123/lead-456/contact-789'
+      );
+      expect(result).toContain('campaignId=campaign-abc');
+      expect(result).toContain('nodeId=node-def');
+      expect(result).toContain('messageId=message-ghi');
+    });
+
+    it('should remove trailing slash from baseUrl', () => {
+      const wrapperWithSlash = new CalendarUrlWrapper('https://api.example.com/');
+      const context = {
+        tenantId: 'tenant-123',
+        leadId: 'lead-456',
+        contactId: 'contact-789',
+      };
+
+      const result = wrapperWithSlash.generateTrackedCalendarUrl(context);
+
+      expect(result).toBe(
+        'https://api.example.com/api/calendar/track/tenant-123/lead-456/contact-789'
+      );
+    });
+  });
+
+  describe('createCalendarMessage', () => {
+    it('should create HTML hyperlink with calendar tie-in text', () => {
+      const calendarTieIn = 'Book a meeting';
+      const trackedUrl =
+        'https://api.example.com/api/calendar/track/tenant-123/lead-456/contact-789';
+
+      const result = wrapper.createCalendarMessage(calendarTieIn, trackedUrl);
+
+      expect(result).toBe(
+        '<a href="https://api.example.com/api/calendar/track/tenant-123/lead-456/contact-789">Book a meeting</a>'
+      );
+    });
+
+    it('should escape HTML special characters in calendar tie-in text', () => {
+      const calendarTieIn = 'Schedule a "free" consultation & get <$100 value>';
+      const trackedUrl = 'https://api.example.com/track';
+
+      const result = wrapper.createCalendarMessage(calendarTieIn, trackedUrl);
+
+      expect(result).toBe(
+        '<a href="https://api.example.com/track">Schedule a &quot;free&quot; consultation &amp; get &lt;$100 value&gt;</a>'
+      );
+    });
+
+    it('should handle empty calendar tie-in text', () => {
+      const calendarTieIn = '';
+      const trackedUrl = 'https://api.example.com/track';
+
+      const result = wrapper.createCalendarMessage(calendarTieIn, trackedUrl);
+
+      expect(result).toBe('<a href="https://api.example.com/track"></a>');
+    });
+
+    it('should handle special characters that need escaping', () => {
+      const calendarTieIn = `Click here & you'll get <benefits> for "free"`;
+      const trackedUrl = 'https://api.example.com/track';
+
+      const result = wrapper.createCalendarMessage(calendarTieIn, trackedUrl);
+
+      expect(result).toBe(
+        '<a href="https://api.example.com/track">Click here &amp; you&#39;ll get &lt;benefits&gt; for &quot;free&quot;</a>'
+      );
+    });
+
+    it('should create valid HTML that works with email formatting', () => {
+      const calendarTieIn = 'Schedule your consultation';
+      const trackedUrl = 'https://tracking-url.com';
+
+      const result = wrapper.createCalendarMessage(calendarTieIn, trackedUrl);
+
+      // Should be valid HTML anchor tag
+      expect(result).toMatch(/^<a href="[^"]+">.*<\/a>$/);
+
+      // Should contain the tracking URL in href
+      expect(result).toContain(`href="${trackedUrl}"`);
+
+      // Should contain the tie-in text as link text
+      expect(result).toContain('>Schedule your consultation<');
+    });
+  });
+});

--- a/server/src/libs/calendar/calendarUrlWrapper.ts
+++ b/server/src/libs/calendar/calendarUrlWrapper.ts
@@ -44,10 +44,18 @@ export class CalendarUrlWrapper {
   }
 
   /**
-   * Create a calendar introduction message with the tracked link
+   * Create a calendar message with HTML hyperlink
    */
   createCalendarMessage(calendarTieIn: string, trackedUrl: string): string {
-    return `${calendarTieIn}: ${trackedUrl}`;
+    // Escape the calendar tie-in text to prevent XSS while preserving it as link text
+    const escapedTieIn = calendarTieIn
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+    return `<a href="${trackedUrl}">${escapedTieIn}</a>`;
   }
 }
 

--- a/server/src/utils/__tests__/emailFormatting.test.ts
+++ b/server/src/utils/__tests__/emailFormatting.test.ts
@@ -1,6 +1,5 @@
 import {
   convertTextToHtml,
-  isHtmlFormatted,
   formatEmailBodyForHtml,
   containsHtml,
   formatMixedContentForHtml,
@@ -72,25 +71,6 @@ Would you be open to a brief call to see how this could fit with your intake and
     it('should handle null/undefined', () => {
       expect(containsHtml(null as any)).toBe(false);
       expect(containsHtml(undefined as any)).toBe(false);
-    });
-  });
-
-  describe('isHtmlFormatted', () => {
-    it('should detect HTML tags', () => {
-      expect(isHtmlFormatted('<p>Hello</p>')).toBe(true);
-      expect(isHtmlFormatted('Hello <br> World')).toBe(true);
-      expect(isHtmlFormatted('<div>Content</div>')).toBe(true);
-    });
-
-    it('should return false for plain text', () => {
-      expect(isHtmlFormatted('Hello\nWorld')).toBe(false);
-      expect(isHtmlFormatted('Plain text email')).toBe(false);
-      expect(isHtmlFormatted('')).toBe(false);
-    });
-
-    it('should handle null/undefined', () => {
-      expect(isHtmlFormatted(null as any)).toBe(false);
-      expect(isHtmlFormatted(undefined as any)).toBe(false);
     });
   });
 

--- a/server/src/utils/emailFormatting.ts
+++ b/server/src/utils/emailFormatting.ts
@@ -28,12 +28,12 @@ export function convertTextToHtml(text: string): string {
 }
 
 /**
- * Checks if a string is already HTML formatted
+ * Checks if a string contains HTML tags
  *
  * @param text - Text to check
  * @returns true if the text appears to contain HTML tags
  */
-export function isHtmlFormatted(text: string): boolean {
+export function containsHtml(text: string): boolean {
   if (!text) {
     return false;
   }
@@ -44,11 +44,62 @@ export function isHtmlFormatted(text: string): boolean {
 }
 
 /**
+ * Checks if a string is already HTML formatted (legacy function for backward compatibility)
+ *
+ * @param text - Text to check
+ * @returns true if the text appears to contain HTML tags
+ */
+export function isHtmlFormatted(text: string): boolean {
+  return containsHtml(text);
+}
+
+/**
+ * Formats mixed content for HTML email delivery.
+ * Handles content that may contain both plain text and HTML elements.
+ * Preserves existing HTML while converting plain text portions to HTML.
+ *
+ * @param content - Content that may contain mixed plain text and HTML
+ * @returns HTML-formatted content
+ */
+export function formatMixedContentForHtml(content: string): string {
+  if (!content) {
+    return '';
+  }
+
+  // If the content contains HTML, we need to handle it carefully
+  if (containsHtml(content)) {
+    // Split content by HTML tags to separate plain text from HTML
+    const parts = content.split(/(<[^>]+>)/);
+
+    return parts
+      .map((part) => {
+        // If this part is an HTML tag, preserve it as-is
+        if (part.match(/^<[^>]+>$/)) {
+          return part;
+        }
+        // If this part is between HTML tags or contains HTML-like content,
+        // we need to be more careful
+        if (containsHtml(part)) {
+          return part; // Preserve existing HTML
+        }
+        // This is plain text, convert newlines to <br> but don't double-escape
+        // if it's already been processed
+        return part.replace(/\r\n/g, '<br>').replace(/\n/g, '<br>');
+      })
+      .join('');
+  }
+
+  // Pure plain text - convert to HTML
+  return convertTextToHtml(content);
+}
+
+/**
  * Formats email body text for HTML email delivery.
  * If the text is already HTML, returns as-is.
  * If it's plain text, converts newlines to HTML breaks.
+ * Now supports mixed content (plain text with HTML elements).
  *
- * @param bodyText - Email body text (plain text or HTML)
+ * @param bodyText - Email body text (plain text, HTML, or mixed)
  * @returns HTML-formatted email body
  */
 export function formatEmailBodyForHtml(bodyText: string): string {
@@ -56,11 +107,5 @@ export function formatEmailBodyForHtml(bodyText: string): string {
     return '';
   }
 
-  // If it's already HTML-formatted, return as-is
-  if (isHtmlFormatted(bodyText)) {
-    return bodyText;
-  }
-
-  // Convert plain text to HTML
-  return convertTextToHtml(bodyText);
+  return formatMixedContentForHtml(bodyText);
 }

--- a/server/src/utils/emailFormatting.ts
+++ b/server/src/utils/emailFormatting.ts
@@ -44,16 +44,6 @@ export function containsHtml(text: string): boolean {
 }
 
 /**
- * Checks if a string is already HTML formatted (legacy function for backward compatibility)
- *
- * @param text - Text to check
- * @returns true if the text appears to contain HTML tags
- */
-export function isHtmlFormatted(text: string): boolean {
-  return containsHtml(text);
-}
-
-/**
  * Formats mixed content for HTML email delivery.
  * Handles content that may contain both plain text and HTML elements.
  * Preserves existing HTML while converting plain text portions to HTML.
@@ -95,9 +85,7 @@ export function formatMixedContentForHtml(content: string): string {
 
 /**
  * Formats email body text for HTML email delivery.
- * If the text is already HTML, returns as-is.
- * If it's plain text, converts newlines to HTML breaks.
- * Now supports mixed content (plain text with HTML elements).
+ * Supports mixed content (plain text with HTML elements).
  *
  * @param bodyText - Email body text (plain text, HTML, or mixed)
  * @returns HTML-formatted email body


### PR DESCRIPTION
Convert calendar links in emails from raw URLs to clickable HTML hyperlinks.

This improves user experience by presenting a clear, clickable link. The implementation ensures proper HTML rendering across email clients, includes HTML escaping for security (XSS prevention), and enhances the email formatting utility to seamlessly handle mixed plain text and HTML content within the email body.

---
<a href="https://cursor.com/background-agent?bcId=bc-f53b83d7-f6e0-40c6-bcdf-bed47c09e9e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f53b83d7-f6e0-40c6-bcdf-bed47c09e9e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

