### PR TITLE
feat: add Supabase SAML SSO bootstrap with JIT provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,10 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 landing/.vite/**
+
+# Local Supabase full-stack runtime data
+server/docker/supabase/.env
+server/docker/supabase/volumes/db/data/
+server/docker/supabase/volumes/storage/
+server/docker/supabase/volumes/snippets/
+server/docker/supabase/volumes/functions/

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -2,7 +2,11 @@ import { createContext, useContext, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { Session } from '@supabase/supabase-js'
 import { authService } from '../services/auth.service'
-import type { AuthUser } from '../services/auth.service'
+import type {
+  AuthUser,
+  SsoBootstrapResult,
+  SsoRegisterResult,
+} from '../services/auth.service'
 import { useQueryClient } from '@tanstack/react-query'
 
 interface AuthContextType {
@@ -10,12 +14,19 @@ interface AuthContextType {
   session: Session | null
   loading: boolean
   login: (email: string, password: string) => Promise<void>
+  startSsoLogin: () => Promise<void>
+  bootstrapSsoSession: () => Promise<SsoBootstrapResult>
   register: (data: {
     email: string
     password: string
     name: string
     tenantName: string
+    enableSsoDomainMapping?: boolean
   }) => Promise<void>
+  completeSsoRegistration: (data: {
+    name: string
+    tenantName: string
+  }) => Promise<SsoRegisterResult>
   logout: () => Promise<void>
   refreshUser: () => Promise<void>
 }
@@ -55,11 +66,36 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }
 
+  const startSsoLogin = async () => {
+    setLoading(true)
+    try {
+      await authService.startSsoLogin()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const bootstrapSsoSession = async () => {
+    setLoading(true)
+    try {
+      const result = await authService.bootstrapSsoSession()
+      if (result.status === 'provisioned' || result.status === 'already_provisioned') {
+        const currentUser = await authService.getCurrentUser()
+        setUser(currentUser)
+      }
+
+      return result
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const register = async (data: {
     email: string
     password: string
     name: string
     tenantName: string
+    enableSsoDomainMapping?: boolean
   }) => {
     try {
       setLoading(true)
@@ -72,6 +108,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     } catch (error) {
       console.error('Registration failed:', error)
       throw error
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const completeSsoRegistration = async (data: {
+    name: string
+    tenantName: string
+  }) => {
+    setLoading(true)
+    try {
+      const result = await authService.completeSsoRegistration(data)
+      const currentUser = await authService.getCurrentUser()
+      setUser(currentUser)
+      return result
     } finally {
       setLoading(false)
     }
@@ -106,8 +157,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       setSession(sessionChange)
 
-      if (sessionChange && event === 'SIGNED_IN') {
-        // User signed in, fetch user data from backend
+      if (sessionChange) {
         try {
           const currentUser = await authService.getCurrentUser(sessionChange)
           if (isMounted) {
@@ -142,7 +192,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     session,
     loading,
     login,
+    startSsoLogin,
+    bootstrapSsoSession,
     register,
+    completeSsoRegistration,
     logout,
     refreshUser,
   }

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -14,7 +14,7 @@ interface AuthContextType {
   session: Session | null
   loading: boolean
   login: (email: string, password: string) => Promise<void>
-  startSsoLogin: () => Promise<void>
+  startSsoLogin: (options: { email?: string; domain?: string }) => Promise<void>
   bootstrapSsoSession: () => Promise<SsoBootstrapResult>
   register: (data: {
     email: string
@@ -66,13 +66,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }
 
-  const startSsoLogin = async () => {
-    setLoading(true)
-    try {
-      await authService.startSsoLogin()
-    } finally {
-      setLoading(false)
-    }
+  const startSsoLogin = async (options: { email?: string; domain?: string }) => {
+    await authService.startSsoLogin(options)
   }
 
   const bootstrapSsoSession = async () => {

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -88,6 +88,11 @@ export default function Login() {
         }
       }
 
+      if (!formData.password) {
+        setError('Please enter your password')
+        return
+      }
+
       await login(formData.email, formData.password)
       // Redirect will happen automatically via auth state change
       router.navigate({ to: '/' })

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -7,7 +7,7 @@ import Logo from '../../components/Logo'
 export default function Login() {
   const router = useRouter()
   const search = useSearch({ strict: false }) as any
-  const { login, loading } = useAuth()
+  const { login, startSsoLogin, loading } = useAuth()
   const showRegistrationSuccess = search?.registered === 'true'
   const [formData, setFormData] = useState({
     email: '',
@@ -15,6 +15,7 @@ export default function Login() {
   })
   const [error, setError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSsoSubmitting, setIsSsoSubmitting] = useState(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -51,6 +52,18 @@ export default function Login() {
       }
     } finally {
       setIsSubmitting(false)
+    }
+  }
+
+  const handleSsoLogin = async () => {
+    try {
+      setIsSsoSubmitting(true)
+      setError('')
+      await startSsoLogin()
+    } catch (ssoError: any) {
+      setError(ssoError?.message || 'Unable to start SSO login')
+    } finally {
+      setIsSsoSubmitting(false)
     }
   }
 
@@ -173,6 +186,31 @@ export default function Login() {
                 </>
               ) : (
                 'Sign in to dripIq'
+              )}
+            </button>
+
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="bg-white px-2 text-gray-500">or</span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleSsoLogin}
+              disabled={isSsoSubmitting}
+              className="w-full border border-gray-300 bg-white text-gray-800 py-3 px-4 rounded-xl text-sm font-semibold hover:bg-gray-50 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSsoSubmitting ? (
+                <>
+                  <Loader2 className="animate-spin -ml-1 mr-3 h-5 w-5 inline" />
+                  Redirecting to SSO...
+                </>
+              ) : (
+                'Continue with company SSO'
               )}
             </button>
           </form>

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -15,14 +15,45 @@ export default function Login() {
   })
   const [error, setError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isSsoSubmitting, setIsSsoSubmitting] = useState(false)
+  const [showPasswordField, setShowPasswordField] = useState(false)
+
+  const shouldFallbackToPassword = (ssoError: any) => {
+    const status = Number(ssoError?.status)
+    const code = String(ssoError?.code || '').toLowerCase()
+    const message = String(ssoError?.message || '').toLowerCase()
+
+    if (
+      status === 404 ||
+      code === 'sso_unavailable' ||
+      code === 'sso_not_found' ||
+      code === 'sso_provider_not_found'
+    ) {
+      return true
+    }
+
+    return (
+      message.includes('not configured') ||
+      message.includes('unable to initialize sso login redirect') ||
+      message.includes('identity provider') ||
+      message.includes('provider not found') ||
+      message.includes('no sso provider assigned for this domain') ||
+      message.includes('sso is not configured')
+    )
+  }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
+    const isEmailChange = name === 'email'
+    if (isEmailChange && showPasswordField) {
+      setShowPasswordField(false)
+    }
+
     setFormData((prev) => ({
       ...prev,
       [name]: value,
+      ...(isEmailChange && showPasswordField ? { password: '' } : {}),
     }))
+
     // Clear error when user starts typing
     if (error) setError('')
   }
@@ -30,14 +61,33 @@ export default function Login() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!formData.email || !formData.password) {
-      setError('Please fill in all fields')
+    if (!formData.email) {
+      setError('Please enter your email')
+      return
+    }
+
+    if (showPasswordField && !formData.password) {
+      setError('Please enter your password')
       return
     }
 
     try {
       setIsSubmitting(true)
       setError('')
+
+      if (!showPasswordField) {
+        try {
+          await startSsoLogin({ email: formData.email })
+          return
+        } catch (ssoError: any) {
+          if (shouldFallbackToPassword(ssoError)) {
+            setShowPasswordField(true)
+            return
+          }
+          throw ssoError
+        }
+      }
+
       await login(formData.email, formData.password)
       // Redirect will happen automatically via auth state change
       router.navigate({ to: '/' })
@@ -52,18 +102,6 @@ export default function Login() {
       }
     } finally {
       setIsSubmitting(false)
-    }
-  }
-
-  const handleSsoLogin = async () => {
-    try {
-      setIsSsoSubmitting(true)
-      setError('')
-      await startSsoLogin()
-    } catch (ssoError: any) {
-      setError(ssoError?.message || 'Unable to start SSO login')
-    } finally {
-      setIsSsoSubmitting(false)
     }
   }
 
@@ -146,26 +184,28 @@ export default function Login() {
                   disabled={isSubmitting}
                 />
               </div>
-              <div>
-                <label
-                  htmlFor="password"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  Password
-                </label>
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  autoComplete="current-password"
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent transition-all duration-200"
-                  placeholder="Enter your password"
-                  value={formData.password}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                />
-              </div>
+              {showPasswordField && (
+                <div>
+                  <label
+                    htmlFor="password"
+                    className="block text-sm font-medium text-gray-700 mb-2"
+                  >
+                    Password
+                  </label>
+                  <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    required
+                    className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent transition-all duration-200"
+                    placeholder="Enter your password"
+                    value={formData.password}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              )}
             </div>
 
             {error && (
@@ -182,35 +222,10 @@ export default function Login() {
               {isSubmitting ? (
                 <>
                   <Loader2 className="animate-spin -ml-1 mr-3 h-5 w-5 text-white inline" />
-                  Signing in...
+                  {showPasswordField ? 'Signing in...' : 'Checking sign-in options...'}
                 </>
               ) : (
-                'Sign in to dripIq'
-              )}
-            </button>
-
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-300" />
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="bg-white px-2 text-gray-500">or</span>
-              </div>
-            </div>
-
-            <button
-              type="button"
-              onClick={handleSsoLogin}
-              disabled={isSsoSubmitting}
-              className="w-full border border-gray-300 bg-white text-gray-800 py-3 px-4 rounded-xl text-sm font-semibold hover:bg-gray-50 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isSsoSubmitting ? (
-                <>
-                  <Loader2 className="animate-spin -ml-1 mr-3 h-5 w-5 inline" />
-                  Redirecting to SSO...
-                </>
-              ) : (
-                'Continue with company SSO'
+                showPasswordField ? 'Sign in to dripIq' : 'Continue'
               )}
             </button>
           </form>

--- a/client/src/pages/auth/Register.tsx
+++ b/client/src/pages/auth/Register.tsx
@@ -1,14 +1,22 @@
 import React, { useState } from 'react'
-import { useRouter } from '@tanstack/react-router'
+import { useRouter, useSearch } from '@tanstack/react-router'
 import { Loader2 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import Logo from '../../components/Logo'
 
 export default function Register() {
   const router = useRouter()
-  const { register, loading } = useAuth()
+  const search = useSearch({ strict: false }) as {
+    sso?: string
+    email?: string
+    domain?: string
+  }
+  const { register, completeSsoRegistration, loading } = useAuth()
+  const isSsoRegistration = search?.sso === 'true'
+  const ssoEmail = search?.email?.trim().toLowerCase() || ''
+  const ssoDomain = search?.domain?.trim().toLowerCase() || ''
   const [formData, setFormData] = useState({
-    email: '',
+    email: ssoEmail,
     password: '',
     confirmPassword: '',
     name: '',
@@ -30,19 +38,20 @@ export default function Register() {
   const validateForm = () => {
     if (
       !formData.email ||
-      !formData.password ||
       !formData.name ||
       !formData.tenantName
     ) {
       return 'Please fill in all fields'
     }
 
-    if (formData.password.length < 8) {
-      return 'Password must be at least 8 characters long'
-    }
+    if (!isSsoRegistration) {
+      if (formData.password.length < 8) {
+        return 'Password must be at least 8 characters long'
+      }
 
-    if (formData.password !== formData.confirmPassword) {
-      return 'Passwords do not match'
+      if (formData.password !== formData.confirmPassword) {
+        return 'Passwords do not match'
+      }
     }
 
     if (!/\S+@\S+\.\S+/.test(formData.email)) {
@@ -65,18 +74,31 @@ export default function Register() {
       setIsSubmitting(true)
       setError('')
 
-      const result = await register({
-        email: formData.email,
-        password: formData.password,
-        name: formData.name,
-        tenantName: formData.tenantName,
-      })
+      let result: unknown
+
+      if (isSsoRegistration) {
+        result = await completeSsoRegistration({
+          name: formData.name,
+          tenantName: formData.tenantName,
+        })
+      } else {
+        result = await register({
+          email: formData.email,
+          password: formData.password,
+          name: formData.name,
+          tenantName: formData.tenantName,
+        })
+      }
 
       // Registration was successful
       console.log('Registration successful:', result)
 
-      // Navigate to login page with confirmation flag
-      router.navigate({ to: '/auth/login', search: { registered: 'true' } })
+      if (isSsoRegistration) {
+        router.navigate({ to: '/' })
+      } else {
+        // Navigate to login page with confirmation flag
+        router.navigate({ to: '/auth/login', search: { registered: 'true' } })
+      }
     } catch (err: any) {
       console.error('Registration error:', err)
       setError(err.message || 'An error occurred during registration')
@@ -109,17 +131,24 @@ export default function Register() {
             </button>
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            Start your free trial
+            {isSsoRegistration ? 'Complete your SSO setup' : 'Start your free trial'}
           </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            Already have an account?{' '}
-            <button
-              onClick={() => router.navigate({ to: '/auth/login' } as any)}
-              className="font-medium text-[var(--color-primary-600)] hover:text-[var(--color-primary-500)] underline bg-transparent border-none cursor-pointer"
-            >
-              Sign in here
-            </button>
-          </p>
+          {isSsoRegistration ? (
+            <p className="mt-2 text-center text-sm text-gray-600">
+              Your organization domain <span className="font-semibold">{ssoDomain || 'unknown'}</span>{' '}
+              is not mapped yet. Finish registration to create your organization and domain mapping.
+            </p>
+          ) : (
+            <p className="mt-2 text-center text-sm text-gray-600">
+              Already have an account?{' '}
+              <button
+                onClick={() => router.navigate({ to: '/auth/login' } as any)}
+                className="font-medium text-[var(--color-primary-600)] hover:text-[var(--color-primary-500)] underline bg-transparent border-none cursor-pointer"
+              >
+                Sign in here
+              </button>
+            </p>
+          )}
         </div>
 
         <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-white/20">
@@ -142,7 +171,7 @@ export default function Register() {
                   placeholder="Enter your email"
                   value={formData.email}
                   onChange={handleChange}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || isSsoRegistration}
                 />
               </div>
 
@@ -187,47 +216,51 @@ export default function Register() {
                 />
               </div>
 
-              <div>
-                <label
-                  htmlFor="password"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  Password
-                </label>
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  autoComplete="new-password"
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent transition-all duration-200"
-                  placeholder="Enter your password (min 8 characters)"
-                  value={formData.password}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                />
-              </div>
+              {!isSsoRegistration && (
+                <>
+                  <div>
+                    <label
+                      htmlFor="password"
+                      className="block text-sm font-medium text-gray-700 mb-2"
+                    >
+                      Password
+                    </label>
+                    <input
+                      id="password"
+                      name="password"
+                      type="password"
+                      autoComplete="new-password"
+                      required
+                      className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent transition-all duration-200"
+                      placeholder="Enter your password (min 8 characters)"
+                      value={formData.password}
+                      onChange={handleChange}
+                      disabled={isSubmitting}
+                    />
+                  </div>
 
-              <div>
-                <label
-                  htmlFor="confirmPassword"
-                  className="block text-sm font-medium text-gray-700 mb-2"
-                >
-                  Confirm password
-                </label>
-                <input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent transition-all duration-200"
-                  placeholder="Re-enter your password"
-                  value={formData.confirmPassword}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                />
-              </div>
+                  <div>
+                    <label
+                      htmlFor="confirmPassword"
+                      className="block text-sm font-medium text-gray-700 mb-2"
+                    >
+                      Confirm password
+                    </label>
+                    <input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      autoComplete="new-password"
+                      required
+                      className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)] focus:border-transparent transition-all duration-200"
+                      placeholder="Re-enter your password"
+                      value={formData.confirmPassword}
+                      onChange={handleChange}
+                      disabled={isSubmitting}
+                    />
+                  </div>
+                </>
+              )}
             </div>
 
             {error && (
@@ -244,10 +277,10 @@ export default function Register() {
               {isSubmitting ? (
                 <>
                   <Loader2 className="animate-spin -ml-1 mr-3 h-5 w-5 text-white inline" />
-                  Creating account...
+                  {isSsoRegistration ? 'Completing setup...' : 'Creating account...'}
                 </>
               ) : (
-                'Start Free Trial'
+                isSsoRegistration ? 'Complete SSO Setup' : 'Start Free Trial'
               )}
             </button>
           </form>

--- a/client/src/pages/auth/SsoCallback.tsx
+++ b/client/src/pages/auth/SsoCallback.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from '@tanstack/react-router'
+import { Loader2 } from 'lucide-react'
+import { useAuth } from '../../contexts/AuthContext'
+
+export default function SsoCallback() {
+  const router = useRouter()
+  const { bootstrapSsoSession } = useAuth()
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let mounted = true
+
+    const handleSsoCallback = async () => {
+      try {
+        const result = await bootstrapSsoSession()
+        if (!mounted) return
+
+        if (result.status === 'requires_registration') {
+          router.navigate({
+            to: '/auth/register',
+            search: {
+              sso: 'true',
+              email: result.email,
+              domain: result.domain,
+            },
+          } as any)
+          return
+        }
+
+        if (result.status === 'linking_required') {
+          setError(result.message)
+          return
+        }
+
+        router.navigate({ to: '/' })
+      } catch (callbackError: any) {
+        if (!mounted) return
+        setError(callbackError?.message || 'Failed to complete SSO sign-in')
+      }
+    }
+
+    void handleSsoCallback()
+
+    return () => {
+      mounted = false
+    }
+  }, [bootstrapSsoSession, router])
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-md w-full rounded-xl border border-red-200 bg-red-50 p-6 text-center">
+          <h1 className="text-lg font-semibold text-red-900">SSO sign-in could not be completed</h1>
+          <p className="mt-2 text-sm text-red-700">{error}</p>
+          <button
+            type="button"
+            onClick={() => router.navigate({ to: '/auth/login' })}
+            className="mt-4 inline-flex items-center rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800"
+          >
+            Back to login
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="mx-auto h-8 w-8 animate-spin text-[var(--color-primary-600)]" />
+        <p className="mt-3 text-sm text-gray-600">Finalizing SSO sign-in...</p>
+      </div>
+    </div>
+  )
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -13,6 +13,7 @@ import Header from './components/Header'
 import { AuthGuard, PublicOnlyGuard } from './components/AuthGuard'
 import Login from './pages/auth/Login'
 import Register from './pages/auth/Register'
+import SsoCallback from './pages/auth/SsoCallback'
 import SetupPassword from './pages/auth/SetupPassword'
 import ConfirmationPage from './pages/auth/ConfirmationPage'
 import LeadsPage from './pages/LeadsPage'
@@ -147,6 +148,12 @@ const authRegisterRoute = createRoute({
   component: () => <Register />,
 })
 
+const authSsoCallbackRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/sso/callback',
+  component: () => <SsoCallback />,
+})
+
 const leadsRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: LEADS_URL,
@@ -248,7 +255,11 @@ const protectedRouteTree = protectedRoute.addChildren([
   settingsRouteTree,
 ])
 
-const authRouteTree = authRoute.addChildren([authLoginRoute, authRegisterRoute])
+const authRouteTree = authRoute.addChildren([
+  authLoginRoute,
+  authRegisterRoute,
+  authSsoCallbackRoute,
+])
 
 // Build the route tree
 const routeTree = rootRoute.addChildren([

--- a/client/src/services/auth.service.test.ts
+++ b/client/src/services/auth.service.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  getUserMock: vi.fn(),
+  signInWithSsoMock: vi.fn(),
+}))
+
+vi.mock('../lib/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: mocks.getSessionMock,
+      getUser: mocks.getUserMock,
+      signInWithSSO: mocks.signInWithSsoMock,
+      signInWithPassword: vi.fn(),
+      setSession: vi.fn(),
+      signOut: vi.fn(),
+      onAuthStateChange: vi.fn(),
+    },
+  },
+}))
+
+import { authService } from './auth.service'
+
+describe('authService SSO flows', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:8080')
+    vi.clearAllMocks()
+    mocks.getSessionMock.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'token_123',
+        },
+      },
+    })
+    mocks.getUserMock.mockResolvedValue({
+      data: { user: null },
+    })
+  })
+
+  it('returns requires_registration from bootstrap endpoint', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: 'requires_registration',
+        email: 'user@example.com',
+        domain: 'example.com',
+      }),
+    } as Response)
+
+    const result = await authService.bootstrapSsoSession()
+
+    expect(result.status).toBe('requires_registration')
+    const [url, options] = (global.fetch as any).mock.calls[0]
+    expect(url).toContain('/api/auth/sso/bootstrap')
+    expect(options).toEqual({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token_123',
+      },
+    })
+  })
+
+  it('returns linking_required for account conflict', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        status: 'linking_required',
+        message: 'Account linking required',
+        email: 'user@example.com',
+      }),
+    } as Response)
+
+    const result = await authService.bootstrapSsoSession()
+
+    expect(result.status).toBe('linking_required')
+  })
+
+  it('completes SSO registration', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: 'registered',
+        message: 'SSO registration completed successfully',
+        user: {
+          id: 'user_1',
+          email: 'user@example.com',
+          name: 'First User',
+        },
+        tenant: {
+          id: 'tenant_1',
+          name: 'example-org',
+        },
+      }),
+    } as Response)
+
+    const result = await authService.completeSsoRegistration({
+      name: 'First User',
+      tenantName: 'Example Org',
+    })
+
+    expect(result.status).toBe('registered')
+    const [url, options] = (global.fetch as any).mock.calls[0]
+    expect(url).toContain('/api/auth/sso/register')
+    expect(options).toEqual({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token_123',
+      },
+      body: JSON.stringify({
+        name: 'First User',
+        tenantName: 'Example Org',
+      }),
+    })
+  })
+})

--- a/client/src/services/auth.service.test.ts
+++ b/client/src/services/auth.service.test.ts
@@ -118,4 +118,47 @@ describe('authService SSO flows', () => {
       }),
     })
   })
+
+  it('starts SSO using explicit domain', async () => {
+    mocks.signInWithSsoMock.mockResolvedValue({
+      data: { url: 'https://sso.example.com/start' },
+      error: null,
+    })
+
+    const redirectSpy = vi
+      .spyOn(authService as any, 'redirectTo')
+      .mockImplementation(() => {})
+    await authService.startSsoLogin({ domain: 'company.com' })
+
+    expect(mocks.signInWithSsoMock).toHaveBeenCalledWith({
+      domain: 'company.com',
+      options: { redirectTo: 'http://localhost:3000/auth/sso/callback' },
+    })
+    expect(redirectSpy).toHaveBeenCalledWith('https://sso.example.com/start')
+  })
+
+  it('starts SSO using email-derived domain', async () => {
+    mocks.signInWithSsoMock.mockResolvedValue({
+      data: { url: 'https://sso.example.com/domain' },
+      error: null,
+    })
+
+    const redirectSpy = vi
+      .spyOn(authService as any, 'redirectTo')
+      .mockImplementation(() => {})
+    await authService.startSsoLogin({ email: 'owner@company.com' })
+
+    expect(mocks.signInWithSsoMock).toHaveBeenCalledWith({
+      domain: 'company.com',
+      options: { redirectTo: 'http://localhost:3000/auth/sso/callback' },
+    })
+    expect(redirectSpy).toHaveBeenCalledWith('https://sso.example.com/domain')
+  })
+
+  it('throws when no domain can be resolved', async () => {
+    await expect(authService.startSsoLogin({})).rejects.toMatchObject({
+      message: 'Enter your work email to discover your company SSO provider.',
+      code: 'sso_domain_required',
+    })
+  })
 })

--- a/client/src/services/auth.service.ts
+++ b/client/src/services/auth.service.ts
@@ -46,11 +46,56 @@ export interface RegisterData {
   password: string
   name: string
   tenantName: string
+  enableSsoDomainMapping?: boolean
 }
 
 export interface LoginData {
   email: string
   password: string
+}
+
+export interface SsoBootstrapProvisioned {
+  status: 'provisioned' | 'already_provisioned'
+  user: {
+    id: string
+    email: string
+    name: string | null
+  }
+  tenant: {
+    id: string
+    name: string
+  }
+}
+
+export interface SsoBootstrapRequiresRegistration {
+  status: 'requires_registration'
+  email: string
+  domain: string
+}
+
+export interface SsoBootstrapLinkingRequired {
+  status: 'linking_required'
+  message: string
+  email: string
+}
+
+export type SsoBootstrapResult =
+  | SsoBootstrapProvisioned
+  | SsoBootstrapRequiresRegistration
+  | SsoBootstrapLinkingRequired
+
+export interface SsoRegisterResult {
+  status: 'registered'
+  message: string
+  user: {
+    id: string
+    email: string
+    name: string | null
+  }
+  tenant: {
+    id: string
+    name: string
+  }
 }
 
 class AuthService {
@@ -86,6 +131,28 @@ class AuthService {
     return authData
   }
 
+  async startSsoLogin() {
+    const providerId = import.meta.env.VITE_SUPABASE_SSO_PROVIDER_ID
+
+    if (!providerId) {
+      throw new Error('SSO is not configured for this environment')
+    }
+
+    const redirectTo = `${window.location.origin}/auth/sso/callback`
+    const { data, error } = await supabase.auth.signInWithSSO({
+      providerId,
+      options: { redirectTo },
+    })
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    if (data?.url) {
+      window.location.assign(data.url)
+    }
+  }
+
   // Register with backend (handles both Supabase and backend user creation)
   async register(data: RegisterData) {
     const response = await fetch(`${this.baseUrl}/auth/register`, {
@@ -109,6 +176,66 @@ class AuthService {
       if (error) {
         console.error('Error setting session after registration:', error)
       }
+    }
+
+    return result
+  }
+
+  async bootstrapSsoSession(session?: Session | null): Promise<SsoBootstrapResult> {
+    if (!session) {
+      session = await this.getCurrentSession()
+    }
+
+    if (!session?.access_token) {
+      throw new Error('No active SSO session found')
+    }
+
+    const response = await fetch(`${this.baseUrl}/auth/sso/bootstrap`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    })
+
+    const result = await response.json()
+
+    if (response.status === 409 && result?.status === 'linking_required') {
+      return result
+    }
+
+    if (!response.ok) {
+      throw new Error(result?.message || 'Failed to bootstrap SSO session')
+    }
+
+    return result
+  }
+
+  async completeSsoRegistration(
+    data: { name: string; tenantName: string },
+    session?: Session | null,
+  ): Promise<SsoRegisterResult> {
+    if (!session) {
+      session = await this.getCurrentSession()
+    }
+
+    if (!session?.access_token) {
+      throw new Error('No active SSO session found')
+    }
+
+    const response = await fetch(`${this.baseUrl}/auth/sso/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify(data),
+    })
+
+    const result = await response.json()
+
+    if (!response.ok) {
+      throw new Error(result?.message || 'Failed to complete SSO registration')
     }
 
     return result

--- a/client/src/services/auth.service.ts
+++ b/client/src/services/auth.service.ts
@@ -54,6 +54,11 @@ export interface LoginData {
   password: string
 }
 
+export interface StartSsoLoginOptions {
+  email?: string
+  domain?: string
+}
+
 export interface SsoBootstrapProvisioned {
   status: 'provisioned' | 'already_provisioned'
   user: {
@@ -100,6 +105,34 @@ export interface SsoRegisterResult {
 
 class AuthService {
   private baseUrl = import.meta.env.VITE_API_BASE_URL + '/api'
+  private redirectTo(url: string) {
+    window.location.assign(url)
+  }
+
+  private createAuthError(message: string, metadata?: Record<string, unknown>) {
+    const error = new Error(message) as Error & Record<string, unknown>
+    if (metadata) {
+      Object.assign(error, metadata)
+    }
+    return error
+  }
+
+  private resolveSsoDomain(options?: StartSsoLoginOptions) {
+    const providedDomain = options?.domain?.trim().toLowerCase()
+    if (providedDomain) {
+      return providedDomain
+    }
+
+    const emailDomain = options?.email?.split('@')?.[1]?.trim().toLowerCase()
+    if (emailDomain) {
+      return emailDomain
+    }
+
+    throw this.createAuthError(
+      'Enter your work email to discover your company SSO provider.',
+      { code: 'sso_domain_required' },
+    )
+  }
 
   // Get current Supabase session
   async getCurrentSession(): Promise<Session | null> {
@@ -131,26 +164,30 @@ class AuthService {
     return authData
   }
 
-  async startSsoLogin() {
-    const providerId = import.meta.env.VITE_SUPABASE_SSO_PROVIDER_ID
-
-    if (!providerId) {
-      throw new Error('SSO is not configured for this environment')
-    }
+  async startSsoLogin(options?: StartSsoLoginOptions) {
+    const resolvedDomain = this.resolveSsoDomain(options)
 
     const redirectTo = `${window.location.origin}/auth/sso/callback`
     const { data, error } = await supabase.auth.signInWithSSO({
-      providerId,
+      domain: resolvedDomain,
       options: { redirectTo },
     })
 
     if (error) {
-      throw new Error(error.message)
+      throw this.createAuthError(error.message, {
+        code: (error as any).code,
+        status: (error as any).status,
+      })
     }
 
     if (data?.url) {
-      window.location.assign(data.url)
+      this.redirectTo(data.url)
+      return
     }
+
+    throw this.createAuthError('Unable to initialize SSO login redirect', {
+      code: 'sso_unavailable',
+    })
   }
 
   // Register with backend (handles both Supabase and backend user creation)

--- a/docs/saml2o.txt
+++ b/docs/saml2o.txt
@@ -1,0 +1,9 @@
+
+Name	Value
+EntityID	https://wflzjydlmlvvluzjjohw.supabase.co/auth/v1/sso/saml/metadata
+Metadata URL	https://wflzjydlmlvvluzjjohw.supabase.co/auth/v1/sso/saml/metadata
+Metadata URL
+(download)	https://wflzjydlmlvvluzjjohw.supabase.co/auth/v1/sso/saml/metadata?download=true
+ACS URL	https://wflzjydlmlvvluzjjohw.supabase.co/auth/v1/sso/saml/acs
+SLO URL	https://wflzjydlmlvvluzjjohw.supabase.co/auth/v1/sso/slo
+NameID	Required emailAddress or persistent

--- a/docs/sso-customer-onboarding.md
+++ b/docs/sso-customer-onboarding.md
@@ -1,0 +1,136 @@
+# Multi-Customer SSO Onboarding (Supabase + DripIQ)
+
+This guide explains how to onboard each enterprise customer with their own SAML SSO configuration while routing users to the correct DripIQ tenant.
+
+## What Was Configured Now
+
+Using the Supabase MCP plugin against project `wflzjydlmlvvluzjjohw` (`dripiq`), we mapped `dripiq.ai` to the existing `dripiq` tenant:
+
+- Tenant: `dripiq_app.tenants.id = f47qpva1z342424trqxiekca` (`name = dripiq`)
+- Domain mapping: `dripiq_app.tenant_domain_mappings.domain = dripiq.ai`
+
+SQL used:
+
+```sql
+insert into dripiq_app.tenant_domain_mappings (id, tenant_id, domain, is_verified, created_at, updated_at)
+values ('map_dripiq_ai', 'f47qpva1z342424trqxiekca', 'dripiq.ai', true, now(), now())
+on conflict (domain) do update
+set tenant_id = excluded.tenant_id,
+    is_verified = excluded.is_verified,
+    updated_at = now();
+```
+
+Then, using Supabase CLI, we created the SAML provider and verified it:
+
+```bash
+supabase sso add --type saml --project-ref wflzjydlmlvvluzjjohw \
+  --metadata-url 'https://trial-8824406.okta.com/app/exk12bo3bwlp0r91S698/sso/saml/metadata' \
+  --domains dripiq.ai
+```
+
+Provider created:
+
+- `sso_provider_id`: `98c1646f-319e-4e19-9e86-b7574a315b17`
+- `entity_id`: `http://www.okta.com/exk12bo3bwlp0r91S698`
+- domain assigned: `dripiq.ai`
+
+Verification commands:
+
+```bash
+supabase sso list --project-ref wflzjydlmlvvluzjjohw -o json
+supabase sso show 98c1646f-319e-4e19-9e86-b7574a315b17 --project-ref wflzjydlmlvvluzjjohw -o json
+supabase sso info --project-ref wflzjydlmlvvluzjjohw -o json
+```
+
+## Architecture (Per Customer)
+
+For each customer, configure two layers:
+
+1. Supabase Auth SAML provider for that customer IdP.
+2. DripIQ tenant-domain mapping (`tenant_domain_mappings`) so SSO bootstrap can auto-provision into the right tenant.
+
+## Onboarding Checklist Per Customer
+
+### 1) Create or identify the customer tenant
+
+Ensure one `dripiq_app.tenants` row exists for the customer.
+
+### 2) Add domain -> tenant mapping
+
+Insert one row in `dripiq_app.tenant_domain_mappings` per customer domain.
+
+Template:
+
+```sql
+insert into dripiq_app.tenant_domain_mappings (id, tenant_id, domain, is_verified, created_at, updated_at)
+values ('map_<customer_domain>', '<tenant_id>', '<customer_domain>', true, now(), now())
+on conflict (domain) do update
+set tenant_id = excluded.tenant_id,
+    is_verified = excluded.is_verified,
+    updated_at = now();
+```
+
+Example:
+
+- domain: `customer1.com`
+- tenant_id: `<their tenant id>`
+
+### 3) Add the customer SAML provider in Supabase
+
+Use the customer metadata URL (or metadata file) to create a SAML connection in Supabase Auth.
+
+For the Okta example metadata URL:
+
+- `https://trial-8824406.okta.com/app/exk12bo3bwlp0r91S698/sso/saml/metadata`
+
+#### Option A: Supabase CLI
+
+```bash
+supabase sso add --type saml --project-ref wflzjydlmlvvluzjjohw \
+  --metadata-url 'https://trial-8824406.okta.com/app/exk12bo3bwlp0r91S698/sso/saml/metadata' \
+  --domains dripiq.ai
+```
+
+Use these commands to inspect or update providers:
+
+```bash
+supabase sso list --project-ref wflzjydlmlvvluzjjohw
+supabase sso show <provider-id> --project-ref wflzjydlmlvvluzjjohw
+supabase sso update <provider-id> --project-ref wflzjydlmlvvluzjjohw --metadata-url '<new-url>'
+```
+
+#### Option B: Supabase Dashboard
+
+1. Open project Auth providers.
+2. Enable SAML.
+3. Add provider metadata URL or upload metadata XML.
+4. Assign customer domain(s), for example `dripiq.ai`.
+5. Save and test.
+
+### 4) Ensure your app flow matches login mode
+
+Current app supports callback bootstrap flow and tenant provisioning.
+
+The login path now uses domain-based discovery for multi-customer routing:
+
+- `signInWithSSO({ domain: 'customer-domain.com' })`
+
+If using pure IdP-initiated tiles, domain assignment is optional for routing from IdP, but you still need `tenant_domain_mappings` for app provisioning.
+
+### 5) Verify end-to-end
+
+1. Login via customer IdP.
+2. Confirm `/auth/sso/bootstrap` returns:
+   - `provisioned` or `already_provisioned` when domain is mapped.
+   - `requires_registration` when domain is not mapped.
+3. Confirm `users` + `user_tenants` rows exist and tenant is correct.
+
+## Multi-Customer Operating Model
+
+- One SAML provider per customer IdP configuration.
+- One or more domains per provider as needed.
+- One tenant per customer in `dripiq_app.tenants`.
+- One domain mapping per customer domain in `dripiq_app.tenant_domain_mappings`.
+
+This scales cleanly to 10+ customers as long as each customer domain is uniquely mapped.
+

--- a/mermaid.md
+++ b/mermaid.md
@@ -1,0 +1,236 @@
+# DripIQ System Network Diagram
+
+## Customer-facing overview (compliance / sharing)
+
+Simplified network diagram: nodes and paths only (no product features). Suitable for sharing with prospects and customers.
+
+```mermaid
+flowchart LR
+  Users["End users"]
+  App["DripIQ\nweb app"]
+  Servers["DripIQ\nservers"]
+  Vendors["Third-party\nvendors"]
+
+  Users <-->|HTTPS| App
+  App -->|API| Servers
+  Servers <-->|APIs, webhooks| Vendors
+```
+
+| Network path | Description |
+|--------------|-------------|
+| **End users ↔ DripIQ web app** | User traffic over HTTPS (browser to our application). |
+| **DripIQ web app → DripIQ servers** | API requests from the app to our backend. |
+| **DripIQ servers ↔ Third-party vendors** | Outbound calls from our servers to vendors (e.g. auth, email, AI); vendors may call back (e.g. webhooks). |
+
+---
+
+## Internal architecture (technical)
+
+High-level architecture of the monorepo: client, landing, server (API + workers), data stores, and external services.
+
+```mermaid
+flowchart TB
+  subgraph users["Users"]
+    Browser["Browser"]
+  end
+
+  subgraph apps["Applications"]
+    Client["Client (React + Vite)\nport 3000"]
+    Landing["Landing (React + Vite)\nport 3001\nSEO / marketing"]
+    Server["Server (Fastify)\nport 3001\nREST API"]
+  end
+
+  subgraph workers["Background Workers"]
+    W1["lead-initial-processing\nworker"]
+    W2["lead-analysis\nworker"]
+    W3["campaign-creation\nworker"]
+    W4["campaign-execution\nworker"]
+  end
+
+  subgraph queues["BullMQ Queues (Redis)"]
+    Q1["lead_initial_processing"]
+    Q2["lead_analysis"]
+    Q3["campaign_creation"]
+    Q4["campaign_execution"]
+  end
+
+  subgraph data["Data & Storage"]
+    Postgres[("Postgres\n(Drizzle ORM)")]
+    Redis[("Redis")]
+  end
+
+  subgraph auth["Auth & Identity"]
+    Supabase["Supabase\n(Auth + Admin API)"]
+  end
+
+  subgraph external["External Services"]
+    Firecrawl["Firecrawl\n(scrape + webhook)"]
+    OpenAI["OpenAI / LangChain\n(embeddings, agents)"]
+    Langfuse["Langfuse\n(tracing)"]
+    EmailVerify["EmailListVerify\n(email validation)"]
+    Gmail["Gmail API"]
+    Outlook["Microsoft Graph\n(Outlook)"]
+    Coresignal["Coresignal\n(web data)"]
+  end
+
+  Browser --> Client
+  Browser --> Landing
+  Client -->|"fetch /api/*\nJWT"| Server
+  Client -->|"auth (session,\nsign in/out)"| Supabase
+
+  Server -->|"read/write"| Postgres
+  Server -->|"enqueue jobs"| Redis
+  Server -->|"admin auth,\ninvite users"| Supabase
+  Server -->|"webhook"| Firecrawl
+  Server -->|"send mail"| Gmail
+  Server -->|"send mail"| Outlook
+  Server -->|"scrape, embed,\ncontact extraction"| OpenAI
+  Server -->|"tracing"| Langfuse
+  Server -->|"validate email"| EmailVerify
+  Server -->|"company/employee data"| Coresignal
+
+  Firecrawl -.->|"webhook POST"| Server
+
+  W1 -->|"consume"| Q1
+  W2 -->|"consume"| Q2
+  W3 -->|"consume"| Q3
+  W4 -->|"consume"| Q4
+  Redis --> Q1 & Q2 & Q3 & Q4
+
+  W1 -->|"read/write"| Postgres
+  W2 -->|"read/write"| Postgres
+  W3 -->|"read/write"| Postgres
+  W4 -->|"read/write"| Postgres
+  W1 -->|"enqueue"| Q2
+  W1 -->|"Firecrawl scrape"| Firecrawl
+  W2 -->|"LangChain / embeddings"| OpenAI
+  W4 -->|"send mail"| Gmail
+  W4 -->|"send mail"| Outlook
+
+  W1 & W2 & W3 & W4 --> Redis
+```
+
+## Queue flow (worker pipeline)
+
+```mermaid
+flowchart LR
+  subgraph ingress["API / triggers"]
+    LeadCreate["Lead create/batch\nResync"]
+    CampaignTrigger["Campaign run"]
+  end
+
+  subgraph q["Queues"]
+    A[lead_initial_processing]
+    B[lead_analysis]
+    C[campaign_creation]
+    D[campaign_execution]
+  end
+
+  LeadCreate --> A
+  A -->|"on complete"| B
+  CampaignTrigger --> C
+  C --> D
+  D -->|"timeout jobs"| D
+```
+
+## API surface (server routes)
+
+| Area | Routes prefix / purpose |
+|------|-------------------------|
+| Auth | `/api/auth/*` (register, login, me, verify-otp, logout) |
+| Users & invites | `/api/users/*`, `/api/invites`, `/api/me/*` |
+| Leads | `/api/leads/*` (CRUD, batch, assign-owner, contacts, analyze, products) |
+| Contacts | `/api/contacts/*`, `/api/bulk-contacts` |
+| Organization | `/api/organizations/*` |
+| Products | `/api/products/*` |
+| Dashboard | `/api/dashboard` |
+| Roles | `/api/roles/*` |
+| Calendar | `/api/calendar/*` |
+| Logo | `/api/logo/upload` |
+| Webhooks | `/api/firecrawl/*` |
+| Third-party auth | `/api/third-party-auth/*` (Google, Microsoft) |
+| Email validation | `/api/email-validation/*` |
+| Unsubscribe | `/api/unsubscribe/*` |
+| Debug / admin | `/api/debug/*`, Bull Board (queues UI) |
+
+## Package dependency summary
+
+| Package | Deps (conceptual) |
+|---------|-------------------|
+| **client** | Server API (fetch), Supabase Auth, TanStack Router/Query |
+| **landing** | Standalone; TanStack Router |
+| **server** | Postgres, Redis, Supabase, Firecrawl, LangChain/OpenAI, Langfuse, EmailListVerify, Gmail, Microsoft Graph, Coresignal |
+
+---
+
+## Third-party vendors: description and interactions
+
+This section describes each integrated vendor and how they interact with DripIQ and with each other.
+
+### Auth and identity
+
+**Supabase**  
+Provides authentication (sessions, sign-in/sign-out), the primary Postgres database, and object storage. The client talks to Supabase for login/logout and session handling; the server uses the Supabase Admin API for invite flows, user management, and storage (e.g. logos, site assets). All app and worker flows that need “who is this user?” or “where do we store this?” ultimately depend on Supabase.
+
+**Google (OAuth + Gmail API)**  
+Users can sign in with Google and connect Gmail for sending/receiving. The server initiates the OAuth flow and stores tokens; it then uses the Gmail API to send campaign emails and (where used) read calendar/email. Interaction is server → Google only; no webhooks from Google into DripIQ.
+
+**Microsoft (OAuth + Microsoft Graph)**  
+Same pattern as Google: sign-in with Microsoft and connect Outlook/calendar. The server uses Microsoft Graph to send mail and access calendar. Again, server → Microsoft only.
+
+*How they interact:* Supabase is the single source of auth and identity. Google and Microsoft are optional “connect your inbox” providers; the server chooses Gmail or Microsoft Graph per tenant/campaign when sending email.
+
+---
+
+### Email delivery and validation
+
+**EmailListVerify**  
+Dedicated email validation API. The server calls it to verify that an address is deliverable and not risky. Used in contact/lead flows before adding contacts or sending; no callback into DripIQ.
+
+*How they interact:* EmailListVerify is used for "is this email valid?" Email is sent via Gmail or Microsoft Graph when the user has connected their own inbox.
+
+---
+
+### AI and observability
+
+**OpenAI (via LangChain)**  
+Used for embeddings, agents, contact extraction from scraped content, lead and organization analysis, and related AI features. The server and workers (especially lead-initial-processing and lead-analysis) call the OpenAI API through LangChain. No webhooks from OpenAI.
+
+**Langfuse**  
+LLM observability and tracing. The server sends traces (prompts, responses, token usage) to Langfuse so you can debug and tune prompts and monitor cost/quality. All OpenAI/LangChain usage can be traced there. One-way: server → Langfuse.
+
+*How they interact:* Every meaningful call to OpenAI is wrapped so that Langfuse receives the same request/response and metadata. No direct OpenAI ↔ Langfuse link; DripIQ is the bridge.
+
+---
+
+### Web scraping and web data
+
+**Firecrawl**  
+Web scraping and job orchestration. The server (or lead-initial-processing worker) requests a scrape; Firecrawl fetches and optionally processes the page, then POSTs results back to the server via webhook. That content is then used for embeddings, contact extraction, and lead analysis (which in turn use OpenAI).
+
+**CoreSignal**  
+Company and employee data (e.g. firmographics, org structure, contact info). The server calls CoreSignal when it needs enriched B2B data for leads or accounts. One-way: server → CoreSignal.
+
+*How they interact:* Firecrawl supplies raw or processed page content; CoreSignal supplies structured company/people data. Both feed into the same lead/contact model and can be used together in analysis and campaign logic. Firecrawl is the only one that calls back into DripIQ (webhook).
+
+---
+
+### Observability and deployment
+
+**Highlight**  
+Error and log observability. The server sends errors and structured logs (e.g. via Pino) to Highlight. Used for debugging and monitoring; one-way, and does not drive other vendors.
+
+**Render**  
+Hosting for the app and workers. CI triggers deploys via Render’s deploy URLs. Render runs the server and workers; it does not integrate with other vendors except insofar as the code it runs calls them.
+
+---
+
+### End-to-end flow example
+
+1. User signs in (Supabase) and creates a lead; client calls server API.
+2. Server enqueues **lead-initial-processing**. Worker asks **Firecrawl** to scrape the lead’s site; Firecrawl later POSTs back to the server (webhook).
+3. Server enqueues **lead-analysis**. Worker sends scraped content and optional **CoreSignal** data to **OpenAI** (LangChain) for embeddings and analysis; **Langfuse** records the trace.
+4. Contacts may be validated with **EmailListVerify** before saving.
+5. When a campaign runs, **campaign-execution** worker sends email via (**Gmail** / **Microsoft Graph** if the user connected an inbox).
+
+Throughout, **Supabase** backs auth and persistence, **Highlight** captures errors and logs, and **Render** runs the deployed app and workers.

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,411 @@
+name: dripiq-local
+
+services:
+  studio:
+    image: supabase/studio:2026.04.08-sha-205cbe7
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://localhost:3000/api/platform/profile').then((r) => {if (r.status !== 200) throw new Error(r.status)})\""
+        ]
+      timeout: 10s
+      interval: 5s
+      retries: 3
+    depends_on:
+      analytics:
+        condition: service_healthy
+    environment:
+      HOSTNAME: "0.0.0.0"
+      STUDIO_PG_META_URL: http://meta:8080
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      PG_META_CRYPTO_KEY: ${PG_META_CRYPTO_KEY:-your-encryption-key-32-chars-min}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,storage,graphql_public}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
+      DEFAULT_ORGANIZATION_NAME: ${STUDIO_DEFAULT_ORGANIZATION:-Default Organization}
+      DEFAULT_PROJECT_NAME: ${STUDIO_DEFAULT_PROJECT:-Default Project}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL:-http://localhost:8000}
+      SUPABASE_ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhYmUtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q}
+      AUTH_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN:-your-super-secret-and-long-logflare-key-public}
+      LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN:-your-super-secret-and-long-logflare-key-private}
+      LOGFLARE_URL: http://analytics:4000
+      NEXT_PUBLIC_ENABLE_LOGS: "true"
+      NEXT_ANALYTICS_BACKEND_PROVIDER: postgres
+      SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
+      EDGE_FUNCTIONS_MANAGEMENT_FOLDER: /app/edge-functions
+    volumes:
+      - ./docker/supabase/volumes/snippets:/app/snippets
+      - ./docker/supabase/volumes/functions:/app/edge-functions
+
+  kong:
+    image: kong/kong:3.9.1
+    restart: unless-stopped
+    networks:
+      default:
+        aliases:
+          - api-gw
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      studio:
+        condition: service_healthy
+    ports:
+      - ${KONG_HTTP_PORT:-8000}:8000/tcp
+      - ${KONG_HTTPS_PORT:-8443}:8443/tcp
+    volumes:
+      - ./docker/supabase/volumes/api/kong.yml:/home/kong/temp.yml:ro
+      - ./docker/supabase/volumes/api/kong-entrypoint.sh:/home/kong/kong-entrypoint.sh:ro
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_NOT_FOUND_TTL: 1
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth,request-termination,ip-restriction,post-function
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      KONG_PROXY_ACCESS_LOG: /dev/stdout combined
+      SUPABASE_ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhYmUtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q}
+      SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY:-}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:-}
+      ANON_KEY_ASYMMETRIC: ${ANON_KEY_ASYMMETRIC:-}
+      SERVICE_ROLE_KEY_ASYMMETRIC: ${SERVICE_ROLE_KEY_ASYMMETRIC:-}
+      DASHBOARD_USERNAME: ${DASHBOARD_USERNAME:-supabase}
+      DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD:-this_password_is_insecure_and_should_be_updated}
+    entrypoint: /home/kong/kong-entrypoint.sh
+
+  auth:
+    image: supabase/gotrue:v2.186.0
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9999/health"]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${API_EXTERNAL_URL:-http://localhost:8000}
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+      GOTRUE_SITE_URL: ${SITE_URL:-http://localhost:3000}
+      GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS:-}
+      GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP:-false}
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_EXP: ${JWT_EXPIRY:-3600}
+      GOTRUE_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: ${ENABLE_EMAIL_SIGNUP:-true}
+      GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: ${ENABLE_ANONYMOUS_USERS:-false}
+      GOTRUE_MAILER_AUTOCONFIRM: ${ENABLE_EMAIL_AUTOCONFIRM:-false}
+      GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL:-admin@example.com}
+      GOTRUE_SMTP_HOST: ${SMTP_HOST:-supabase-mail}
+      GOTRUE_SMTP_PORT: ${SMTP_PORT:-2500}
+      GOTRUE_SMTP_USER: ${SMTP_USER:-fake_mail_user}
+      GOTRUE_SMTP_PASS: ${SMTP_PASS:-fake_mail_password}
+      GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-fake_sender}
+      GOTRUE_MAILER_URLPATHS_INVITE: ${MAILER_URLPATHS_INVITE:-/auth/v1/verify}
+      GOTRUE_MAILER_URLPATHS_CONFIRMATION: ${MAILER_URLPATHS_CONFIRMATION:-/auth/v1/verify}
+      GOTRUE_MAILER_URLPATHS_RECOVERY: ${MAILER_URLPATHS_RECOVERY:-/auth/v1/verify}
+      GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: ${MAILER_URLPATHS_EMAIL_CHANGE:-/auth/v1/verify}
+      GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP:-true}
+      GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM:-true}
+
+  rest:
+    image: postgrest/postgrest:v14.8
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,storage,graphql_public}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY:-3600}
+
+  realtime:
+    image: supabase/realtime:v2.76.5
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sSfL --head -o /dev/null -H \"Authorization: Bearer ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhYmUtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE}\" http://localhost:4000/api/tenants/realtime-dev/health"
+        ]
+      timeout: 5s
+      interval: 30s
+      retries: 3
+      start_period: 10s
+    environment:
+      PORT: 4000
+      DB_HOST: ${POSTGRES_HOST:-db}
+      DB_PORT: ${POSTGRES_PORT:-5432}
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      DB_NAME: ${POSTGRES_DB:-postgres}
+      DB_AFTER_CONNECT_QUERY: "SET search_path TO _realtime"
+      DB_ENC_KEY: supabaserealtime
+      API_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq}
+      METRICS_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: "10000"
+      APP_NAME: realtime
+      SEED_SELF_HOST: "true"
+      RUN_JANITOR: "true"
+      DISABLE_HEALTHCHECK_LOGGING: "true"
+
+  storage:
+    image: supabase/storage-api:v1.48.26
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      rest:
+        condition: service_started
+      imgproxy:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://storage:5000/status"]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+      start_period: 10s
+    environment:
+      ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhYmUtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE}
+      SERVICE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q}
+      POSTGREST_URL: http://rest:3000
+      AUTH_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+      STORAGE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL:-http://localhost:8000}
+      REQUEST_ALLOW_X_FORWARDED_PATH: "true"
+      FILE_SIZE_LIMIT: 52428800
+      STORAGE_BACKEND: file
+      GLOBAL_S3_BUCKET: ${GLOBAL_S3_BUCKET:-stub}
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: ${STORAGE_TENANT_ID:-stub}
+      REGION: ${REGION:-stub}
+      ENABLE_IMAGE_TRANSFORMATION: "true"
+      IMGPROXY_URL: http://imgproxy:5001
+      S3_PROTOCOL_ACCESS_KEY_ID: ${S3_PROTOCOL_ACCESS_KEY_ID:-625729a08b95bf1b7ff351a663f3a23c}
+      S3_PROTOCOL_ACCESS_KEY_SECRET: ${S3_PROTOCOL_ACCESS_KEY_SECRET:-850181e4652dd023b7a98c58ae0d2d34bd487ee0cc3254aed6eda37307425907}
+    volumes:
+      - ./docker/supabase/volumes/storage:/var/lib/storage
+
+  imgproxy:
+    image: darthsim/imgproxy:v3.30.1
+    restart: unless-stopped
+    volumes:
+      - ./docker/supabase/volumes/storage:/var/lib/storage
+    healthcheck:
+      test: ["CMD", "imgproxy", "health"]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    environment:
+      IMGPROXY_BIND: ":5001"
+      IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
+      IMGPROXY_USE_ETAG: "true"
+      IMGPROXY_AUTO_WEBP: ${IMGPROXY_AUTO_WEBP:-true}
+      IMGPROXY_MAX_SRC_RESOLUTION: 16.8
+
+  meta:
+    image: supabase/postgres-meta:v0.96.3
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: ${POSTGRES_HOST:-db}
+      PG_META_DB_PORT: ${POSTGRES_PORT:-5432}
+      PG_META_DB_NAME: ${POSTGRES_DB:-postgres}
+      PG_META_DB_USER: supabase_admin
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      CRYPTO_KEY: ${PG_META_CRYPTO_KEY:-your-encryption-key-32-chars-min}
+
+  functions:
+    image: supabase/edge-runtime:v1.71.2
+    restart: unless-stopped
+    depends_on:
+      kong:
+        condition: service_healthy
+    volumes:
+      - ./docker/supabase/volumes/functions:/home/deno/functions
+      - deno-cache:/root/.cache/deno
+    environment:
+      JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL:-http://localhost:8000}
+      SUPABASE_ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhYmUtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE}
+      SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q}
+      SUPABASE_PUBLISHABLE_KEYS: "{\"default\":\"${SUPABASE_PUBLISHABLE_KEY:-}\"}"
+      SUPABASE_SECRET_KEYS: "{\"default\":\"${SUPABASE_SECRET_KEY:-}\"}"
+      SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
+      VERIFY_JWT: "${FUNCTIONS_VERIFY_JWT:-false}"
+    command: ["start", "--main-service", "/home/deno/functions/main"]
+
+  analytics:
+    image: supabase/logflare:1.36.1
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:4000/health"]
+      timeout: 5s
+      interval: 5s
+      retries: 10
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      LOGFLARE_NODE_HOST: 127.0.0.1
+      DB_USERNAME: supabase_admin
+      DB_DATABASE: _supabase
+      DB_HOSTNAME: ${POSTGRES_HOST:-db}
+      DB_PORT: ${POSTGRES_PORT:-5432}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      DB_SCHEMA: _analytics
+      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN:-your-super-secret-and-long-logflare-key-public}
+      LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN:-your-super-secret-and-long-logflare-key-private}
+      LOGFLARE_SINGLE_TENANT: "true"
+      LOGFLARE_SUPABASE_MODE: "true"
+      POSTGRES_BACKEND_URL: postgresql://supabase_admin:${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/_supabase
+      POSTGRES_BACKEND_SCHEMA: _analytics
+      LOGFLARE_FEATURE_FLAG_OVERRIDE: multibackend=true
+
+  db:
+    image: supabase/postgres:15.8.1.085
+    restart: unless-stopped
+    volumes:
+      - ./docker/supabase/volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:ro
+      - ./docker/supabase/volumes/db/webhooks.sql:/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql:ro
+      - ./docker/supabase/volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:ro
+      - ./docker/supabase/volumes/db/jwt.sql:/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql:ro
+      - ./docker/supabase/volumes/db/data:/var/lib/postgresql/data
+      - ./docker/supabase/volumes/db/_supabase.sql:/docker-entrypoint-initdb.d/migrations/97-_supabase.sql:ro
+      - ./docker/supabase/volumes/db/logs.sql:/docker-entrypoint-initdb.d/migrations/99-logs.sql:ro
+      - ./docker/supabase/volumes/db/pooler.sql:/docker-entrypoint-initdb.d/migrations/99-pooler.sql:ro
+      - db-config:/etc/postgresql-custom
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    environment:
+      POSTGRES_HOST: /var/run/postgresql
+      PGPORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      PGDATABASE: ${POSTGRES_DB:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      JWT_EXP: ${JWT_EXPIRY:-3600}
+    command:
+      [
+        "postgres",
+        "-c",
+        "config_file=/etc/postgresql/postgresql.conf",
+        "-c",
+        "log_min_messages=fatal"
+      ]
+
+  vector:
+    image: timberio/vector:0.53.0-alpine
+    restart: unless-stopped
+    volumes:
+      - ./docker/supabase/volumes/logs/vector.yml:/etc/vector/vector.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://vector:9001/health"]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    environment:
+      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN:-your-super-secret-and-long-logflare-key-public}
+    command: ["--config", "/etc/vector/vector.yml"]
+
+  supavisor:
+    image: supabase/supavisor:2.7.4
+    restart: unless-stopped
+    ports:
+      - ${POSTGRES_PORT:-5432}:5432
+      - ${POOLER_PROXY_PORT_TRANSACTION:-6543}:6543
+    volumes:
+      - ./docker/supabase/volumes/pooler/pooler.exs:/etc/pooler/pooler.exs:ro
+    healthcheck:
+      test: ["CMD", "curl", "-sSfL", "--head", "-o", "/dev/null", "http://127.0.0.1:4000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PORT: 4000
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}
+      DATABASE_URL: ecto://supabase_admin:${POSTGRES_PASSWORD:-your-super-secret-and-long-postgres-password}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/_supabase
+      CLUSTER_POSTGRES: "true"
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq}
+      VAULT_ENC_KEY: ${VAULT_ENC_KEY:-your-32-character-encryption-key}
+      API_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      METRICS_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters-long}
+      REGION: local
+      ERL_AFLAGS: -proto_dist inet_tcp
+      POOLER_TENANT_ID: ${POOLER_TENANT_ID:-dripiq-local}
+      POOLER_DEFAULT_POOL_SIZE: ${POOLER_DEFAULT_POOL_SIZE:-20}
+      POOLER_MAX_CLIENT_CONN: ${POOLER_MAX_CLIENT_CONN:-100}
+      POOLER_POOL_MODE: transaction
+      DB_POOL_SIZE: ${POOLER_DB_POOL_SIZE:-5}
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "/app/bin/migrate && /app/bin/supavisor eval \"$$(cat /etc/pooler/pooler.exs)\" && /app/bin/server"
+      ]
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  db-config:
+  deno-cache:
+  redis-data:

--- a/server/docker/supabase/.env.example
+++ b/server/docker/supabase/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to docker/supabase/.env and adjust values as needed.
+# docker compose --env-file ./docker/supabase/.env up -d
+
+POSTGRES_PASSWORD=your-super-secret-and-long-postgres-password
+JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
+ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhYmUtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
+SUPABASE_PUBLIC_URL=http://localhost:8000
+API_EXTERNAL_URL=http://localhost:8000
+POSTGRES_HOST=db
+POSTGRES_DB=postgres
+POSTGRES_PORT=5432
+KONG_HTTP_PORT=8000
+KONG_HTTPS_PORT=8443
+POOLER_PROXY_PORT_TRANSACTION=6543
+POOLER_TENANT_ID=dripiq-local
+STUDIO_DEFAULT_ORGANIZATION=Default Organization
+STUDIO_DEFAULT_PROJECT=DripIQ Local
+DASHBOARD_USERNAME=supabase
+DASHBOARD_PASSWORD=this_password_is_insecure_and_should_be_updated
+SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
+VAULT_ENC_KEY=your-32-character-encryption-key
+PG_META_CRYPTO_KEY=your-encryption-key-32-chars-min
+LOGFLARE_PUBLIC_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-public
+LOGFLARE_PRIVATE_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-private

--- a/server/docker/supabase/README.md
+++ b/server/docker/supabase/README.md
@@ -1,0 +1,37 @@
+# Local Supabase + BullMQ
+
+## 1) Create env file for Docker stack
+
+```bash
+cp ./docker/supabase/.env.example ./docker/supabase/.env
+```
+
+## 2) Start full stack
+
+```bash
+docker compose --env-file ./docker/supabase/.env up -d
+```
+
+## 3) Stop stack
+
+```bash
+docker compose --env-file ./docker/supabase/.env down
+```
+
+## 4) Server `.env` local values
+
+Use these values in `server/.env` when running against this local stack:
+
+- `SUPABASE_URL=http://localhost:8000`
+- `SUPABASE_SERVICE_ROLE_KEY=<SERVICE_ROLE_KEY from docker/supabase/.env>`
+- `DB_HOST=127.0.0.1`
+- `DB_PORT=5432`
+- `DB_USER=postgres.dripiq-local`
+- `DB_PASSWORD=<POSTGRES_PASSWORD from docker/supabase/.env>`
+- `DB_NAME=postgres`
+- `REDIS_URL=redis://127.0.0.1:6379`
+
+## Notes
+
+- This compose file includes the full Supabase local stack and Redis for BullMQ.
+- `kong.yml` is committed as a file, which avoids the file-vs-directory mount issue.

--- a/server/docker/supabase/volumes/api/kong-entrypoint.sh
+++ b/server/docker/supabase/volumes/api/kong-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Custom entrypoint for Kong that builds Lua expressions for request-transformer
+# and performs environment variable substitution in the declarative config.
+
+if [ -n "$SUPABASE_SECRET_KEY" ] && [ -n "$SUPABASE_PUBLISHABLE_KEY" ]; then
+  export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or (headers.apikey == '$SUPABASE_SECRET_KEY' and 'Bearer $SERVICE_ROLE_KEY_ASYMMETRIC') or (headers.apikey == '$SUPABASE_PUBLISHABLE_KEY' and 'Bearer $ANON_KEY_ASYMMETRIC') or headers.apikey)"
+  export LUA_RT_WS_EXPR="\$((query_params.apikey == '$SUPABASE_SECRET_KEY' and '$SERVICE_ROLE_KEY_ASYMMETRIC') or (query_params.apikey == '$SUPABASE_PUBLISHABLE_KEY' and '$ANON_KEY_ASYMMETRIC') or query_params.apikey)"
+else
+  export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or headers.apikey)"
+  export LUA_RT_WS_EXPR="\$(query_params.apikey)"
+fi
+
+awk '{
+  result = ""
+  rest = $0
+  while (match(rest, /\$[A-Za-z_][A-Za-z_0-9]*/)) {
+    varname = substr(rest, RSTART + 1, RLENGTH - 1)
+    if (varname in ENVIRON) {
+      result = result substr(rest, 1, RSTART - 1) ENVIRON[varname]
+    } else {
+      result = result substr(rest, 1, RSTART + RLENGTH - 1)
+    }
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+  print result rest
+}' /home/kong/temp.yml > "$KONG_DECLARATIVE_CONFIG"
+
+sed -i '/^[[:space:]]*- key:[[:space:]]*$/d' "$KONG_DECLARATIVE_CONFIG"
+
+exec /entrypoint.sh kong docker-start

--- a/server/docker/supabase/volumes/api/kong.yml
+++ b/server/docker/supabase/volumes/api/kong.yml
@@ -1,0 +1,262 @@
+_format_version: "2.1"
+_transform: true
+
+consumers:
+  - username: DASHBOARD
+  - username: anon
+    keyauth_credentials:
+      - key: $SUPABASE_ANON_KEY
+      - key: $SUPABASE_PUBLISHABLE_KEY
+  - username: service_role
+    keyauth_credentials:
+      - key: $SUPABASE_SERVICE_KEY
+      - key: $SUPABASE_SECRET_KEY
+
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+basicauth_credentials:
+  - consumer: DASHBOARD
+    username: "$DASHBOARD_USERNAME"
+    password: "$DASHBOARD_PASSWORD"
+
+services:
+  - name: auth-v1-open
+    url: http://auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths:
+          - /auth/v1/verify
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-callback
+    url: http://auth:9999/callback
+    routes:
+      - name: auth-v1-open-callback
+        strip_path: true
+        paths:
+          - /auth/v1/callback
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-authorize
+    url: http://auth:9999/authorize
+    routes:
+      - name: auth-v1-open-authorize
+        strip_path: true
+        paths:
+          - /auth/v1/authorize
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-jwks
+    url: http://auth:9999/.well-known/jwks.json
+    routes:
+      - name: auth-v1-open-jwks
+        strip_path: true
+        paths:
+          - /auth/v1/.well-known/jwks.json
+    plugins:
+      - name: cors
+
+  - name: auth-v1
+    url: http://auth:9999/
+    routes:
+      - name: auth-v1-all
+        strip_path: true
+        paths:
+          - /auth/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: rest-v1
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-all
+        strip_path: true
+        paths:
+          - /rest/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: graphql-v1
+    url: http://rest:3000/rpc/graphql
+    routes:
+      - name: graphql-v1-all
+        strip_path: true
+        paths:
+          - /graphql/v1
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Content-Profile: graphql_public"
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: realtime-v1-ws
+    url: http://realtime-dev.supabase-realtime:4000/socket
+    protocol: ws
+    routes:
+      - name: realtime-v1-ws
+        strip_path: true
+        paths:
+          - /realtime/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "x-api-key:$LUA_RT_WS_EXPR"
+          replace:
+            querystring:
+              - "apikey:$LUA_RT_WS_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: realtime-v1-rest
+    url: http://realtime-dev.supabase-realtime:4000/api
+    protocol: http
+    routes:
+      - name: realtime-v1-rest
+        strip_path: true
+        paths:
+          - /realtime/v1/api
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: storage-v1
+    url: http://storage:5000/
+    routes:
+      - name: storage-v1-all
+        strip_path: true
+        paths:
+          - /storage/v1/
+    plugins:
+      - name: cors
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+
+  - name: functions-v1
+    url: http://functions:9000/
+    read_timeout: 150000
+    routes:
+      - name: functions-v1-all
+        strip_path: true
+        paths:
+          - /functions/v1/
+    plugins:
+      - name: cors
+
+  - name: meta
+    url: http://meta:8080/
+    routes:
+      - name: meta-all
+        strip_path: true
+        paths:
+          - /pg/
+    plugins:
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+
+  - name: dashboard
+    url: http://studio:3000/
+    routes:
+      - name: dashboard-all
+        strip_path: true
+        paths:
+          - /
+    plugins:
+      - name: cors
+      - name: basic-auth
+        config:
+          hide_credentials: true

--- a/server/docker/supabase/volumes/db/_supabase.sql
+++ b/server/docker/supabase/volumes/db/_supabase.sql
@@ -1,0 +1,3 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+CREATE DATABASE _supabase WITH OWNER :pguser;

--- a/server/docker/supabase/volumes/db/jwt.sql
+++ b/server/docker/supabase/volumes/db/jwt.sql
@@ -1,0 +1,5 @@
+\set jwt_secret `echo "$JWT_SECRET"`
+\set jwt_exp `echo "$JWT_EXP"`
+
+ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
+ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';

--- a/server/docker/supabase/volumes/db/logs.sql
+++ b/server/docker/supabase/volumes/db/logs.sql
@@ -1,0 +1,6 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+\c _supabase
+create schema if not exists _analytics;
+alter schema _analytics owner to :pguser;
+\c postgres

--- a/server/docker/supabase/volumes/db/pooler.sql
+++ b/server/docker/supabase/volumes/db/pooler.sql
@@ -1,0 +1,6 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+\c _supabase
+create schema if not exists _supavisor;
+alter schema _supavisor owner to :pguser;
+\c postgres

--- a/server/docker/supabase/volumes/db/realtime.sql
+++ b/server/docker/supabase/volumes/db/realtime.sql
@@ -1,0 +1,4 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+create schema if not exists _realtime;
+alter schema _realtime owner to :pguser;

--- a/server/docker/supabase/volumes/db/roles.sql
+++ b/server/docker/supabase/volumes/db/roles.sql
@@ -1,0 +1,8 @@
+-- NOTE: change to your own passwords for production environments
+\set pgpass `echo "$POSTGRES_PASSWORD"`
+
+ALTER USER authenticator WITH PASSWORD :'pgpass';
+ALTER USER pgbouncer WITH PASSWORD :'pgpass';
+ALTER USER supabase_auth_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_functions_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_storage_admin WITH PASSWORD :'pgpass';

--- a/server/docker/supabase/volumes/db/webhooks.sql
+++ b/server/docker/supabase/volumes/db/webhooks.sql
@@ -1,0 +1,208 @@
+BEGIN;
+ -- Create pg_net extension
+ CREATE EXTENSION IF NOT EXISTS pg_net SCHEMA extensions;
+ -- Create supabase_functions schema
+ CREATE SCHEMA supabase_functions AUTHORIZATION supabase_admin;
+ GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;
+ ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+ ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+ ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+ -- supabase_functions.migrations definition
+ CREATE TABLE supabase_functions.migrations (
+ version text PRIMARY KEY,
+ inserted_at timestamptz NOT NULL DEFAULT NOW()
+ );
+ -- Initial supabase_functions migration
+ INSERT INTO supabase_functions.migrations (version) VALUES ('initial');
+ -- supabase_functions.hooks definition
+ CREATE TABLE supabase_functions.hooks (
+ id bigserial PRIMARY KEY,
+ hook_table_id integer NOT NULL,
+ hook_name text NOT NULL,
+ created_at timestamptz NOT NULL DEFAULT NOW(),
+ request_id bigint
+ );
+ CREATE INDEX supabase_functions_hooks_request_id_idx ON supabase_functions.hooks USING btree (request_id);
+ CREATE INDEX supabase_functions_hooks_h_table_id_h_name_idx ON supabase_functions.hooks USING btree (hook_table_id, hook_name);
+ COMMENT ON TABLE supabase_functions.hooks IS 'Supabase Functions Hooks: Audit trail for triggered hooks.';
+ CREATE FUNCTION supabase_functions.http_request()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ AS $function$
+ DECLARE
+ request_id bigint;
+ payload jsonb;
+ url text := TG_ARGV[0]::text;
+ method text := TG_ARGV[1]::text;
+ headers jsonb DEFAULT '{}'::jsonb;
+ params jsonb DEFAULT '{}'::jsonb;
+ timeout_ms integer DEFAULT 1000;
+ BEGIN
+ IF url IS NULL OR url = 'null' THEN
+ RAISE EXCEPTION 'url argument is missing';
+ END IF;
+
+ IF method IS NULL OR method = 'null' THEN
+ RAISE EXCEPTION 'method argument is missing';
+ END IF;
+
+ IF TG_ARGV[2] IS NULL OR TG_ARGV[2] = 'null' THEN
+ headers = '{"Content-Type": "application/json"}'::jsonb;
+ ELSE
+ headers = TG_ARGV[2]::jsonb;
+ END IF;
+
+ IF TG_ARGV[3] IS NULL OR TG_ARGV[3] = 'null' THEN
+ params = '{}'::jsonb;
+ ELSE
+ params = TG_ARGV[3]::jsonb;
+ END IF;
+
+ IF TG_ARGV[4] IS NULL OR TG_ARGV[4] = 'null' THEN
+ timeout_ms = 1000;
+ ELSE
+ timeout_ms = TG_ARGV[4]::integer;
+ END IF;
+
+ CASE
+ WHEN method = 'GET' THEN
+ SELECT http_get INTO request_id FROM net.http_get(
+ url,
+ params,
+ headers,
+ timeout_ms
+ );
+ WHEN method = 'POST' THEN
+ payload = jsonb_build_object(
+ 'old_record', OLD,
+ 'record', NEW,
+ 'type', TG_OP,
+ 'table', TG_TABLE_NAME,
+ 'schema', TG_TABLE_SCHEMA
+ );
+
+ SELECT http_post INTO request_id FROM net.http_post(
+ url,
+ payload,
+ params,
+ headers,
+ timeout_ms
+ );
+ ELSE
+ RAISE EXCEPTION 'method argument % is invalid', method;
+ END CASE;
+
+ INSERT INTO supabase_functions.hooks
+ (hook_table_id, hook_name, request_id)
+ VALUES
+ (TG_RELID, TG_NAME, request_id);
+
+ RETURN NEW;
+ END
+ $function$;
+ -- Supabase super admin
+ DO
+ $$
+ BEGIN
+ IF NOT EXISTS (
+ SELECT 1
+ FROM pg_roles
+ WHERE rolname = 'supabase_functions_admin'
+ )
+ THEN
+ CREATE USER supabase_functions_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+ END IF;
+ END
+ $$;
+ GRANT ALL PRIVILEGES ON SCHEMA supabase_functions TO supabase_functions_admin;
+ GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA supabase_functions TO supabase_functions_admin;
+ GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA supabase_functions TO supabase_functions_admin;
+ ALTER USER supabase_functions_admin SET search_path = "supabase_functions";
+ ALTER table "supabase_functions".migrations OWNER TO supabase_functions_admin;
+ ALTER table "supabase_functions".hooks OWNER TO supabase_functions_admin;
+ ALTER function "supabase_functions".http_request() OWNER TO supabase_functions_admin;
+ GRANT supabase_functions_admin TO postgres;
+ -- Remove unused supabase_pg_net_admin role
+ DO
+ $$
+ BEGIN
+ IF EXISTS (
+ SELECT 1
+ FROM pg_roles
+ WHERE rolname = 'supabase_pg_net_admin'
+ )
+ THEN
+ REASSIGN OWNED BY supabase_pg_net_admin TO supabase_admin;
+ DROP OWNED BY supabase_pg_net_admin;
+ DROP ROLE supabase_pg_net_admin;
+ END IF;
+ END
+ $$;
+ -- pg_net grants when extension is already enabled
+ DO
+ $$
+ BEGIN
+ IF EXISTS (
+ SELECT 1
+ FROM pg_extension
+ WHERE extname = 'pg_net'
+ )
+ THEN
+ GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+ ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+ ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+ ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+ ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+ REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+ REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+ GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+ GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+ END IF;
+ END
+ $$;
+ -- Event trigger for pg_net
+ CREATE OR REPLACE FUNCTION extensions.grant_pg_net_access()
+ RETURNS event_trigger
+ LANGUAGE plpgsql
+ AS $$
+ BEGIN
+ IF EXISTS (
+ SELECT 1
+ FROM pg_event_trigger_ddl_commands() AS ev
+ JOIN pg_extension AS ext
+ ON ev.objid = ext.oid
+ WHERE ext.extname = 'pg_net'
+ )
+ THEN
+ GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+ ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+ ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+ ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+ ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+ REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+ REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+ GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+ GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+ END IF;
+ END;
+ $$;
+ COMMENT ON FUNCTION extensions.grant_pg_net_access IS 'Grants access to pg_net';
+ DO
+ $$
+ BEGIN
+ IF NOT EXISTS (
+ SELECT 1
+ FROM pg_event_trigger
+ WHERE evtname = 'issue_pg_net_access'
+ ) THEN
+ CREATE EVENT TRIGGER issue_pg_net_access ON ddl_command_end WHEN TAG IN ('CREATE EXTENSION')
+ EXECUTE PROCEDURE extensions.grant_pg_net_access();
+ END IF;
+ END
+ $$;
+ INSERT INTO supabase_functions.migrations (version) VALUES ('20210809183423_update_grants');
+ ALTER function supabase_functions.http_request() SECURITY DEFINER;
+ ALTER function supabase_functions.http_request() SET search_path = supabase_functions;
+ REVOKE ALL ON FUNCTION supabase_functions.http_request() FROM PUBLIC;
+ GRANT EXECUTE ON FUNCTION supabase_functions.http_request() TO postgres, anon, authenticated, service_role;
+COMMIT;

--- a/server/docker/supabase/volumes/pooler/pooler.exs
+++ b/server/docker/supabase/volumes/pooler/pooler.exs
@@ -1,0 +1,32 @@
+{:ok, _} = Application.ensure_all_started(:supavisor)
+
+{:ok, version} =
+  case Supavisor.Repo.query!("select version()") do
+    %{rows: [[ver]]} -> Supavisor.Helpers.parse_pg_version(ver)
+    _ -> nil
+  end
+
+params = %{
+  "external_id" => System.get_env("POOLER_TENANT_ID"),
+  "db_host" => "db",
+  "db_port" => System.get_env("POSTGRES_PORT"),
+  "db_database" => System.get_env("POSTGRES_DB"),
+  "require_user" => false,
+  "auth_query" => "SELECT * FROM pgbouncer.get_auth($1)",
+  "default_max_clients" => System.get_env("POOLER_MAX_CLIENT_CONN"),
+  "default_pool_size" => System.get_env("POOLER_DEFAULT_POOL_SIZE"),
+  "default_parameter_status" => %{"server_version" => version},
+  "users" => [
+    %{
+      "db_user" => "pgbouncer",
+      "db_password" => System.get_env("POSTGRES_PASSWORD"),
+      "mode_type" => System.get_env("POOLER_POOL_MODE"),
+      "pool_size" => System.get_env("POOLER_DEFAULT_POOL_SIZE"),
+      "is_manager" => true
+    }
+  ]
+}
+
+if !Supavisor.Tenants.get_tenant_by_external_id(params["external_id"]) do
+  {:ok, _} = Supavisor.Tenants.create_tenant(params)
+end

--- a/server/src/db/migrations/0042_tenant_domain_mappings.sql
+++ b/server/src/db/migrations/0042_tenant_domain_mappings.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "dripiq_app"."tenant_domain_mappings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"domain" text NOT NULL,
+	"is_verified" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "tenant_domain_mapping_domain_unique" UNIQUE("domain")
+);
+--> statement-breakpoint
+ALTER TABLE "dripiq_app"."tenant_domain_mappings" ADD CONSTRAINT "tenant_domain_mappings_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "dripiq_app"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "tenant_domain_mapping_tenant_idx" ON "dripiq_app"."tenant_domain_mappings" USING btree ("tenant_id");

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1759511748293,
       "tag": "0041_add_email_verification_status",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1766500000000,
+      "tag": "0042_tenant_domain_mappings",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -172,6 +172,26 @@ export const userTenants = appSchema.table(
   (table) => [unique('user_tenant_unique').on(table.userId, table.tenantId)]
 );
 
+export const tenantDomainMappings = appSchema.table(
+  'tenant_domain_mappings',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    domain: text('domain').notNull(),
+    isVerified: boolean('is_verified').notNull().default(true),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    unique('tenant_domain_mapping_domain_unique').on(table.domain),
+    index('tenant_domain_mapping_tenant_idx').on(table.tenantId),
+  ]
+);
+
 // Relations
 export const usersRelations = relations(users, ({ many }) => ({
   tenants: many(userTenants),
@@ -182,6 +202,7 @@ export const tenantsRelations = relations(tenants, ({ many, one }) => ({
   users: many(userTenants),
   leads: many(leads),
   products: many(products),
+  domainMappings: many(tenantDomainMappings),
   mailAccounts: many(mailAccounts),
   siteEmbeddingDomain: one(siteEmbeddingDomains, {
     fields: [tenants.siteEmbeddingDomainId],
@@ -221,6 +242,13 @@ export const userTenantsRelations = relations(userTenants, ({ one }) => ({
   role: one(roles, {
     fields: [userTenants.roleId],
     references: [roles.id],
+  }),
+}));
+
+export const tenantDomainMappingsRelations = relations(tenantDomainMappings, ({ one }) => ({
+  tenant: one(tenants, {
+    fields: [tenantDomainMappings.tenantId],
+    references: [tenants.id],
   }),
 }));
 
@@ -1157,6 +1185,8 @@ export type Product = typeof products.$inferSelect;
 export type NewProduct = typeof products.$inferInsert;
 export type UserTenant = typeof userTenants.$inferSelect;
 export type NewUserTenant = typeof userTenants.$inferInsert;
+export type TenantDomainMapping = typeof tenantDomainMappings.$inferSelect;
+export type NewTenantDomainMapping = typeof tenantDomainMappings.$inferInsert;
 export type Role = typeof roles.$inferSelect;
 export type NewRole = typeof roles.$inferInsert;
 export type Permission = typeof permissions.$inferSelect;

--- a/server/src/modules/tenant-domain-mapping.service.spec.ts
+++ b/server/src/modules/tenant-domain-mapping.service.spec.ts
@@ -1,0 +1,89 @@
+import { BadRequestError, ConflictError } from '@/exceptions/error';
+import { TenantDomainMappingService } from './tenant-domain-mapping.service';
+import { tenantDomainMappingRepository, tenantRepository } from '@/repositories';
+
+jest.mock('@/repositories', () => ({
+  tenantDomainMappingRepository: {
+    findByDomain: jest.fn(),
+    findTenantByDomain: jest.fn(),
+    create: jest.fn(),
+  },
+  tenantRepository: {
+    findById: jest.fn(),
+  },
+}));
+
+describe('TenantDomainMappingService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('normalizeDomain', () => {
+    it('normalizes email input into lowercase domain', () => {
+      expect(TenantDomainMappingService.normalizeDomain('USER@Example.COM')).toBe('example.com');
+    });
+
+    it('throws for invalid domain inputs', () => {
+      expect(() => TenantDomainMappingService.normalizeDomain('invalid-domain')).toThrow(
+        BadRequestError
+      );
+    });
+  });
+
+  describe('ensureMappingForTenant', () => {
+    it('returns existing mapping for same tenant', async () => {
+      (tenantRepository.findById as jest.Mock).mockResolvedValue({ id: 'tenant_1' });
+      (tenantDomainMappingRepository.findByDomain as jest.Mock).mockResolvedValue({
+        id: 'mapping_1',
+        tenantId: 'tenant_1',
+        domain: 'example.com',
+      });
+
+      const result = await TenantDomainMappingService.ensureMappingForTenant({
+        tenantId: 'tenant_1',
+        domain: 'example.com',
+      });
+
+      expect(result.id).toBe('mapping_1');
+      expect(tenantDomainMappingRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('throws conflict if domain belongs to a different tenant', async () => {
+      (tenantRepository.findById as jest.Mock).mockResolvedValue({ id: 'tenant_1' });
+      (tenantDomainMappingRepository.findByDomain as jest.Mock).mockResolvedValue({
+        id: 'mapping_1',
+        tenantId: 'tenant_2',
+        domain: 'example.com',
+      });
+
+      await expect(
+        TenantDomainMappingService.ensureMappingForTenant({
+          tenantId: 'tenant_1',
+          domain: 'example.com',
+        })
+      ).rejects.toThrow(ConflictError);
+    });
+
+    it('creates mapping when none exists', async () => {
+      (tenantRepository.findById as jest.Mock).mockResolvedValue({ id: 'tenant_1' });
+      (tenantDomainMappingRepository.findByDomain as jest.Mock).mockResolvedValueOnce(undefined);
+      (tenantDomainMappingRepository.create as jest.Mock).mockResolvedValue({
+        id: 'mapping_2',
+        tenantId: 'tenant_1',
+        domain: 'example.com',
+      });
+
+      const result = await TenantDomainMappingService.ensureMappingForTenant({
+        tenantId: 'tenant_1',
+        domain: 'example.com',
+      });
+
+      expect(result.id).toBe('mapping_2');
+      expect(tenantDomainMappingRepository.create).toHaveBeenCalledWith({
+        tenantId: 'tenant_1',
+        domain: 'example.com',
+        isVerified: true,
+      });
+    });
+  });
+});

--- a/server/src/modules/tenant-domain-mapping.service.ts
+++ b/server/src/modules/tenant-domain-mapping.service.ts
@@ -1,0 +1,77 @@
+import { TenantDomainMapping, Tenant } from '@/db';
+import { tenantDomainMappingRepository, tenantRepository } from '@/repositories';
+import { BadRequestError, ConflictError } from '@/exceptions/error';
+
+export class TenantDomainMappingService {
+  static normalizeDomain(value: string): string {
+    const candidate = value.trim().toLowerCase();
+    const withoutAtPrefix = candidate.startsWith('@') ? candidate.slice(1) : candidate;
+    const domain = withoutAtPrefix.includes('@')
+      ? (withoutAtPrefix.split('@').at(-1) ?? '')
+      : withoutAtPrefix;
+
+    if (!domain || domain.startsWith('.') || domain.endsWith('.') || !domain.includes('.')) {
+      throw new BadRequestError('Invalid domain');
+    }
+
+    return domain;
+  }
+
+  static getDomainFromEmail(email: string): string {
+    if (!email || !email.includes('@')) {
+      throw new BadRequestError('Invalid email');
+    }
+
+    return this.normalizeDomain(email);
+  }
+
+  static async findTenantByDomain(domain: string): Promise<Tenant | null> {
+    const normalizedDomain = this.normalizeDomain(domain);
+    const tenant = await tenantDomainMappingRepository.findTenantByDomain(normalizedDomain);
+    return tenant ?? null;
+  }
+
+  static async findMappingByDomain(domain: string): Promise<TenantDomainMapping | null> {
+    const normalizedDomain = this.normalizeDomain(domain);
+    const mapping = await tenantDomainMappingRepository.findByDomain(normalizedDomain);
+    return mapping ?? null;
+  }
+
+  static async ensureMappingForTenant(params: {
+    tenantId: string;
+    domain: string;
+    isVerified?: boolean;
+  }): Promise<TenantDomainMapping> {
+    const normalizedDomain = this.normalizeDomain(params.domain);
+    await tenantRepository.findById(params.tenantId);
+
+    const existing = await tenantDomainMappingRepository.findByDomain(normalizedDomain);
+    if (existing) {
+      if (existing.tenantId !== params.tenantId) {
+        throw new ConflictError(`Domain "${normalizedDomain}" is already mapped to another tenant`);
+      }
+      return existing;
+    }
+
+    try {
+      return await tenantDomainMappingRepository.create({
+        tenantId: params.tenantId,
+        domain: normalizedDomain,
+        isVerified: params.isVerified ?? true,
+      });
+    } catch (error: any) {
+      if (error?.code === '23505') {
+        const mapping = await tenantDomainMappingRepository.findByDomain(normalizedDomain);
+        if (mapping) {
+          if (mapping.tenantId !== params.tenantId) {
+            throw new ConflictError(
+              `Domain "${normalizedDomain}" is already mapped to another tenant`
+            );
+          }
+          return mapping;
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/server/src/modules/user.service.ts
+++ b/server/src/modules/user.service.ts
@@ -1,5 +1,6 @@
 import { User, NewUser } from '@/db';
 import { userRepository } from '@/repositories';
+import { NotFoundError } from '@/exceptions/error';
 
 export interface CreateUserData {
   supabaseId: string;
@@ -58,6 +59,18 @@ export class UserService {
    */
   static async getUserById(id: string): Promise<User> {
     return await userRepository.findById(id);
+  }
+
+  static async findUserByEmail(email: string): Promise<User | null> {
+    try {
+      return await userRepository.findByEmail(email);
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return null;
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/server/src/repositories/entities/TenantDomainMappingRepository.ts
+++ b/server/src/repositories/entities/TenantDomainMappingRepository.ts
@@ -1,0 +1,42 @@
+import { eq } from 'drizzle-orm';
+import {
+  tenantDomainMappings,
+  TenantDomainMapping,
+  NewTenantDomainMapping,
+  tenants,
+  Tenant,
+} from '@/db/schema';
+import { BaseRepository } from '../base/BaseRepository';
+
+export class TenantDomainMappingRepository extends BaseRepository<
+  typeof tenantDomainMappings,
+  TenantDomainMapping,
+  NewTenantDomainMapping
+> {
+  constructor() {
+    super(tenantDomainMappings);
+  }
+
+  async findByDomain(domain: string): Promise<TenantDomainMapping | undefined> {
+    const [result] = await this.db
+      .select()
+      .from(this.table)
+      .where(eq(this.table.domain, domain))
+      .limit(1);
+
+    return result;
+  }
+
+  async findTenantByDomain(domain: string): Promise<Tenant | undefined> {
+    const [result] = await this.db
+      .select({
+        tenant: tenants,
+      })
+      .from(this.table)
+      .innerJoin(tenants, eq(this.table.tenantId, tenants.id))
+      .where(eq(this.table.domain, domain))
+      .limit(1);
+
+    return result?.tenant;
+  }
+}

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -32,6 +32,7 @@ import { TenantSetupTransactionRepository } from './transactions/TenantSetupTran
 import { CalendarLinkClickRepository } from './entities/CalendarLinkClickRepository';
 import { MailAccountRepository } from './entities/MailAccountRepository';
 import { OauthTokenRepository } from './entities/OauthTokenRepository';
+import { TenantDomainMappingRepository } from './entities/TenantDomainMappingRepository';
 
 // Base repositories
 export { BaseRepository } from './base/BaseRepository';
@@ -68,6 +69,7 @@ export { ContactUnsubscribeRepository } from './entities/ContactUnsubscribeRepos
 export { CalendarLinkClickRepository } from './entities/CalendarLinkClickRepository';
 export { MailAccountRepository } from './entities/MailAccountRepository';
 export { OauthTokenRepository } from './entities/OauthTokenRepository';
+export { TenantDomainMappingRepository } from './entities/TenantDomainMappingRepository';
 
 // Transaction repositories
 export { LeadTransactionRepository } from './transactions/LeadTransactionRepository';
@@ -140,6 +142,7 @@ const contactUnsubscribeRepository = new ContactUnsubscribeRepository();
 const calendarLinkClickRepository = new CalendarLinkClickRepository();
 const mailAccountRepository = new MailAccountRepository();
 const oauthTokenRepository = new OauthTokenRepository();
+const tenantDomainMappingRepository = new TenantDomainMappingRepository();
 
 // Transaction repository instances
 const leadTransactionRepository = new LeadTransactionRepository();
@@ -179,6 +182,7 @@ export const repositories = {
   calendarLinkClick: calendarLinkClickRepository,
   mailAccount: mailAccountRepository,
   oauthToken: oauthTokenRepository,
+  tenantDomainMapping: tenantDomainMappingRepository,
 
   // Transaction repositories
   leadTransaction: leadTransactionRepository,
@@ -218,6 +222,7 @@ export {
   calendarLinkClickRepository,
   mailAccountRepository,
   oauthTokenRepository,
+  tenantDomainMappingRepository,
   leadTransactionRepository,
   userInvitationTransactionRepository,
   tenantSetupTransactionRepository,

--- a/server/src/routes/apiSchema/authentication/index.ts
+++ b/server/src/routes/apiSchema/authentication/index.ts
@@ -4,3 +4,5 @@ export * from './createUser.schema';
 export * from './auth.response.schema';
 export * from './session.schema';
 export * from './verifyOtp.schema';
+export * from './ssoBootstrap.schema';
+export * from './ssoRegister.schema';

--- a/server/src/routes/apiSchema/authentication/register.schema.ts
+++ b/server/src/routes/apiSchema/authentication/register.schema.ts
@@ -6,6 +6,7 @@ export const registerBodySchema = Type.Object({
   password: Type.String({ minLength: 8 }),
   name: Type.String(),
   tenantName: Type.String(),
+  enableSsoDomainMapping: Type.Optional(Type.Boolean()),
 });
 
 // Response schema for successful registration

--- a/server/src/routes/apiSchema/authentication/ssoBootstrap.schema.ts
+++ b/server/src/routes/apiSchema/authentication/ssoBootstrap.schema.ts
@@ -1,0 +1,26 @@
+import { Type } from '@sinclair/typebox';
+
+export const ssoBootstrapSuccessResponseSchema = Type.Object({
+  status: Type.Union([Type.Literal('already_provisioned'), Type.Literal('provisioned')]),
+  user: Type.Object({
+    id: Type.String(),
+    email: Type.String(),
+    name: Type.Union([Type.String(), Type.Null()]),
+  }),
+  tenant: Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+  }),
+});
+
+export const ssoBootstrapRequiresRegistrationResponseSchema = Type.Object({
+  status: Type.Literal('requires_registration'),
+  email: Type.String(),
+  domain: Type.String(),
+});
+
+export const ssoBootstrapConflictResponseSchema = Type.Object({
+  status: Type.Literal('linking_required'),
+  message: Type.String(),
+  email: Type.String(),
+});

--- a/server/src/routes/apiSchema/authentication/ssoRegister.schema.ts
+++ b/server/src/routes/apiSchema/authentication/ssoRegister.schema.ts
@@ -1,0 +1,26 @@
+import { Type } from '@sinclair/typebox';
+
+export const ssoRegisterBodySchema = Type.Object({
+  name: Type.String(),
+  tenantName: Type.String(),
+});
+
+export const ssoRegisterSuccessResponseSchema = Type.Object({
+  status: Type.Literal('registered'),
+  message: Type.String(),
+  user: Type.Object({
+    id: Type.String(),
+    email: Type.String(),
+    name: Type.Union([Type.String(), Type.Null()]),
+  }),
+  tenant: Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+  }),
+});
+
+export const ssoRegisterConflictResponseSchema = Type.Object({
+  status: Type.Union([Type.Literal('domain_conflict'), Type.Literal('linking_required')]),
+  message: Type.String(),
+  email: Type.String(),
+});

--- a/server/src/routes/authentication.routes.ts
+++ b/server/src/routes/authentication.routes.ts
@@ -1,13 +1,16 @@
 import { FastifyInstance, FastifyRequest, FastifyReply, RouteOptions } from 'fastify';
 import { Type } from '@sinclair/typebox';
+import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { HttpMethods } from '@/utils/HttpMethods';
 import { logger } from '@/libs/logger';
 import { supabase } from '@/libs/supabase.client';
 import { UserService, CreateUserData } from '@/modules/user.service';
 import { TenantService } from '@/modules/tenant.service';
+import { TenantDomainMappingService } from '@/modules/tenant-domain-mapping.service';
 import { RoleService } from '@/modules/role.service';
 import { authCache } from '@/cache/AuthCacheRedis';
 import { DEFAULT_CALENDAR_TIE_IN } from '@/constants';
+import { ConflictError, NotFoundError } from '@/exceptions/error';
 
 // Import all authentication schemas from organized schema files
 import isFakeMail from '@/libs/isFakeMail.client';
@@ -23,11 +26,38 @@ import {
   sessionInfoResponseSchema,
   verifyOtpBodySchema,
   verifyOtpResponseSchema,
+  ssoBootstrapSuccessResponseSchema,
+  ssoBootstrapRequiresRegistrationResponseSchema,
+  ssoBootstrapConflictResponseSchema,
+  ssoRegisterBodySchema,
+  ssoRegisterSuccessResponseSchema,
+  ssoRegisterConflictResponseSchema,
 } from './apiSchema/authentication';
 
 const basePath = '/auth';
 
 export default async function Authentication(fastify: FastifyInstance, _opts: RouteOptions) {
+  const resolveSupabaseUser = async (
+    authHeader?: string
+  ): Promise<{ token: string; supabaseUser: SupabaseUser } | null> => {
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.substring('Bearer '.length) : null;
+
+    if (!token) {
+      return null;
+    }
+
+    const {
+      data: { user: supabaseUser },
+      error: getUserError,
+    } = await supabase.auth.getUser(token);
+
+    if (getUserError || !supabaseUser) {
+      return null;
+    }
+
+    return { token, supabaseUser };
+  };
+
   // Registration route - Complete onboarding flow
   fastify.route({
     method: HttpMethods.POST,
@@ -37,6 +67,7 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
       response: {
         201: registerSuccessResponseSchema,
         400: errorResponseSchema,
+        409: errorResponseSchema,
         500: errorResponseSchema,
       },
       tags: ['Authentication'],
@@ -51,12 +82,13 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
           password: string;
           name: string;
           tenantName: string;
+          enableSsoDomainMapping?: boolean;
         };
       }>,
       reply: FastifyReply
     ) => {
       try {
-        const { email, password, name, tenantName } = request.body;
+        const { email, password, name, tenantName, enableSsoDomainMapping } = request.body;
 
         const isRealEmail = await isFakeMail(email);
 
@@ -113,6 +145,15 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
         // Step 5: Link user to tenant as admin with super user privileges
         await TenantService.addUserToTenant(user.id, tenant.id, adminRole.id, true);
 
+        if (enableSsoDomainMapping) {
+          const domain = TenantDomainMappingService.getDomainFromEmail(email);
+          await TenantDomainMappingService.ensureMappingForTenant({
+            tenantId: tenant.id,
+            domain,
+            isVerified: true,
+          });
+        }
+
         // Step 6: Sign in the user to get session token
         const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
           email,
@@ -151,6 +192,14 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
           session: signInData.session,
         });
       } catch (error: any) {
+        if (error instanceof ConflictError) {
+          reply.status(409).send({
+            message: error.message,
+            error: 'domain_conflict',
+          });
+          return;
+        }
+
         logger.error(`Registration error: ${error.message}`);
         reply.status(500).send({
           message: 'Failed to complete registration',
@@ -193,6 +242,304 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
         logger.error(`Error creating user: ${error.message}`);
         reply.status(500).send({
           message: 'Failed to create user',
+          error: error.message,
+        });
+      }
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.POST,
+    url: `${basePath}/sso/bootstrap`,
+    schema: {
+      response: {
+        200: Type.Union([
+          ssoBootstrapSuccessResponseSchema,
+          ssoBootstrapRequiresRegistrationResponseSchema,
+        ]),
+        400: errorResponseSchema,
+        401: errorResponseSchema,
+        409: ssoBootstrapConflictResponseSchema,
+        500: errorResponseSchema,
+      },
+      tags: ['Authentication'],
+      summary: 'Bootstrap SSO Session',
+      description:
+        'Provision app user and tenant membership after Supabase SSO login, or instruct client to register.',
+    },
+    handler: async (request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        const authSession = await resolveSupabaseUser(request.headers.authorization);
+        if (!authSession) {
+          reply.status(401).send({
+            message: 'Invalid SSO session',
+            error: 'Unable to resolve authenticated user',
+          });
+          return;
+        }
+        const { supabaseUser } = authSession;
+
+        const email = supabaseUser.email?.trim().toLowerCase();
+        if (!email) {
+          reply
+            .status(400)
+            .send({ message: 'Authenticated SSO user does not have an email address' });
+          return;
+        }
+
+        const domain = TenantDomainMappingService.getDomainFromEmail(email);
+        const mapping = await TenantDomainMappingService.findMappingByDomain(domain);
+
+        let existingUserWithTenants: Awaited<
+          ReturnType<typeof UserService.getUserWithTenantsForAuth>
+        > | null = null;
+
+        try {
+          existingUserWithTenants = await UserService.getUserWithTenantsForAuth(supabaseUser.id);
+        } catch (error) {
+          if (!(error instanceof NotFoundError)) {
+            throw error;
+          }
+        }
+
+        if (existingUserWithTenants && existingUserWithTenants.userTenants.length > 0) {
+          return reply.send({
+            status: 'already_provisioned',
+            user: {
+              id: existingUserWithTenants.user.id,
+              email: existingUserWithTenants.user.email,
+              name: existingUserWithTenants.user.name,
+            },
+            tenant: {
+              id: existingUserWithTenants.userTenants[0]!.id,
+              name: existingUserWithTenants.userTenants[0]!.name,
+            },
+          });
+        }
+
+        if (!mapping) {
+          reply.send({
+            status: 'requires_registration',
+            email,
+            domain,
+          });
+          return;
+        }
+
+        const existingUserByEmail = await UserService.findUserByEmail(email);
+
+        if (existingUserByEmail && existingUserByEmail.supabaseId !== supabaseUser.id) {
+          reply.status(409).send({
+            status: 'linking_required',
+            message:
+              'An account with this email already exists. Contact support to link SSO access.',
+            email,
+          });
+          return;
+        }
+
+        const displayName =
+          supabaseUser.user_metadata?.full_name ||
+          supabaseUser.user_metadata?.name ||
+          supabaseUser.user_metadata?.display_name ||
+          null;
+
+        const dbUser =
+          existingUserByEmail ||
+          (await UserService.createUser({
+            supabaseId: supabaseUser.id,
+            email,
+            name: displayName || undefined,
+          }));
+
+        const defaultSsoRole =
+          (await RoleService.getRoleByName('Sales')) || (await RoleService.getRoleByName('Admin'));
+
+        if (!defaultSsoRole) {
+          reply.status(500).send({ message: 'No default role configured for SSO provisioning' });
+          return;
+        }
+
+        await TenantService.addUserToTenant(dbUser.id, mapping.tenantId, defaultSsoRole.id, false);
+        await authCache.clear(supabaseUser.id);
+
+        const provisioned = await UserService.getUserWithTenantsForAuth(supabaseUser.id);
+        if (!provisioned || provisioned.userTenants.length === 0) {
+          reply.status(500).send({ message: 'Failed to complete SSO provisioning' });
+          return;
+        }
+
+        const provisionedTenant =
+          provisioned.userTenants.find((tenant) => tenant.id === mapping.tenantId) ||
+          provisioned.userTenants[0]!;
+
+        reply.send({
+          status: 'provisioned',
+          user: {
+            id: provisioned.user.id,
+            email: provisioned.user.email,
+            name: provisioned.user.name,
+          },
+          tenant: {
+            id: provisionedTenant.id,
+            name: provisionedTenant.name,
+          },
+        });
+      } catch (error: any) {
+        logger.error(`SSO bootstrap error: ${error.message}`);
+        reply.status(500).send({
+          message: 'Failed to bootstrap SSO session',
+          error: error.message,
+        });
+      }
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.POST,
+    url: `${basePath}/sso/register`,
+    schema: {
+      body: ssoRegisterBodySchema,
+      response: {
+        200: ssoRegisterSuccessResponseSchema,
+        400: errorResponseSchema,
+        401: errorResponseSchema,
+        409: ssoRegisterConflictResponseSchema,
+        500: errorResponseSchema,
+      },
+      tags: ['Authentication'],
+      summary: 'Complete SSO Registration',
+      description:
+        'Creates tenant ownership and domain mapping for first-time SSO users when no mapping exists.',
+    },
+    handler: async (
+      request: FastifyRequest<{
+        Body: {
+          name: string;
+          tenantName: string;
+        };
+      }>,
+      reply: FastifyReply
+    ) => {
+      let authenticatedEmail = '';
+      try {
+        const authSession = await resolveSupabaseUser(request.headers.authorization);
+        if (!authSession) {
+          reply.status(401).send({ message: 'Invalid SSO session' });
+          return;
+        }
+
+        const { supabaseUser } = authSession;
+        const email = supabaseUser.email?.trim().toLowerCase();
+        if (!email) {
+          reply
+            .status(400)
+            .send({ message: 'Authenticated SSO user does not have an email address' });
+          return;
+        }
+        authenticatedEmail = email;
+
+        const domain = TenantDomainMappingService.getDomainFromEmail(email);
+        const existingMapping = await TenantDomainMappingService.findMappingByDomain(domain);
+        if (existingMapping) {
+          reply.status(409).send({
+            status: 'domain_conflict',
+            message: 'This domain is already mapped. Please continue through SSO login.',
+            email,
+          });
+          return;
+        }
+
+        let existingUserWithTenants: Awaited<
+          ReturnType<typeof UserService.getUserWithTenantsForAuth>
+        > | null = null;
+        try {
+          existingUserWithTenants = await UserService.getUserWithTenantsForAuth(supabaseUser.id);
+        } catch (error) {
+          if (!(error instanceof NotFoundError)) {
+            throw error;
+          }
+        }
+
+        if (existingUserWithTenants && existingUserWithTenants.userTenants.length > 0) {
+          reply.send({
+            status: 'registered',
+            message: 'SSO registration already completed',
+            user: {
+              id: existingUserWithTenants.user.id,
+              email: existingUserWithTenants.user.email,
+              name: existingUserWithTenants.user.name,
+            },
+            tenant: {
+              id: existingUserWithTenants.userTenants[0]!.id,
+              name: existingUserWithTenants.userTenants[0]!.name,
+            },
+          });
+          return;
+        }
+
+        const existingUserByEmail = await UserService.findUserByEmail(email);
+        if (existingUserByEmail && existingUserByEmail.supabaseId !== supabaseUser.id) {
+          reply.status(409).send({
+            status: 'linking_required',
+            message:
+              'An account with this email already exists. Contact support to link SSO access.',
+            email,
+          });
+          return;
+        }
+
+        const tenant = await TenantService.createTenant({ name: request.body.tenantName });
+        const adminRole = await RoleService.getRoleByName('Admin');
+        if (!adminRole) {
+          reply.status(500).send({
+            message: 'Admin role not found. Please ensure roles are seeded.',
+          });
+          return;
+        }
+
+        const dbUser =
+          existingUserByEmail ||
+          (await UserService.createUser({
+            supabaseId: supabaseUser.id,
+            email,
+            name: request.body.name || supabaseUser.user_metadata?.full_name || undefined,
+          }));
+
+        await TenantService.addUserToTenant(dbUser.id, tenant.id, adminRole.id, true);
+        await TenantDomainMappingService.ensureMappingForTenant({
+          tenantId: tenant.id,
+          domain,
+          isVerified: true,
+        });
+        await authCache.clear(supabaseUser.id);
+
+        reply.send({
+          status: 'registered',
+          message: 'SSO registration completed successfully',
+          user: {
+            id: dbUser.id,
+            email: dbUser.email,
+            name: dbUser.name,
+          },
+          tenant: {
+            id: tenant.id,
+            name: tenant.name,
+          },
+        });
+      } catch (error: any) {
+        if (error instanceof ConflictError) {
+          reply.status(409).send({
+            status: 'domain_conflict',
+            message: error.message,
+            email: authenticatedEmail,
+          });
+          return;
+        }
+
+        logger.error(`SSO register error: ${error.message}`);
+        reply.status(500).send({
+          message: 'Failed to complete SSO registration',
           error: error.message,
         });
       }


### PR DESCRIPTION
## Summary
- add domain-to-tenant mapping support in the backend schema, migration, repository, and service layer
- implement SSO bootstrap and SSO registration endpoints for Okta-initiated Supabase SAML login, including `requires_registration`, `domain_conflict`, and `linking_required` paths
- add client SSO callback orchestration, login SSO trigger, register fallback UX for unmapped domains, and targeted server/client tests

## Test plan
- [x] `cd server && npm run lint`
- [x] `cd server && npm test -- tenant-domain-mapping.service.spec.ts`
- [x] `cd server && npm run build`
- [x] `cd client && npm test -- auth.service.test.ts`
- [x] `cd client && npm run build`
- [ ] `cd server && npm run prod:server` *(blocked locally: Postgres connection refused on `127.0.0.1:5432` during migration)*


Made with [Cursor](https://cursor.com)