### PR TITLE
Add contact unsubscribe button and record

### DIFF
--- a/client/src/components/tabs/ContactsTab.tsx
+++ b/client/src/components/tabs/ContactsTab.tsx
@@ -13,6 +13,7 @@ import {
   Save,
   X,
   Plus,
+  UserX,
 } from 'lucide-react'
 import { useMutation } from '@tanstack/react-query'
 import CopyButton from '../CopyButton'
@@ -25,6 +26,7 @@ import {
   useUpdateContact,
   useToggleContactManuallyReviewed,
   useCreateContact,
+  useUnsubscribeContact,
 } from '../../hooks/useLeadsQuery'
 
 interface ContactsTabProps {
@@ -59,6 +61,9 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
   const [validationErrors, setValidationErrors] = useState<{
     [key: string]: string
   }>({})
+  const [unsubscribeModalOpen, setUnsubscribeModalOpen] = useState(false)
+  const [contactToUnsubscribe, setContactToUnsubscribe] =
+    useState<LeadPointOfContact | null>(null)
   const leadsService = getLeadsService()
 
   useEffect(() => {
@@ -92,6 +97,20 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
     // onError callback
     (error) => {
       console.error('Failed to create contact:', error)
+      // You might want to show a toast notification here
+    },
+  )
+
+  const unsubscribeContactMutation = useUnsubscribeContact(
+    // onSuccess callback
+    () => {
+      setUnsubscribeModalOpen(false)
+      setContactToUnsubscribe(null)
+      console.log('Contact unsubscribed successfully')
+    },
+    // onError callback
+    (error) => {
+      console.error('Failed to unsubscribe contact:', error)
       // You might want to show a toast notification here
     },
   )
@@ -147,6 +166,25 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
       leadId,
       contactData,
     })
+  }
+
+  const handleUnsubscribeContact = (contact: LeadPointOfContact) => {
+    setContactToUnsubscribe(contact)
+    setUnsubscribeModalOpen(true)
+  }
+
+  const handleConfirmUnsubscribe = () => {
+    if (contactToUnsubscribe) {
+      unsubscribeContactMutation.mutate({
+        leadId,
+        contactId: contactToUnsubscribe.id,
+      })
+    }
+  }
+
+  const handleCancelUnsubscribe = () => {
+    setUnsubscribeModalOpen(false)
+    setContactToUnsubscribe(null)
   }
 
   const handleEditContact = (contact: LeadPointOfContact) => {
@@ -530,6 +568,26 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
                               : 'Generate Strategy'}
                           </span>
                         </button>
+                        <button
+                          onClick={() => handleUnsubscribeContact(contact)}
+                          disabled={
+                            editingContactId !== null ||
+                            qualifyingContactId === contact.id ||
+                            unsubscribeContactMutation.isPending ||
+                            !contact.email
+                          }
+                          className="flex items-center space-x-2 px-3 py-2 rounded-md bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          title={
+                            !contact.email
+                              ? 'Contact must have an email to unsubscribe'
+                              : 'Unsubscribe this contact from email communications'
+                          }
+                        >
+                          <UserX className="h-4 w-4" />
+                          <span className="text-sm font-medium">
+                            Unsubscribe
+                          </span>
+                        </button>
                         <AnimatedCheckbox
                           checked={contact.manuallyReviewed}
                           onChange={() => handleToggleManuallyReviewed(contact)}
@@ -801,6 +859,57 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
         onSubmit={handleCreateContact}
         isSubmitting={createContactMutation.isPending}
       />
+
+      {/* Unsubscribe Confirmation Modal */}
+      {unsubscribeModalOpen && contactToUnsubscribe && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+            <div className="flex items-center mb-4">
+              <UserX className="h-6 w-6 text-red-600 mr-3" />
+              <h3 className="text-lg font-medium text-gray-900">
+                Unsubscribe Contact
+              </h3>
+            </div>
+            <p className="text-gray-600 mb-6">
+              Are you sure you want to unsubscribe{' '}
+              <span className="font-medium text-gray-900">
+                {contactToUnsubscribe.name}
+              </span>{' '}
+              ({contactToUnsubscribe.email}) from email communications?
+            </p>
+            <p className="text-sm text-gray-500 mb-6">
+              This action will prevent them from receiving future campaign
+              emails.
+            </p>
+            <div className="flex justify-end space-x-3">
+              <button
+                onClick={handleCancelUnsubscribe}
+                disabled={unsubscribeContactMutation.isPending}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmUnsubscribe}
+                disabled={unsubscribeContactMutation.isPending}
+                className="flex items-center space-x-2 px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {unsubscribeContactMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>Unsubscribing...</span>
+                  </>
+                ) : (
+                  <>
+                    <UserX className="h-4 w-4" />
+                    <span>Unsubscribe</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/client/src/hooks/useLeadsQuery.ts
+++ b/client/src/hooks/useLeadsQuery.ts
@@ -456,5 +456,47 @@ export function useUsers(page = 1, limit = 25) {
   })
 }
 
+// Hook to unsubscribe a contact
+export function useUnsubscribeContact(
+  onSuccess?: () => void,
+  onError?: (error: any) => void,
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      leadId,
+      contactId,
+    }: {
+      leadId: string
+      contactId: string
+    }) => leadsService.unsubscribeContact(leadId, contactId),
+    onSuccess: (_, { leadId }) => {
+      // Invalidate the lead detail to refresh the contact data
+      queryClient.invalidateQueries({
+        queryKey: leadQueryKeys.detail(leadId),
+      })
+
+      // Invalidate leads list to ensure consistency
+      queryClient.invalidateQueries({
+        queryKey: leadQueryKeys.lists(),
+      })
+
+      // Call the custom success callback if provided
+      if (onSuccess) {
+        onSuccess()
+      }
+    },
+    onError: (error) => {
+      console.error('Error unsubscribing contact:', error)
+
+      // Call the custom error callback if provided
+      if (onError) {
+        onError(error)
+      }
+    },
+  })
+}
+
 // Re-export the query keys for use in other components
 export { leadQueryKeys }

--- a/server/src/routes/apiSchema/contact/contact.unsubscribe.schema.ts
+++ b/server/src/routes/apiSchema/contact/contact.unsubscribe.schema.ts
@@ -1,0 +1,32 @@
+import { Type } from '@sinclair/typebox';
+
+export const ContactUnsubscribeSchema = {
+  params: Type.Object({
+    leadId: Type.String({ description: 'The ID of the lead' }),
+    contactId: Type.String({ description: 'The ID of the contact to unsubscribe' }),
+  }),
+  response: {
+    200: Type.Object({
+      message: Type.String({ description: 'Success message' }),
+      unsubscribed: Type.Boolean({
+        description: 'Whether the contact was successfully unsubscribed',
+      }),
+    }),
+    400: Type.Object({
+      message: Type.String({ description: 'Error message' }),
+      error: Type.String({ description: 'Detailed error information' }),
+    }),
+    403: Type.Object({
+      message: Type.String({ description: 'Access denied message' }),
+      error: Type.String({ description: 'Detailed error information' }),
+    }),
+    404: Type.Object({
+      message: Type.String({ description: 'Not found message' }),
+      error: Type.String({ description: 'Detailed error information' }),
+    }),
+    500: Type.Object({
+      message: Type.String({ description: 'Internal server error message' }),
+      error: Type.String({ description: 'Detailed error information' }),
+    }),
+  },
+};

--- a/server/src/routes/apiSchema/contact/index.ts
+++ b/server/src/routes/apiSchema/contact/index.ts
@@ -6,3 +6,4 @@ export * from './contact.delete.schema';
 
 // Contact special operations
 export * from './contact.manualReview.schema';
+export * from './contact.unsubscribe.schema';


### PR DESCRIPTION
Add a manual unsubscribe button to the contact interface, allowing administrators to unsubscribe contacts and record the action in the unsubscribe table as a 'manual_admin' source.

This feature provides administrative control to opt contacts out of email communications directly from the application, replicating the effect of a user-initiated unsubscribe link click by adding an entry to the `contact_unsubscribes` table.

---
<a href="https://cursor.com/background-agent?bcId=bc-d070e567-df80-4146-a4b8-9a5c64a21fc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d070e567-df80-4146-a4b8-9a5c64a21fc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

