### PR TITLE
feat: auto-link SSO users during bootstrap

### DIFF
--- a/client/src/services/auth.service.test.ts
+++ b/client/src/services/auth.service.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { authService } from './auth.service'
 
 const mocks = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   getUserMock: vi.fn(),
   signInWithSsoMock: vi.fn(),
+  signOutMock: vi.fn(),
 }))
 
 vi.mock('../lib/supabaseClient', () => ({
@@ -14,13 +16,11 @@ vi.mock('../lib/supabaseClient', () => ({
       signInWithSSO: mocks.signInWithSsoMock,
       signInWithPassword: vi.fn(),
       setSession: vi.fn(),
-      signOut: vi.fn(),
+      signOut: mocks.signOutMock,
       onAuthStateChange: vi.fn(),
     },
   },
 }))
-
-import { authService } from './auth.service'
 
 describe('authService SSO flows', () => {
   beforeEach(() => {
@@ -52,6 +52,7 @@ describe('authService SSO flows', () => {
     const result = await authService.bootstrapSsoSession()
 
     expect(result.status).toBe('requires_registration')
+    expect(mocks.signOutMock).toHaveBeenCalledTimes(1)
     const [url, options] = (global.fetch as any).mock.calls[0]
     expect(url).toContain('/api/auth/sso/bootstrap')
     expect(options).toEqual({

--- a/client/src/services/auth.service.ts
+++ b/client/src/services/auth.service.ts
@@ -241,6 +241,12 @@ class AuthService {
       return result
     }
 
+    if (response.ok && result?.status === 'requires_registration') {
+      // Clear active SSO session before entering tenant registration flow.
+      await supabase.auth.signOut()
+      return result
+    }
+
     if (!response.ok) {
       throw new Error(result?.message || 'Failed to bootstrap SSO session')
     }

--- a/server/src/modules/user.service.ts
+++ b/server/src/modules/user.service.ts
@@ -73,6 +73,16 @@ export class UserService {
     }
   }
 
+  static async updateUserSupabaseId(userId: string, supabaseId: string): Promise<User> {
+    const updatedUser = await userRepository.updateById(userId, { supabaseId });
+
+    if (!updatedUser) {
+      throw new Error('User not found');
+    }
+
+    return updatedUser;
+  }
+
   /**
    * Updates a user's data based on their Supabase ID.
    * @param supabaseId - The Supabase ID of the user to update.

--- a/server/src/routes/authentication.routes.ts
+++ b/server/src/routes/authentication.routes.ts
@@ -328,29 +328,34 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
 
         const existingUserByEmail = await UserService.findUserByEmail(email);
 
-        if (existingUserByEmail && existingUserByEmail.supabaseId !== supabaseUser.id) {
-          reply.status(409).send({
-            status: 'linking_required',
-            message:
-              'An account with this email already exists. Contact support to link SSO access.',
-            email,
-          });
-          return;
-        }
-
         const displayName =
           supabaseUser.user_metadata?.full_name ||
           supabaseUser.user_metadata?.name ||
           supabaseUser.user_metadata?.display_name ||
           null;
 
-        const dbUser =
-          existingUserByEmail ||
-          (await UserService.createUser({
+        let dbUser = existingUserWithTenants?.user || null;
+        let previousSupabaseId: string | null = null;
+
+        if (!dbUser && existingUserByEmail) {
+          if (existingUserByEmail.supabaseId !== supabaseUser.id) {
+            previousSupabaseId = existingUserByEmail.supabaseId;
+            dbUser = await UserService.updateUserSupabaseId(
+              existingUserByEmail.id,
+              supabaseUser.id
+            );
+          } else {
+            dbUser = existingUserByEmail;
+          }
+        }
+
+        if (!dbUser) {
+          dbUser = await UserService.createUser({
             supabaseId: supabaseUser.id,
             email,
             name: displayName || undefined,
-          }));
+          });
+        }
 
         const defaultSsoRole =
           (await RoleService.getRoleByName('Sales')) || (await RoleService.getRoleByName('Admin'));
@@ -362,6 +367,9 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
 
         await TenantService.addUserToTenant(dbUser.id, mapping.tenantId, defaultSsoRole.id, false);
         await authCache.clear(supabaseUser.id);
+        if (previousSupabaseId && previousSupabaseId !== supabaseUser.id) {
+          await authCache.clear(previousSupabaseId);
+        }
 
         const provisioned = await UserService.getUserWithTenantsForAuth(supabaseUser.id);
         if (!provisioned || provisioned.userTenants.length === 0) {


### PR DESCRIPTION
## Summary
- update SSO bootstrap to auto-link an existing app user by email when Supabase identity changes
- keep existing pass-through for users already provisioned by Supabase ID and provision new users only when no email or ID match exists
- sign out Supabase session when bootstrap returns `requires_registration` to ensure users are unauthenticated before registration

## Test plan
- [x] `cd client && npm run test -- src/services/auth.service.test.ts`
- [x] `cd client && npx eslint src/services/auth.service.ts src/services/auth.service.test.ts`
- [x] `cd server && npx eslint src/modules/user.service.ts src/routes/authentication.routes.ts`
- [ ] Verify SSO flow manually for all four tenant/user matching scenarios


Made with [Cursor](https://cursor.com)