### PR TITLE
Handle missing tenant for sendgrid webhook

### DIFF
--- a/server/src/modules/webhooks/sendgrid.webhook.types.ts
+++ b/server/src/modules/webhooks/sendgrid.webhook.types.ts
@@ -161,7 +161,7 @@ export interface ProcessedEventResult {
 // Webhook Processing Result
 export interface WebhookProcessingResult {
   success: boolean;
-  webhookDeliveryId: string;
+  webhookDeliveryId: string | null;
   processedEvents: ProcessedEventResult[];
   totalEvents: number;
   successfulEvents: number;


### PR DESCRIPTION
Gracefully handle SendGrid webhooks for missing tenants to prevent errors and ensure successful processing of other events.

Previously, if a SendGrid webhook contained events for a tenant that no longer existed in the database, the system would throw an error and crash the webhook processing. This led to failed webhook deliveries and continuous retries from SendGrid. This change modifies the `WebhookDeliveryRepository` to return `null` for missing tenants and updates the `SendGridWebhookService` to log a warning, skip processing for that tenant, and return a success response (HTTP 200) to SendGrid, thus preventing crashes and allowing other valid events to be processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-24cd8cee-126b-422c-afee-3aff4c968d4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24cd8cee-126b-422c-afee-3aff4c968d4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

