### PR TITLE
Update provider card for single primary selection

### DIFF
--- a/client/src/components/ProviderCard.tsx
+++ b/client/src/components/ProviderCard.tsx
@@ -5,6 +5,8 @@ interface ProviderCardProps {
   icon: React.ReactNode
   connectedProvider: EmailProvider | null
   children: React.ReactNode // The provider-specific button component
+  onPrimaryChange?: (providerId: string) => void
+  allProviders?: EmailProvider[]
 }
 
 export default function ProviderCard({
@@ -12,18 +14,34 @@ export default function ProviderCard({
   icon,
   connectedProvider,
   children,
+  onPrimaryChange,
+  allProviders: _allProviders = [],
 }: ProviderCardProps) {
   const isConnected = connectedProvider?.isConnected || false
+  const isPrimary = connectedProvider?.isPrimary || false
+
+  const handlePrimaryChange = () => {
+    if (isConnected && connectedProvider && onPrimaryChange) {
+      onPrimaryChange(connectedProvider.id)
+    }
+  }
 
   return (
     <div className="border border-[var(--color-border-default)] rounded-lg p-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           {icon}
-          <div>
-            <h3 className="font-medium text-[var(--color-text-primary)]">
-              {displayName}
-            </h3>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="font-medium text-[var(--color-text-primary)]">
+                {displayName}
+              </h3>
+              {isPrimary && (
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
+                  Primary
+                </span>
+              )}
+            </div>
             {isConnected && connectedProvider && (
               <p className="text-sm text-[var(--color-text-muted)]">
                 Connected as{' '}
@@ -34,7 +52,29 @@ export default function ProviderCard({
           </div>
         </div>
 
-        {children}
+        <div className="flex items-center gap-3">
+          {/* Primary provider radio button - only show for connected providers */}
+          {isConnected && onPrimaryChange && (
+            <div className="flex items-center">
+              <input
+                type="radio"
+                id={`primary-${connectedProvider?.id}`}
+                name="primary-provider"
+                checked={isPrimary}
+                onChange={handlePrimaryChange}
+                className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2"
+              />
+              <label
+                htmlFor={`primary-${connectedProvider?.id}`}
+                className="ml-2 text-sm font-medium text-[var(--color-text-secondary)] cursor-pointer select-none"
+              >
+                Primary
+              </label>
+            </div>
+          )}
+          
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/server/src/db/migrations/0038_add_primary_provider_constraint.sql
+++ b/server/src/db/migrations/0038_add_primary_provider_constraint.sql
@@ -1,0 +1,2 @@
+-- Add unique partial index to ensure only one primary mail account per user
+CREATE UNIQUE INDEX CONCURRENTLY "mail_accounts_user_primary_uq" ON "dripiq_app"."mail_accounts" ("user_id") WHERE "is_primary" = true;--> statement-breakpoint

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
   text,
   timestamp,
@@ -929,6 +929,7 @@ export const mailAccounts = appSchema.table(
     index('mail_accounts_email_idx').on(table.primaryEmail),
     index('mail_accounts_user_idx').on(table.userId),
     index('mail_accounts_tenant_idx').on(table.tenantId),
+    // Note: Partial unique index for primary mail accounts is created via migration
   ]
 );
 


### PR DESCRIPTION
Enable single primary email provider selection with a new API endpoint, radial buttons, and visual badges.

This ensures only one email provider is designated as primary at a time, which is critical for consistent email sending. It includes logic to automatically set the first connected provider as primary and subsequent ones as non-primary, along with optimistic UI updates for a smooth user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-03b6272d-2d8e-4ba2-948f-84b90fc7911d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03b6272d-2d8e-4ba2-948f-84b90fc7911d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

