### PR TITLE
Fix landing page scroll to top

### DIFF
--- a/landing/public/sitemap.xml
+++ b/landing/public/sitemap.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dripiq.ai/</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/about</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/contact</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/pricing</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/blog/</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/blog/ai-sales-automation-guide</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/blog/salesforce-lead-re-engagement-strategies</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://dripiq.ai/blog/cold-leads-conversion-tactics</loc>
-    <lastmod>2025-09-02</lastmod>
+    <lastmod>2025-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/landing/src/components/shared/Footer.tsx
+++ b/landing/src/components/shared/Footer.tsx
@@ -4,15 +4,11 @@ import Logo from './Logo'
 export default function Footer() {
   const currentYear = new Date().getFullYear()
 
-  const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }
-
   const footerLinks = {
     Product: [
       { name: 'Features', href: '/#features' },
       { name: 'Pricing', href: '/pricing' },
-      { name: 'Integrations', href: '/#integrations' },
+      { name: 'Integrations', href: '/#features' },
     ],
     Company: [
       { name: 'About', href: '/about' },
@@ -47,7 +43,6 @@ export default function Footer() {
             <div className="mt-6">
               <a
                 href="https://app.dripiq.ai/signup"
-                onClick={scrollToTop}
                 className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-primary-600 hover:bg-primary-700 transition-colors"
               >
                 Get Started Free
@@ -67,7 +62,6 @@ export default function Footer() {
                         href={link.href}
                         target="_blank"
                         rel="noopener noreferrer"
-                        onClick={scrollToTop}
                         className="text-surface-400 hover:text-white transition-colors text-sm"
                       >
                         {link.name}
@@ -75,7 +69,6 @@ export default function Footer() {
                     ) : (
                       <Link
                         to={link.href}
-                        onClick={scrollToTop}
                         className="text-surface-400 hover:text-white transition-colors text-sm"
                       >
                         {link.name}
@@ -99,7 +92,6 @@ export default function Footer() {
                 href="https://twitter.com/dripiq"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={scrollToTop}
                 className="text-surface-400 hover:text-white transition-colors"
                 aria-label="Follow us on Twitter"
               >
@@ -115,7 +107,6 @@ export default function Footer() {
                 href="https://linkedin.com/company/dripiq"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={scrollToTop}
                 className="text-surface-400 hover:text-white transition-colors"
                 aria-label="Follow us on LinkedIn"
               >

--- a/landing/src/routes/__root.tsx
+++ b/landing/src/routes/__root.tsx
@@ -2,16 +2,37 @@ import {
   createRootRoute,
   Outlet,
   ScrollRestoration,
+  useRouter,
 } from '@tanstack/react-router'
+import { useEffect } from 'react'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import Header from '@/components/shared/Header'
 import Footer from '@/components/shared/Footer'
 import SEOHead from '@/components/shared/SEOHead'
 
+function ScrollToTopOnRouteChange() {
+  const router = useRouter()
+
+  useEffect(() => {
+    // Scroll to top when route changes, but not on initial load
+    const unsubscribe = router.subscribe('onLoad', () => {
+      // Only scroll to top if it's not a hash navigation (anchor link)
+      if (!window.location.hash) {
+        window.scrollTo(0, 0)
+      }
+    })
+
+    return unsubscribe
+  }, [router])
+
+  return null
+}
+
 export const Route = createRootRoute({
   component: () => (
     <>
       <SEOHead />
+      <ScrollToTopOnRouteChange />
       <div className="min-h-screen flex flex-col bg-background">
         <Header />
         <main className="flex-1">

--- a/landing/src/styles.css
+++ b/landing/src/styles.css
@@ -155,6 +155,7 @@
 /* Base styles */
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 4rem; /* Account for sticky header height (h-16 = 4rem) */
 }
 
 body {


### PR DESCRIPTION
Implements automatic scroll-to-top on route changes and adjusts for sticky header to fix navigation scroll issues.

Previously, clicking footer links would not scroll the page to the top due to conflicting manual `onClick` scroll handlers and TanStack Router's navigation. Additionally, the sticky header caused content to be obscured. This PR removes the manual handlers, introduces a `ScrollToTopOnRouteChange` component for proper router-driven scrolling, and adds `scroll-padding-top` to prevent header overlap. It also corrects a broken "Integrations" footer link to point to the existing "Features" section.

---
<a href="https://cursor.com/background-agent?bcId=bc-421d356a-e851-44c8-b4ae-9c3b782c9078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-421d356a-e851-44c8-b4ae-9c3b782c9078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

