### PR TITLE
Add plain text email version

### DIFF
--- a/server/src/libs/email/sendgrid.client.ts
+++ b/server/src/libs/email/sendgrid.client.ts
@@ -31,19 +31,24 @@ class SendgridClient {
     // Prepare plain text with simple unsubscribe format
     const finalText = hasText ? `${input.text}\n\nUnsubscribe: ${unsubscribeUrl}` : undefined;
 
-    const msg: MailDataRequired = {
+    const msg: Partial<MailDataRequired> = {
       from: input.from,
       to: input.to,
       subject: input.subject,
-      ...(hasHtml ? { html: input.html } : {}),
-      ...(finalText ? { text: finalText } : {}),
       headers,
       categories: input.categories,
       customArgs: this.buildCustomArgs(input),
       ...(input.asmGroupId ? { asm: { groupId: input.asmGroupId } } : {}),
     };
 
-    const [resp] = await sgMail.send(msg, false); // no built-in retry; you handle backoff in worker
+    if (hasHtml) {
+      msg.html = input.html;
+    }
+    if (finalText) {
+      msg.text = finalText;
+    }
+
+    const [resp] = await sgMail.send(msg as MailDataRequired, false); // no built-in retry; you handle backoff in worker
     return this.extractProviderIds(resp);
   }
 

--- a/server/src/utils/emailFormatting.ts
+++ b/server/src/utils/emailFormatting.ts
@@ -3,6 +3,65 @@
  */
 
 /**
+ * Converts HTML content to plain text by removing HTML tags and entities.
+ * Preserves line breaks and basic text formatting for readability.
+ *
+ * @param html - HTML content to convert
+ * @returns Plain text version
+ */
+export function convertHtmlToText(html: string): string {
+  if (!html) {
+    return '';
+  }
+
+  let text = html;
+
+  // Convert common HTML elements to plain text equivalents
+  text = text
+    // Convert line breaks and paragraphs to newlines
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n')
+    .replace(/<p[^>]*>/gi, '')
+    // Convert headers to plain text with spacing
+    .replace(/<\/h[1-6]>/gi, '\n\n')
+    .replace(/<h[1-6][^>]*>/gi, '')
+    // Convert lists
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '• ')
+    .replace(/<\/(ul|ol)>/gi, '\n')
+    .replace(/<(ul|ol)[^>]*>/gi, '')
+    // Convert divs to line breaks
+    .replace(/<\/div>/gi, '\n')
+    .replace(/<div[^>]*>/gi, '')
+    // Remove all other HTML tags
+    .replace(/<[^>]+>/g, '');
+
+  // Decode HTML entities
+  text = text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+
+  // Clean up extra whitespace and newlines
+  text = text
+    // Replace multiple consecutive spaces with single space
+    .replace(/[ \t]+/g, ' ')
+    // Replace multiple consecutive newlines with double newline
+    .replace(/\n\s*\n\s*\n/g, '\n\n')
+    // Trim whitespace from each line
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    // Trim overall string
+    .trim();
+
+  return text;
+}
+
+/**
  * Converts plain text to HTML-formatted text for email display.
  * This preserves line breaks and paragraphs while keeping the text safe for HTML.
  *
@@ -96,4 +155,26 @@ export function formatEmailBodyForHtml(bodyText: string): string {
   }
 
   return formatMixedContentForHtml(bodyText);
+}
+
+/**
+ * Formats email body text for plain text email delivery.
+ * If the content contains HTML, it will be converted to plain text.
+ * If it's already plain text, it will be returned as-is.
+ *
+ * @param bodyText - Email body text (plain text, HTML, or mixed)
+ * @returns Plain text email body
+ */
+export function formatEmailBodyForText(bodyText: string): string {
+  if (!bodyText) {
+    return '';
+  }
+
+  // If the content contains HTML, convert it to plain text
+  if (containsHtml(bodyText)) {
+    return convertHtmlToText(bodyText);
+  }
+
+  // Already plain text, return as-is
+  return bodyText;
 }

--- a/server/src/workers/campaign-execution/email-execution.service.ts
+++ b/server/src/workers/campaign-execution/email-execution.service.ts
@@ -19,7 +19,7 @@ import {
   TIMEOUT_JOB_OPTIONS,
 } from '@/constants/timeout-jobs';
 import { calendarUrlWrapper } from '@/libs/calendar/calendarUrlWrapper';
-import { formatEmailBodyForHtml } from '@/utils/emailFormatting';
+import { formatEmailBodyForHtml, formatEmailBodyForText } from '@/utils/emailFormatting';
 import type { SendBase } from '@/libs/email/sendgrid.types';
 import type { ContactCampaign, LeadPointOfContact } from '@/db/schema';
 import type { CampaignPlanOutput } from '@/modules/ai/schemas/contactCampaignStrategySchema';
@@ -206,7 +206,10 @@ export class EmailExecutionService {
         // Continue without calendar info - don't fail the email send
       }
 
-      // Prepare SendGrid payload
+      // Prepare SendGrid payload with both HTML and plain text versions
+      const htmlBody = formatEmailBodyForHtml(emailBody);
+      const textBody = formatEmailBodyForText(emailBody);
+
       const sendPayload: SendBase = {
         tenantId,
         campaignId,
@@ -219,7 +222,8 @@ export class EmailExecutionService {
         },
         to: contact.email,
         subject: node.subject,
-        html: formatEmailBodyForHtml(emailBody),
+        html: htmlBody,
+        text: textBody,
         categories: ['campaign', `tenant:${tenantId}`],
       };
 


### PR DESCRIPTION
Send both plain text and HTML versions of emails to improve compatibility and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-925c2dbf-ccbb-4587-9f4b-c1a552550fc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-925c2dbf-ccbb-4587-9f4b-c1a552550fc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

