### PR TITLE
Investigate smart filter scraping bug

### DIFF
--- a/server/src/modules/ai/siteScrape.service.test.ts
+++ b/server/src/modules/ai/siteScrape.service.test.ts
@@ -1,0 +1,169 @@
+import { SearchResultWeb } from '@mendable/firecrawl-js';
+import { SiteScrapeService } from './siteScrape.service';
+import { smartUrlFilterAgent } from './langchain';
+
+jest.mock('@/libs/firecrawl/firecrawl.client', () => ({
+  __esModule: true,
+  default: {
+    getSiteMap: jest.fn(),
+    batchScrapeUrls: jest.fn(),
+  },
+}));
+
+jest.mock('./langchain', () => ({
+  smartUrlFilterAgent: {
+    execute: jest.fn(),
+  },
+}));
+
+jest.mock('@/libs/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('SiteScrapeService.smartFilterSiteMap', () => {
+  const createMockUrls = (count: number): SearchResultWeb[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      url: `https://example.com/page-${i + 1}`,
+      title: `Page ${i + 1}`,
+    }));
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Max limit enforcement', () => {
+    it('should enforce max limit of 75 when smart filter returns more than 75 URLs', async () => {
+      const mockUrls = createMockUrls(100);
+      const mockFilteredUrls = Array.from(
+        { length: 90 },
+        (_, i) => `https://example.com/page-${i + 1}`
+      );
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockResolvedValue(mockFilteredUrls);
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(75);
+      expect(result).toEqual(mockFilteredUrls.slice(0, 75));
+    });
+
+    it('should enforce max limit of 75 when smart filter fails and falls back', async () => {
+      const mockUrls = createMockUrls(398); // Simulate the reported bug scenario
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockRejectedValue(
+        new Error('Smart filter failed')
+      );
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(75);
+      expect(result[0]).toBe('https://example.com/page-1');
+      expect(result[74]).toBe('https://example.com/page-75');
+    });
+
+    it('should enforce max limit of 75 when smart filter throws exception', async () => {
+      const mockUrls = createMockUrls(200);
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(75);
+    });
+
+    it('should return all URLs when count is below minimum (45)', async () => {
+      const mockUrls = createMockUrls(30);
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(30);
+      expect(smartUrlFilterAgent.execute).not.toHaveBeenCalled();
+    });
+
+    it('should enforce min limit of 45 when smart filter returns fewer URLs', async () => {
+      const mockUrls = createMockUrls(100);
+      const mockFilteredUrls = Array.from(
+        { length: 30 },
+        (_, i) => `https://example.com/page-${i + 1}`
+      );
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockResolvedValue(mockFilteredUrls);
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      // Should fall back to all input URLs when LLM returns fewer than minimum, but still respect max limit
+      expect(result).toHaveLength(75);
+      expect(result).toEqual(mockUrls.slice(0, 75).map((u) => u.url));
+    });
+
+    it('should return URLs within range when smart filter works correctly', async () => {
+      const mockUrls = createMockUrls(100);
+      const mockFilteredUrls = Array.from(
+        { length: 60 },
+        (_, i) => `https://example.com/page-${i + 1}`
+      );
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockResolvedValue(mockFilteredUrls);
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(60);
+      expect(result).toEqual(mockFilteredUrls);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle exactly 45 URLs without invoking smart filter', async () => {
+      const mockUrls = createMockUrls(45);
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(45);
+      expect(smartUrlFilterAgent.execute).not.toHaveBeenCalled();
+    });
+
+    it('should handle exactly 75 URLs with smart filter', async () => {
+      const mockUrls = createMockUrls(75);
+      const mockFilteredUrls = mockUrls.map((u) => u.url);
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockResolvedValue(mockFilteredUrls);
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(75);
+      expect(smartUrlFilterAgent.execute).toHaveBeenCalled();
+    });
+
+    it('should handle exactly 76 URLs and ensure max limit is enforced on error', async () => {
+      const mockUrls = createMockUrls(76);
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockRejectedValue(new Error('Failed'));
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(75);
+    });
+  });
+
+  describe('Regression test for 398 pages bug', () => {
+    it('should never return more than 75 URLs even when smart filter fails with 398 input URLs', async () => {
+      const mockUrls = createMockUrls(398);
+
+      (smartUrlFilterAgent.execute as jest.Mock).mockRejectedValue(
+        new Error('Smart filter agent error')
+      );
+
+      const result = await SiteScrapeService.smartFilterSiteMap(mockUrls, 'lead_site');
+
+      expect(result).toHaveLength(75);
+      expect(result.length).toBeLessThanOrEqual(75);
+    });
+  });
+});

--- a/server/src/modules/ai/siteScrape.service.ts
+++ b/server/src/modules/ai/siteScrape.service.ts
@@ -80,14 +80,23 @@ export const SiteScrapeService = {
     } catch (error) {
       const executionTimeMs = Date.now() - startTime;
 
-      logger.error('Failed to smart filter site map, falling back to all URLs', {
+      logger.error('Failed to smart filter site map, falling back to URLs with max limit', {
         error,
         siteMapLength: siteMap.length,
         executionTimeMs,
       });
 
-      // Fallback: return all URLs
-      return siteMap.map((url) => url.url);
+      // Fallback: return all URLs but enforce max limit
+      const fallbackUrls = siteMap.map((url) => url.url).slice(0, maxUrls);
+
+      logger.info('Applied max limit to fallback URLs after smart filter error', {
+        originalCount: siteMap.length,
+        limitedCount: fallbackUrls.length,
+        maxUrls,
+        executionTimeMs,
+      });
+
+      return fallbackUrls;
     }
   },
 

--- a/server/src/workers/lead-initial-processing/lead-initial-processing.worker.ts
+++ b/server/src/workers/lead-initial-processing/lead-initial-processing.worker.ts
@@ -167,12 +167,25 @@ async function processLeadInitialProcessing(
         smartFilteredCount: smartFilteredUrls.length,
       });
     } catch (error) {
-      logger.warn('[LeadInitialProcessingWorker] Smart filter failed, using basic filtered URLs', {
+      logger.warn(
+        '[LeadInitialProcessingWorker] Smart filter failed, using basic filtered URLs with max limit',
+        {
+          jobId: job.id,
+          leadId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          basicFilteredCount: basicFilteredUrls.length,
+        }
+      );
+      // Fallback to basic filtered URLs but enforce max limit of 75
+      const maxUrls = 75;
+      smartFilteredUrls = basicFilteredUrls.map((url) => url.url).slice(0, maxUrls);
+      logger.info('[LeadInitialProcessingWorker] Applied max limit to fallback URLs', {
         jobId: job.id,
         leadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        originalCount: basicFilteredUrls.length,
+        limitedCount: smartFilteredUrls.length,
+        maxUrls,
       });
-      smartFilteredUrls = basicFilteredUrls.map((url) => url.url);
     }
 
     // Update status to syncing site


### PR DESCRIPTION
Enforce the 75-page maximum limit for site scraping when the smart filter fails or returns an excessive number of URLs.

The smart filter previously had a bug where, upon failure, it would fall back to all basic filtered URLs without applying the configured 75-page limit. This resulted in cases like 398 pages being submitted for scraping, exceeding the intended maximum. This PR fixes this by ensuring the limit is always applied, even in fallback scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddab2e1e-83d8-4580-b23e-46364162757a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddab2e1e-83d8-4580-b23e-46364162757a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

