### PR TITLE
feat: apply SSO relink fallback in auth middleware

### DIFF
--- a/server/src/modules/sso-provisioning.service.ts
+++ b/server/src/modules/sso-provisioning.service.ts
@@ -1,0 +1,156 @@
+import type { User as SupabaseUser } from '@supabase/supabase-js';
+import { supabase } from '@/libs/supabase.client';
+import { authCache } from '@/cache/AuthCacheRedis';
+import { UserService } from '@/modules/user.service';
+import { RoleService } from '@/modules/role.service';
+import { TenantService } from '@/modules/tenant.service';
+import { TenantDomainMappingService } from '@/modules/tenant-domain-mapping.service';
+
+type UserWithTenants = NonNullable<
+  Awaited<ReturnType<typeof UserService.getUserWithTenantsForAuth>>
+>;
+
+export type SsoProvisioningResult =
+  | {
+      status: 'invalid_session';
+      message: string;
+    }
+  | {
+      status: 'missing_email';
+      message: string;
+    }
+  | {
+      status: 'requires_registration';
+      email: string;
+      domain: string;
+    }
+  | {
+      status: 'already_provisioned' | 'provisioned';
+      email: string;
+      domain: string;
+      userWithTenants: UserWithTenants;
+      tenantId: string;
+    };
+
+export class SsoProvisioningService {
+  static getTokenFromAuthHeader(authHeader?: string): string | null {
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return null;
+    }
+
+    return authHeader.substring('Bearer '.length);
+  }
+
+  static async resolveFromToken(
+    token: string,
+    initialSupabaseUser?: SupabaseUser | null
+  ): Promise<SsoProvisioningResult> {
+    const resolvedSupabaseUser = initialSupabaseUser ?? (await this.resolveSupabaseUser(token));
+    if (!resolvedSupabaseUser) {
+      return {
+        status: 'invalid_session',
+        message: 'Unable to resolve authenticated user',
+      };
+    }
+
+    const supabaseUserId = resolvedSupabaseUser.id;
+    const email = resolvedSupabaseUser.email?.trim().toLowerCase();
+    if (!email) {
+      return {
+        status: 'missing_email',
+        message: 'Authenticated SSO user does not have an email address',
+      };
+    }
+
+    const domain = TenantDomainMappingService.getDomainFromEmail(email);
+
+    const existingUserWithTenants = await UserService.getUserWithTenantsForAuth(
+      supabaseUserId
+    ).catch(() => null);
+    if (existingUserWithTenants && existingUserWithTenants.userTenants.length > 0) {
+      return {
+        status: 'already_provisioned',
+        email,
+        domain,
+        userWithTenants: existingUserWithTenants,
+        tenantId: existingUserWithTenants.userTenants[0]!.id,
+      };
+    }
+
+    const mapping = await TenantDomainMappingService.findMappingByDomain(domain);
+    if (!mapping) {
+      return {
+        status: 'requires_registration',
+        email,
+        domain,
+      };
+    }
+
+    const existingUserByEmail = await UserService.findUserByEmail(email);
+    let dbUser = existingUserWithTenants?.user ?? existingUserByEmail;
+    let previousSupabaseId: string | null = null;
+
+    if (dbUser && dbUser.supabaseId !== supabaseUserId) {
+      previousSupabaseId = dbUser.supabaseId;
+      dbUser = await UserService.updateUserSupabaseId(dbUser.id, supabaseUserId);
+    }
+
+    if (!dbUser) {
+      const displayName =
+        resolvedSupabaseUser.user_metadata?.full_name ||
+        resolvedSupabaseUser.user_metadata?.name ||
+        resolvedSupabaseUser.user_metadata?.display_name ||
+        undefined;
+
+      dbUser = await UserService.createUser({
+        supabaseId: supabaseUserId,
+        email,
+        name: displayName || undefined,
+      });
+    }
+
+    const defaultSsoRole =
+      (await RoleService.getRoleByName('Sales')) || (await RoleService.getRoleByName('Admin'));
+    if (!defaultSsoRole) {
+      throw new Error('No default role configured for SSO provisioning');
+    }
+
+    await TenantService.addUserToTenant(dbUser.id, mapping.tenantId, defaultSsoRole.id, false);
+    await authCache.clear(supabaseUserId);
+    if (previousSupabaseId && previousSupabaseId !== supabaseUserId) {
+      await authCache.clear(previousSupabaseId);
+    }
+
+    const provisionedUserWithTenants = await UserService.getUserWithTenantsForAuth(
+      supabaseUserId
+    ).catch(() => null);
+    if (!provisionedUserWithTenants || provisionedUserWithTenants.userTenants.length === 0) {
+      throw new Error('Failed to complete SSO provisioning');
+    }
+
+    const resolvedTenant =
+      provisionedUserWithTenants.userTenants.find((tenant) => tenant.id === mapping.tenantId) ||
+      provisionedUserWithTenants.userTenants[0]!;
+
+    return {
+      status: 'provisioned',
+      email,
+      domain,
+      userWithTenants: provisionedUserWithTenants,
+      tenantId: resolvedTenant.id,
+    };
+  }
+
+  private static async resolveSupabaseUser(token: string): Promise<SupabaseUser | null> {
+    const {
+      data: { user: supabaseUser },
+      error: getUserError,
+    } = await supabase.auth.getUser(token);
+
+    if (getUserError || !supabaseUser) {
+      return null;
+    }
+
+    return supabaseUser;
+  }
+}

--- a/server/src/plugins/authentication.plugin.ts
+++ b/server/src/plugins/authentication.plugin.ts
@@ -1,9 +1,13 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import fastifyPlugin from 'fastify-plugin';
+import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { ForbiddenError } from '@/exceptions/error';
 import { logger } from '@/libs/logger';
 import { supabase } from '@/libs/supabase.client';
 import { UserService } from '@/modules/user.service';
+import { RoleService } from '@/modules/role.service';
+import { TenantService } from '@/modules/tenant.service';
+import { TenantDomainMappingService } from '@/modules/tenant-domain-mapping.service';
 import { getDecodedJwt, isTokenExpired } from '@/libs/jwt';
 import { authCache } from '@/cache/AuthCacheRedis';
 
@@ -28,6 +32,98 @@ export interface AuthenticatedRequest extends FastifyRequest {
 
 export default fastifyPlugin(
   async (fastify: FastifyInstance) => {
+    const resolveSupabaseUser = async (
+      token: string
+    ): Promise<{ supabaseUser: SupabaseUser; supabaseUserId: string }> => {
+      const {
+        data: { user: supabaseUser },
+        error,
+      } = await supabase.auth.getUser(token);
+      if (error || !supabaseUser) {
+        logger.warn(`Supabase auth.getUser error: ${error?.message}`);
+        throw new ForbiddenError(`Invalid Token: ${error?.message || 'User not found'}`);
+      }
+
+      return {
+        supabaseUser,
+        supabaseUserId: supabaseUser.id,
+      };
+    };
+
+    const resolveDbUserWithTenants = async (
+      token: string,
+      initialSupabaseUserId: string,
+      initialSupabaseUser: SupabaseUser | null
+    ) => {
+      let dbResult = await UserService.getUserWithTenantsForAuth(initialSupabaseUserId).catch(
+        () => null
+      );
+      if (dbResult) {
+        return dbResult;
+      }
+
+      const resolvedSupabase =
+        initialSupabaseUser && initialSupabaseUser.id === initialSupabaseUserId
+          ? { supabaseUser: initialSupabaseUser, supabaseUserId: initialSupabaseUserId }
+          : await resolveSupabaseUser(token);
+
+      const { supabaseUser, supabaseUserId } = resolvedSupabase;
+      const email = supabaseUser.email?.trim().toLowerCase();
+      if (!email) {
+        throw new ForbiddenError('Authenticated SSO user does not have an email address');
+      }
+
+      const domain = TenantDomainMappingService.getDomainFromEmail(email);
+      const mapping = await TenantDomainMappingService.findMappingByDomain(domain);
+      if (!mapping) {
+        throw new ForbiddenError(
+          'SSO domain is not mapped to a tenant. Complete registration first.'
+        );
+      }
+
+      const existingUserByEmail = await UserService.findUserByEmail(email);
+      let dbUser = existingUserByEmail;
+      let previousSupabaseId: string | null = null;
+
+      if (dbUser && dbUser.supabaseId !== supabaseUserId) {
+        previousSupabaseId = dbUser.supabaseId;
+        dbUser = await UserService.updateUserSupabaseId(dbUser.id, supabaseUserId);
+      }
+
+      if (!dbUser) {
+        const displayName =
+          supabaseUser.user_metadata?.full_name ||
+          supabaseUser.user_metadata?.name ||
+          supabaseUser.user_metadata?.display_name ||
+          undefined;
+
+        dbUser = await UserService.createUser({
+          supabaseId: supabaseUserId,
+          email,
+          name: displayName || undefined,
+        });
+      }
+
+      const defaultSsoRole =
+        (await RoleService.getRoleByName('Sales')) || (await RoleService.getRoleByName('Admin'));
+      if (!defaultSsoRole) {
+        throw new ForbiddenError('No default role configured for SSO provisioning');
+      }
+
+      await TenantService.addUserToTenant(dbUser.id, mapping.tenantId, defaultSsoRole.id, false);
+      await authCache.clear(supabaseUserId);
+      if (previousSupabaseId && previousSupabaseId !== supabaseUserId) {
+        await authCache.clear(previousSupabaseId);
+      }
+
+      dbResult = await UserService.getUserWithTenantsForAuth(supabaseUserId).catch(() => null);
+      if (!dbResult) {
+        throw new ForbiddenError('User not found in database');
+      }
+
+      return dbResult;
+    };
+
     /**
      * Enhanced authentication prehandler - validates JWT, attaches user, and determines tenant context
      * Optimized with caching and single database query
@@ -51,6 +147,7 @@ export default fastifyPlugin(
         let cachedToken = await authCache.getToken(token);
 
         let supabaseUserId: string | null = null;
+        let supabaseUser: SupabaseUser | null = null;
 
         if (!cachedToken || isTokenExpired(token)) {
           await authCache.clearToken(token);
@@ -58,17 +155,9 @@ export default fastifyPlugin(
 
           const supabaseGetUserStart = process.hrtime();
           // Validate JWT with Supabase
-          const {
-            data: { user: supabaseUser },
-            error,
-          } = await supabase.auth.getUser(token);
-          if (error || !supabaseUser) {
-            logger.warn(`Supabase auth.getUser error: ${error?.message}`, {
-              requestUrl: request.url,
-            });
-            throw new ForbiddenError(`Invalid Token: ${error?.message || 'User not found'}`);
-          }
-          supabaseUserId = supabaseUser.id;
+          const resolvedSupabase = await resolveSupabaseUser(token);
+          supabaseUser = resolvedSupabase.supabaseUser;
+          supabaseUserId = resolvedSupabase.supabaseUserId;
 
           const supabaseGetUserEnd = process.hrtime(supabaseGetUserStart);
           const supabaseGetUserDurationMicroSeconds =
@@ -87,7 +176,7 @@ export default fastifyPlugin(
         if (!userData) {
           const dbResultStart = process.hrtime();
           // Cache miss - fetch from database with single optimized query
-          const dbResult = await UserService.getUserWithTenantsForAuth(supabaseUserId);
+          const dbResult = await resolveDbUserWithTenants(token, supabaseUserId, supabaseUser);
           const dbResultEnd = process.hrtime(dbResultStart);
           const dbResultDurationMicroSeconds = dbResultEnd[0] * 1e6 + dbResultEnd[1] / 1e3;
           logger.info(`dbResult took ${dbResultDurationMicroSeconds}μs`, {
@@ -95,10 +184,6 @@ export default fastifyPlugin(
             dbResultEnd: dbResultEnd[0] * 1e6 + dbResultEnd[1] / 1e3,
             dbResultDurationMicroSeconds,
           });
-
-          if (!dbResult) {
-            throw new ForbiddenError('User not found in database');
-          }
 
           if (dbResult.userTenants.length === 0) {
             throw new ForbiddenError('User is not associated with any tenant');

--- a/server/src/plugins/authentication.plugin.ts
+++ b/server/src/plugins/authentication.plugin.ts
@@ -4,10 +4,7 @@ import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { ForbiddenError } from '@/exceptions/error';
 import { logger } from '@/libs/logger';
 import { supabase } from '@/libs/supabase.client';
-import { UserService } from '@/modules/user.service';
-import { RoleService } from '@/modules/role.service';
-import { TenantService } from '@/modules/tenant.service';
-import { TenantDomainMappingService } from '@/modules/tenant-domain-mapping.service';
+import { SsoProvisioningService } from '@/modules/sso-provisioning.service';
 import { getDecodedJwt, isTokenExpired } from '@/libs/jwt';
 import { authCache } from '@/cache/AuthCacheRedis';
 
@@ -48,80 +45,6 @@ export default fastifyPlugin(
         supabaseUser,
         supabaseUserId: supabaseUser.id,
       };
-    };
-
-    const resolveDbUserWithTenants = async (
-      token: string,
-      initialSupabaseUserId: string,
-      initialSupabaseUser: SupabaseUser | null
-    ) => {
-      let dbResult = await UserService.getUserWithTenantsForAuth(initialSupabaseUserId).catch(
-        () => null
-      );
-      if (dbResult) {
-        return dbResult;
-      }
-
-      const resolvedSupabase =
-        initialSupabaseUser && initialSupabaseUser.id === initialSupabaseUserId
-          ? { supabaseUser: initialSupabaseUser, supabaseUserId: initialSupabaseUserId }
-          : await resolveSupabaseUser(token);
-
-      const { supabaseUser, supabaseUserId } = resolvedSupabase;
-      const email = supabaseUser.email?.trim().toLowerCase();
-      if (!email) {
-        throw new ForbiddenError('Authenticated SSO user does not have an email address');
-      }
-
-      const domain = TenantDomainMappingService.getDomainFromEmail(email);
-      const mapping = await TenantDomainMappingService.findMappingByDomain(domain);
-      if (!mapping) {
-        throw new ForbiddenError(
-          'SSO domain is not mapped to a tenant. Complete registration first.'
-        );
-      }
-
-      const existingUserByEmail = await UserService.findUserByEmail(email);
-      let dbUser = existingUserByEmail;
-      let previousSupabaseId: string | null = null;
-
-      if (dbUser && dbUser.supabaseId !== supabaseUserId) {
-        previousSupabaseId = dbUser.supabaseId;
-        dbUser = await UserService.updateUserSupabaseId(dbUser.id, supabaseUserId);
-      }
-
-      if (!dbUser) {
-        const displayName =
-          supabaseUser.user_metadata?.full_name ||
-          supabaseUser.user_metadata?.name ||
-          supabaseUser.user_metadata?.display_name ||
-          undefined;
-
-        dbUser = await UserService.createUser({
-          supabaseId: supabaseUserId,
-          email,
-          name: displayName || undefined,
-        });
-      }
-
-      const defaultSsoRole =
-        (await RoleService.getRoleByName('Sales')) || (await RoleService.getRoleByName('Admin'));
-      if (!defaultSsoRole) {
-        throw new ForbiddenError('No default role configured for SSO provisioning');
-      }
-
-      await TenantService.addUserToTenant(dbUser.id, mapping.tenantId, defaultSsoRole.id, false);
-      await authCache.clear(supabaseUserId);
-      if (previousSupabaseId && previousSupabaseId !== supabaseUserId) {
-        await authCache.clear(previousSupabaseId);
-      }
-
-      dbResult = await UserService.getUserWithTenantsForAuth(supabaseUserId).catch(() => null);
-      if (!dbResult) {
-        throw new ForbiddenError('User not found in database');
-      }
-
-      return dbResult;
     };
 
     /**
@@ -175,8 +98,24 @@ export default fastifyPlugin(
 
         if (!userData) {
           const dbResultStart = process.hrtime();
-          // Cache miss - fetch from database with single optimized query
-          const dbResult = await resolveDbUserWithTenants(token, supabaseUserId, supabaseUser);
+          // Cache miss - resolve and provision SSO user if needed.
+          const ssoProvisioningResult = await SsoProvisioningService.resolveFromToken(
+            token,
+            supabaseUser
+          );
+          if (
+            ssoProvisioningResult.status === 'invalid_session' ||
+            ssoProvisioningResult.status === 'missing_email' ||
+            ssoProvisioningResult.status === 'requires_registration'
+          ) {
+            const errorMessage =
+              ssoProvisioningResult.status === 'requires_registration'
+                ? 'SSO user is not provisioned'
+                : ssoProvisioningResult.message;
+            throw new ForbiddenError(errorMessage);
+          }
+
+          const dbResult = ssoProvisioningResult.userWithTenants;
           const dbResultEnd = process.hrtime(dbResultStart);
           const dbResultDurationMicroSeconds = dbResultEnd[0] * 1e6 + dbResultEnd[1] / 1e3;
           logger.info(`dbResult took ${dbResultDurationMicroSeconds}μs`, {

--- a/server/src/routes/authentication.routes.ts
+++ b/server/src/routes/authentication.routes.ts
@@ -9,6 +9,7 @@ import { TenantService } from '@/modules/tenant.service';
 import { TenantDomainMappingService } from '@/modules/tenant-domain-mapping.service';
 import { RoleService } from '@/modules/role.service';
 import { authCache } from '@/cache/AuthCacheRedis';
+import { SsoProvisioningService } from '@/modules/sso-provisioning.service';
 import { DEFAULT_CALENDAR_TIE_IN } from '@/constants';
 import { ConflictError, NotFoundError } from '@/exceptions/error';
 
@@ -269,128 +270,51 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
     },
     handler: async (request: FastifyRequest, reply: FastifyReply) => {
       try {
-        const authSession = await resolveSupabaseUser(request.headers.authorization);
-        if (!authSession) {
+        const token = SsoProvisioningService.getTokenFromAuthHeader(request.headers.authorization);
+        if (!token) {
           reply.status(401).send({
             message: 'Invalid SSO session',
             error: 'Unable to resolve authenticated user',
           });
           return;
         }
-        const { supabaseUser } = authSession;
+        const ssoProvisioningResult = await SsoProvisioningService.resolveFromToken(token);
 
-        const email = supabaseUser.email?.trim().toLowerCase();
-        if (!email) {
-          reply
-            .status(400)
-            .send({ message: 'Authenticated SSO user does not have an email address' });
+        if (ssoProvisioningResult.status === 'invalid_session') {
+          reply.status(401).send({
+            message: 'Invalid SSO session',
+            error: ssoProvisioningResult.message,
+          });
           return;
         }
 
-        const domain = TenantDomainMappingService.getDomainFromEmail(email);
-        const mapping = await TenantDomainMappingService.findMappingByDomain(domain);
-
-        let existingUserWithTenants: Awaited<
-          ReturnType<typeof UserService.getUserWithTenantsForAuth>
-        > | null = null;
-
-        try {
-          existingUserWithTenants = await UserService.getUserWithTenantsForAuth(supabaseUser.id);
-        } catch (error) {
-          if (!(error instanceof NotFoundError)) {
-            throw error;
-          }
+        if (ssoProvisioningResult.status === 'missing_email') {
+          reply.status(400).send({ message: ssoProvisioningResult.message });
+          return;
         }
 
-        if (existingUserWithTenants && existingUserWithTenants.userTenants.length > 0) {
-          return reply.send({
-            status: 'already_provisioned',
-            user: {
-              id: existingUserWithTenants.user.id,
-              email: existingUserWithTenants.user.email,
-              name: existingUserWithTenants.user.name,
-            },
-            tenant: {
-              id: existingUserWithTenants.userTenants[0]!.id,
-              name: existingUserWithTenants.userTenants[0]!.name,
-            },
-          });
-        }
-
-        if (!mapping) {
+        if (ssoProvisioningResult.status === 'requires_registration') {
           reply.send({
             status: 'requires_registration',
-            email,
-            domain,
+            email: ssoProvisioningResult.email,
+            domain: ssoProvisioningResult.domain,
           });
           return;
         }
-
-        const existingUserByEmail = await UserService.findUserByEmail(email);
-
-        const displayName =
-          supabaseUser.user_metadata?.full_name ||
-          supabaseUser.user_metadata?.name ||
-          supabaseUser.user_metadata?.display_name ||
-          null;
-
-        let dbUser = existingUserWithTenants?.user || null;
-        let previousSupabaseId: string | null = null;
-
-        if (!dbUser && existingUserByEmail) {
-          if (existingUserByEmail.supabaseId !== supabaseUser.id) {
-            previousSupabaseId = existingUserByEmail.supabaseId;
-            dbUser = await UserService.updateUserSupabaseId(
-              existingUserByEmail.id,
-              supabaseUser.id
-            );
-          } else {
-            dbUser = existingUserByEmail;
-          }
-        }
-
-        if (!dbUser) {
-          dbUser = await UserService.createUser({
-            supabaseId: supabaseUser.id,
-            email,
-            name: displayName || undefined,
-          });
-        }
-
-        const defaultSsoRole =
-          (await RoleService.getRoleByName('Sales')) || (await RoleService.getRoleByName('Admin'));
-
-        if (!defaultSsoRole) {
-          reply.status(500).send({ message: 'No default role configured for SSO provisioning' });
-          return;
-        }
-
-        await TenantService.addUserToTenant(dbUser.id, mapping.tenantId, defaultSsoRole.id, false);
-        await authCache.clear(supabaseUser.id);
-        if (previousSupabaseId && previousSupabaseId !== supabaseUser.id) {
-          await authCache.clear(previousSupabaseId);
-        }
-
-        const provisioned = await UserService.getUserWithTenantsForAuth(supabaseUser.id);
-        if (!provisioned || provisioned.userTenants.length === 0) {
-          reply.status(500).send({ message: 'Failed to complete SSO provisioning' });
-          return;
-        }
-
-        const provisionedTenant =
-          provisioned.userTenants.find((tenant) => tenant.id === mapping.tenantId) ||
-          provisioned.userTenants[0]!;
 
         reply.send({
-          status: 'provisioned',
+          status: ssoProvisioningResult.status,
           user: {
-            id: provisioned.user.id,
-            email: provisioned.user.email,
-            name: provisioned.user.name,
+            id: ssoProvisioningResult.userWithTenants.user.id,
+            email: ssoProvisioningResult.userWithTenants.user.email,
+            name: ssoProvisioningResult.userWithTenants.user.name,
           },
           tenant: {
-            id: provisionedTenant.id,
-            name: provisionedTenant.name,
+            id: ssoProvisioningResult.tenantId,
+            name:
+              ssoProvisioningResult.userWithTenants.userTenants.find(
+                (tenant) => tenant.id === ssoProvisioningResult.tenantId
+              )?.name || ssoProvisioningResult.userWithTenants.userTenants[0]!.name,
           },
         });
       } catch (error: any) {


### PR DESCRIPTION
## Summary
- add Supabase user resolution helpers in auth middleware so cache misses can recover user context from the token
- mirror SSO bootstrap fallback in prehandler: enforce mapped SSO domain, relink existing users by email when Supabase ID changes, and provision mapped users when absent
- preserve cache correctness by clearing current and prior Supabase ID cache entries after relink/provision operations

## Test plan
- [x] `cd server && npx eslint src/plugins/authentication.plugin.ts`
- [ ] Verify auth middleware behavior manually for mapped and unmapped SSO domains
- [ ] Verify relink path by authenticating with a new Supabase ID that matches an existing app email


Made with [Cursor](https://cursor.com)