### PR TITLE
Restructure contact card buttons and create reusable menu

### DIFF
--- a/client/src/components/tabs/ContactsTab.tsx
+++ b/client/src/components/tabs/ContactsTab.tsx
@@ -15,6 +15,7 @@ import {
   Plus,
   UserX,
 } from 'lucide-react'
+import { Menu, MenuItem, MenuSeparator } from '../ui'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import CopyButton from '../CopyButton'
 import ContactStrategyModal from '../ContactStrategyModal'
@@ -188,7 +189,7 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
   const getStrategyButtonState = (contact: LeadPointOfContact) => {
     const isGenerating = qualifyingContactId === contact.id
     const strategyStatus = contact.strategyStatus || 'none'
-    
+
     if (isGenerating) {
       return {
         type: 'generating',
@@ -199,7 +200,7 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
         icon: <Loader2 className="h-4 w-4 animate-spin" />,
       }
     }
-    
+
     switch (strategyStatus) {
       case 'completed':
         return {
@@ -617,19 +618,6 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
                       </>
                     ) : (
                       <>
-                        <button
-                          onClick={() => handleEditContact(contact)}
-                          disabled={
-                            editingContactId !== null ||
-                            qualifyingContactId === contact.id ||
-                            loadingContactId === contact.id
-                          }
-                          className="flex items-center space-x-2 px-3 py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                          title="Edit contact"
-                        >
-                          <Edit3 className="h-4 w-4" />
-                          <span className="text-sm font-medium">Edit</span>
-                        </button>
                         {(() => {
                           const buttonState = getStrategyButtonState(contact)
                           return (
@@ -649,26 +637,6 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
                             </button>
                           )
                         })()}
-                        <button
-                          onClick={() => handleUnsubscribeContact(contact)}
-                          disabled={
-                            editingContactId !== null ||
-                            qualifyingContactId === contact.id ||
-                            unsubscribeContactMutation.isPending ||
-                            !contact.email
-                          }
-                          className="flex items-center space-x-2 px-3 py-2 rounded-md bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                          title={
-                            !contact.email
-                              ? 'Contact must have an email to unsubscribe'
-                              : 'Unsubscribe this contact from email communications'
-                          }
-                        >
-                          <UserX className="h-4 w-4" />
-                          <span className="text-sm font-medium">
-                            Unsubscribe
-                          </span>
-                        </button>
                         <AnimatedCheckbox
                           checked={contact.manuallyReviewed}
                           onChange={() => handleToggleManuallyReviewed(contact)}
@@ -688,6 +656,37 @@ const ContactsTab: React.FC<ContactsTabProps> = ({
                               : 'Mark as manually reviewed'
                           }
                         />
+                        <Menu>
+                          <MenuItem
+                            onClick={() => handleEditContact(contact)}
+                            disabled={
+                              editingContactId !== null ||
+                              qualifyingContactId === contact.id ||
+                              loadingContactId === contact.id
+                            }
+                          >
+                            <div className="flex items-center space-x-2">
+                              <Edit3 className="h-4 w-4" />
+                              <span>Edit Contact</span>
+                            </div>
+                          </MenuItem>
+                          <MenuSeparator />
+                          <MenuItem
+                            onClick={() => handleUnsubscribeContact(contact)}
+                            disabled={
+                              editingContactId !== null ||
+                              qualifyingContactId === contact.id ||
+                              unsubscribeContactMutation.isPending ||
+                              !contact.email
+                            }
+                            variant="danger"
+                          >
+                            <div className="flex items-center space-x-2">
+                              <UserX className="h-4 w-4" />
+                              <span>Unsubscribe</span>
+                            </div>
+                          </MenuItem>
+                        </Menu>
                       </>
                     )}
                   </div>

--- a/client/src/components/ui/Menu.tsx
+++ b/client/src/components/ui/Menu.tsx
@@ -1,0 +1,130 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { MoreVertical } from 'lucide-react'
+
+interface MenuProps {
+  children: React.ReactNode
+  trigger?: React.ReactNode
+  className?: string
+  align?: 'left' | 'right'
+}
+
+interface MenuItemProps {
+  children: React.ReactNode
+  onClick?: () => void
+  disabled?: boolean
+  variant?: 'default' | 'danger'
+  className?: string
+}
+
+interface MenuSeparatorProps {
+  className?: string
+}
+
+// Menu Context
+const MenuContext = React.createContext<{
+  isOpen: boolean
+  setIsOpen: (open: boolean) => void
+}>({
+  isOpen: false,
+  setIsOpen: () => {},
+})
+
+// Main Menu Component
+export const Menu: React.FC<MenuProps> = ({
+  children,
+  trigger,
+  className = '',
+  align = 'right',
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen])
+
+  const defaultTrigger = (
+    <button
+      className="flex items-center justify-center w-8 h-8 rounded-md bg-gray-100 hover:bg-gray-200 transition-colors"
+      title="More options"
+    >
+      <MoreVertical className="h-4 w-4 text-gray-600" />
+    </button>
+  )
+
+  return (
+    <MenuContext.Provider value={{ isOpen, setIsOpen }}>
+      <div className={`relative ${className}`} ref={menuRef}>
+        <div onClick={() => setIsOpen(!isOpen)}>
+          {trigger || defaultTrigger}
+        </div>
+
+        {isOpen && (
+          <div
+            className={`absolute top-full mt-1 w-48 bg-white rounded-md shadow-lg border border-gray-200 py-1 z-50 ${
+              align === 'left' ? 'left-0' : 'right-0'
+            }`}
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    </MenuContext.Provider>
+  )
+}
+
+// Menu Item Component
+export const MenuItem: React.FC<MenuItemProps> = ({
+  children,
+  onClick,
+  disabled = false,
+  variant = 'default',
+  className = '',
+}) => {
+  const { setIsOpen } = React.useContext(MenuContext)
+
+  const handleClick = () => {
+    if (!disabled && onClick) {
+      onClick()
+      setIsOpen(false)
+    }
+  }
+
+  const variantClasses = {
+    default: 'text-gray-700 hover:bg-gray-50',
+    danger: 'text-red-600 hover:bg-red-50',
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={disabled}
+      className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+        variantClasses[variant]
+      } ${
+        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+      } ${className}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+// Menu Separator Component
+export const MenuSeparator: React.FC<MenuSeparatorProps> = ({
+  className = '',
+}) => {
+  return <div className={`h-px bg-gray-200 my-1 ${className}`} />
+}

--- a/client/src/components/ui/index.ts
+++ b/client/src/components/ui/index.ts
@@ -1,0 +1,1 @@
+export { Menu, MenuItem, MenuSeparator } from './Menu'

--- a/client/src/services/leads.service.ts
+++ b/client/src/services/leads.service.ts
@@ -550,10 +550,7 @@ class LeadsService {
   }
 
   // Get existing contact strategy for a contact
-  async getContactStrategy(
-    leadId: string,
-    contactId: string,
-  ): Promise<any> {
+  async getContactStrategy(leadId: string, contactId: string): Promise<any> {
     const authHeaders = await authService.getAuthHeaders()
 
     const response = await fetch(
@@ -568,9 +565,7 @@ class LeadsService {
 
     if (!response.ok) {
       const errorData = await response.json()
-      throw new Error(
-        errorData.message || 'Failed to get contact strategy',
-      )
+      throw new Error(errorData.message || 'Failed to get contact strategy')
     }
 
     const result = await response.json()


### PR DESCRIPTION
Move contact card action buttons into a reusable dropdown menu to declutter the UI and provide a consistent component for future use.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2729da9-c7a7-4b24-9406-b3bdd2537cde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2729da9-c7a7-4b24-9406-b3bdd2537cde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

