### PR TITLE
Add smart scheduling booking flow

### DIFF
--- a/.cursor/skills/local-supabase-setup/SKILL.md
+++ b/.cursor/skills/local-supabase-setup/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: local-supabase-setup
+description: Run local Supabase setup and troubleshooting for DripIQ. Use when configuring local Supabase, local Auth, local password login, anon key mismatches, Docker Compose Supabase services, or local /auth/v1 failures.
+---
+
+# Local Supabase Setup
+
+Use this runbook for DripIQ's local Supabase stack.
+
+## Rules
+
+- Local auth is password auth only. Do not enable SAML or SSO locally.
+- Public email domains such as `gmail.com`, `yahoo.com`, `outlook.com`, `hotmail.com`, and `icloud.com` must remain password-account domains.
+- Do not add `GOTRUE_SAML_ENABLED`, `GOTRUE_SAML_PRIVATE_KEY`, `ENABLE_SAML`, or `SAML_PRIVATE_KEY` to local setup.
+- Do not create local SAML providers. If one exists, delete it.
+- `server/docker/supabase/.env` and `client/.env` are local-only; do not commit local secret values.
+
+## Start Local Supabase
+
+```bash
+cd server
+docker compose --env-file ./docker/supabase/.env up -d
+```
+
+Use these local values:
+
+```dotenv
+VITE_SUPABASE_URL=http://localhost:8000
+SUPABASE_URL=http://localhost:8000
+```
+
+## Fix Anon Key Mismatch
+
+Kong returns `401` with `WWW-Authenticate: Key` when the client anon key does not match the key loaded into Kong.
+
+1. Compare `client/.env` `VITE_SUPABASE_ANON_KEY` with `server/docker/supabase/.env` `ANON_KEY`.
+2. Align `client/.env` to the local stack anon key.
+3. Recreate only the local auth gateway containers:
+
+```bash
+cd server
+env -u ANON_KEY -u SERVICE_ROLE_KEY docker compose --env-file ./docker/supabase/.env up -d --force-recreate kong auth
+```
+
+4. Restart the client Vite dev server so env changes are loaded.
+
+## Verify Local Auth
+
+Settings should show SAML disabled:
+
+```bash
+curl -sS http://localhost:8000/auth/v1/settings \
+  -H "apikey: <local anon key>"
+```
+
+Expected: `"saml_enabled": false`.
+
+Password login uses Supabase Auth password endpoints through `supabase-js`. Do not route local users through `/auth/v1/sso`.
+
+## Remove Accidental Local SSO Providers
+
+List local SSO providers:
+
+```bash
+curl -sS http://localhost:8000/auth/v1/admin/sso/providers \
+  -H "apikey: <local service role key>" \
+  -H "Authorization: Bearer <local service role key>"
+```
+
+Delete any provider that appears:
+
+```bash
+curl -sS -X DELETE http://localhost:8000/auth/v1/admin/sso/providers/<provider-id> \
+  -H "apikey: <local service role key>" \
+  -H "Authorization: Bearer <local service role key>"
+```
+
+## Verify No Local SSO
+
+This should not return an IdP URL:
+
+```bash
+curl -i -sS http://localhost:8000/auth/v1/sso \
+  -H "apikey: <local anon key>" \
+  -H "Authorization: Bearer <local anon key>" \
+  -H "Content-Type: application/json" \
+  --data '{"domain":"gmail.com","redirect_to":"http://localhost:3000/auth/sso/callback","skip_http_redirect":true}'
+```
+
+Expected: a non-200 SSO discovery error, not an SSO redirect URL.

--- a/client/src/components/EmailProvider.tsx
+++ b/client/src/components/EmailProvider.tsx
@@ -64,6 +64,42 @@ export default function EmailProvider({
     },
   })
 
+  const disconnectProviderMutation = useMutation({
+    mutationFn: (providerId: string) =>
+      getUsersService().disconnectEmailProvider(providerId),
+    onSuccess: (_data, providerId) => {
+      const currentData = queryClient.getQueryData(
+        userQueryKeys.emailProviders(),
+      ) as { providers: EmailProvider[] } | undefined
+
+      if (currentData?.providers) {
+        queryClient.setQueryData(userQueryKeys.emailProviders(), {
+          providers: currentData.providers.map((provider) =>
+            provider.id === providerId
+              ? { ...provider, isConnected: false, isPrimary: false }
+              : provider,
+          ),
+        })
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: userQueryKeys.emailProviders(),
+      })
+    },
+    onError: (error) => {
+      if (onError) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Failed to unlink email provider'
+        onError(errorMessage)
+      }
+      queryClient.invalidateQueries({
+        queryKey: userQueryKeys.emailProviders(),
+      })
+    },
+  })
+
   const getProviderStatus = (providerName: string): EmailProvider | null => {
     return (
       providersData?.providers.find((p) => p.provider === providerName) || null
@@ -76,6 +112,17 @@ export default function EmailProvider({
       return
     }
     switchPrimaryMutation.mutate(providerId)
+  }
+
+  const handleDisconnect = (providerId: string) => {
+    if (disconnectProviderMutation.isPending) return
+
+    const confirmed = window.confirm(
+      'Unlink this email provider? DripIQ will stop using it for sending email and scheduling until you reconnect.',
+    )
+    if (!confirmed) return
+
+    disconnectProviderMutation.mutate(providerId)
   }
 
   if (isLoading) {
@@ -139,8 +186,10 @@ export default function EmailProvider({
           icon={<GoogleIcon />}
           connectedProvider={googleProvider}
           onPrimaryChange={handlePrimaryChange}
+          onDisconnect={handleDisconnect}
           allProviders={providersData?.providers || []}
           isChangingPrimary={switchPrimaryMutation.isPending}
+          isDisconnecting={disconnectProviderMutation.isPending}
         >
           <GoogleProviderButton
             isConnected={googleProvider?.isConnected || false}
@@ -153,8 +202,10 @@ export default function EmailProvider({
           icon={<MicrosoftIcon />}
           connectedProvider={microsoftProvider}
           onPrimaryChange={handlePrimaryChange}
+          onDisconnect={handleDisconnect}
           allProviders={providersData?.providers || []}
           isChangingPrimary={switchPrimaryMutation.isPending}
+          isDisconnecting={disconnectProviderMutation.isPending}
         >
           <MicrosoftProviderButton
             isConnected={microsoftProvider?.isConnected || false}

--- a/client/src/components/ProviderCard.tsx
+++ b/client/src/components/ProviderCard.tsx
@@ -6,8 +6,10 @@ interface ProviderCardProps {
   connectedProvider: EmailProvider | null
   children: React.ReactNode // The provider-specific button component
   onPrimaryChange?: (providerId: string) => void
+  onDisconnect?: (providerId: string) => void
   allProviders?: EmailProvider[]
   isChangingPrimary?: boolean
+  isDisconnecting?: boolean
 }
 
 export default function ProviderCard({
@@ -16,8 +18,10 @@ export default function ProviderCard({
   connectedProvider,
   children,
   onPrimaryChange,
+  onDisconnect,
   allProviders: _allProviders = [],
   isChangingPrimary = false,
+  isDisconnecting = false,
 }: ProviderCardProps) {
   const isConnected = connectedProvider?.isConnected || false
   const isPrimary = connectedProvider?.isPrimary || false
@@ -25,6 +29,12 @@ export default function ProviderCard({
   const handlePrimaryChange = () => {
     if (isConnected && connectedProvider && onPrimaryChange) {
       onPrimaryChange(connectedProvider.id)
+    }
+  }
+
+  const handleDisconnect = () => {
+    if (isConnected && connectedProvider && onDisconnect) {
+      onDisconnect(connectedProvider.id)
     }
   }
 
@@ -79,6 +89,17 @@ export default function ProviderCard({
           )}
 
           {children}
+
+          {isConnected && onDisconnect && (
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              disabled={isDisconnecting}
+              className="inline-flex items-center rounded-lg border border-red-200 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+            >
+              {isDisconnecting ? 'Unlinking...' : 'Unlink'}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/SchedulingSettingsCard.tsx
+++ b/client/src/components/SchedulingSettingsCard.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  useSchedulingSettings,
+  useUpdateSchedulingSettings,
+} from '../hooks/useSchedulingQuery'
+import type {
+  SchedulingSettingsUpdate,
+  WorkingHours,
+} from '../services/scheduling.service'
+
+const DAYS: Array<keyof WorkingHours> = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+]
+
+const DAY_LABELS: Record<keyof WorkingHours, string> = {
+  monday: 'Monday',
+  tuesday: 'Tuesday',
+  wednesday: 'Wednesday',
+  thursday: 'Thursday',
+  friday: 'Friday',
+  saturday: 'Saturday',
+  sunday: 'Sunday',
+}
+
+export default function SchedulingSettingsCard() {
+  const { data, isLoading, error } = useSchedulingSettings()
+  const updateSettings = useUpdateSchedulingSettings()
+  const [form, setForm] = useState<SchedulingSettingsUpdate | null>(null)
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (data) {
+      setForm({
+        timezone: data.timezone,
+        workingHours: data.workingHours,
+        meetingDurationMinutes: data.meetingDurationMinutes,
+        bufferBeforeMinutes: data.bufferBeforeMinutes,
+        bufferAfterMinutes: data.bufferAfterMinutes,
+        minNoticeMinutes: data.minNoticeMinutes,
+        bookingHorizonDays: data.bookingHorizonDays,
+        respectFreeBusy: data.respectFreeBusy,
+      })
+    }
+  }, [data])
+
+  const canSave = useMemo(
+    () => !!form && !updateSettings.isPending,
+    [form, updateSettings.isPending],
+  )
+
+  if (isLoading || !form?.workingHours) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm ring-1 ring-gray-200/60 p-6">
+        <p className="text-sm text-gray-600">Loading scheduling settings...</p>
+      </div>
+    )
+  }
+
+  const setNumber = (field: keyof SchedulingSettingsUpdate, value: string) => {
+    setForm((current) => ({
+      ...current!,
+      [field]: Number(value),
+    }))
+  }
+
+  const setWorkingDay = (
+    day: keyof WorkingHours,
+    field: 'enabled' | 'start' | 'end',
+    value: boolean | string,
+  ) => {
+    setForm((current) => {
+      const workingHours = { ...current!.workingHours! }
+      const firstRange = workingHours[day][0] ?? { start: '09:00', end: '17:00' }
+
+      if (field === 'enabled') {
+        workingHours[day] = value ? [firstRange] : []
+      } else {
+        workingHours[day] = [{ ...firstRange, [field]: value as string }]
+      }
+
+      return { ...current!, workingHours }
+    })
+  }
+
+  const handleSave = async () => {
+    try {
+      setLocalError(null)
+      await updateSettings.mutateAsync(form)
+    } catch (e: any) {
+      setLocalError(e?.message || 'Failed to save scheduling settings')
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm ring-1 ring-gray-200/60 p-6">
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold text-gray-900">Smart Scheduling</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Configure the availability DripIQ uses for authenticated booking
+          links.
+        </p>
+      </div>
+
+      {(error || localError) && (
+        <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm">
+          {localError || (error as Error).message}
+        </div>
+      )}
+
+      {updateSettings.isSuccess && (
+        <div className="mb-4 p-3 rounded-md border border-green-200 bg-green-50 text-green-700 text-sm">
+          Scheduling settings saved.
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700 mb-1">
+            Timezone
+          </span>
+          <input
+            value={form.timezone || ''}
+            onChange={(event) =>
+              setForm((current) => ({
+                ...current!,
+                timezone: event.target.value,
+              }))
+            }
+            className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-200)]"
+            placeholder="America/Chicago"
+          />
+        </label>
+
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700 mb-1">
+            Meeting Duration
+          </span>
+          <select
+            value={form.meetingDurationMinutes}
+            onChange={(event) =>
+              setNumber('meetingDurationMinutes', event.target.value)
+            }
+            className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-200)]"
+          >
+            {[15, 30, 45, 60, 90].map((minutes) => (
+              <option key={minutes} value={minutes}>
+                {minutes} minutes
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700 mb-1">
+            Buffer Before
+          </span>
+          <input
+            type="number"
+            min={0}
+            max={240}
+            value={form.bufferBeforeMinutes}
+            onChange={(event) => setNumber('bufferBeforeMinutes', event.target.value)}
+            className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-200)]"
+          />
+        </label>
+
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700 mb-1">
+            Buffer After
+          </span>
+          <input
+            type="number"
+            min={0}
+            max={240}
+            value={form.bufferAfterMinutes}
+            onChange={(event) => setNumber('bufferAfterMinutes', event.target.value)}
+            className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-200)]"
+          />
+        </label>
+
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700 mb-1">
+            Minimum Notice
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={form.minNoticeMinutes}
+            onChange={(event) => setNumber('minNoticeMinutes', event.target.value)}
+            className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-200)]"
+          />
+        </label>
+
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700 mb-1">
+            Booking Horizon
+          </span>
+          <input
+            type="number"
+            min={1}
+            max={365}
+            value={form.bookingHorizonDays}
+            onChange={(event) => setNumber('bookingHorizonDays', event.target.value)}
+            className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-200)]"
+          />
+        </label>
+      </div>
+
+      <div className="mt-6">
+        <h3 className="text-sm font-medium text-gray-900 mb-3">Working Hours</h3>
+        <div className="space-y-3">
+          {DAYS.map((day) => {
+            const range = form.workingHours?.[day]?.[0]
+            const enabled = !!range
+
+            return (
+              <div
+                key={day}
+                className="grid gap-3 sm:grid-cols-[120px_1fr_1fr] sm:items-center"
+              >
+                <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={(event) =>
+                      setWorkingDay(day, 'enabled', event.target.checked)
+                    }
+                    className="rounded border-gray-300 text-[var(--color-primary-600)]"
+                  />
+                  {DAY_LABELS[day]}
+                </label>
+                <input
+                  type="time"
+                  value={range?.start || '09:00'}
+                  disabled={!enabled}
+                  onChange={(event) => setWorkingDay(day, 'start', event.target.value)}
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm disabled:bg-gray-50 disabled:text-gray-400"
+                />
+                <input
+                  type="time"
+                  value={range?.end || '17:00'}
+                  disabled={!enabled}
+                  onChange={(event) => setWorkingDay(day, 'end', event.target.value)}
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm disabled:bg-gray-50 disabled:text-gray-400"
+                />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <label className="mt-6 flex items-start gap-3 text-sm text-gray-700">
+        <input
+          type="checkbox"
+          checked={form.respectFreeBusy ?? true}
+          onChange={(event) =>
+            setForm((current) => ({
+              ...current!,
+              respectFreeBusy: event.target.checked,
+            }))
+          }
+          className="mt-1 rounded border-gray-300 text-[var(--color-primary-600)]"
+        />
+        <span>
+          Respect free/busy status. When enabled, events marked free will not
+          block booking slots.
+        </span>
+      </label>
+
+      <div className="mt-6">
+        <button
+          onClick={handleSave}
+          disabled={!canSave}
+          className="inline-flex items-center px-5 py-2.5 rounded-lg text-white bg-[var(--color-primary-600)] hover:bg-[var(--color-primary-700)] disabled:opacity-50 shadow-sm"
+        >
+          {updateSettings.isPending ? 'Saving...' : 'Save scheduling settings'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/client/src/hooks/useSchedulingQuery.ts
+++ b/client/src/hooks/useSchedulingQuery.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  schedulingQueryKeys,
+  schedulingService,
+  type SchedulingSettingsUpdate,
+} from '../services/scheduling.service'
+
+export function useSchedulingSettings(enabled = true) {
+  return useQuery({
+    queryKey: schedulingQueryKeys.settings(),
+    queryFn: () => schedulingService.getSettings(),
+    enabled,
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useUpdateSchedulingSettings() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: SchedulingSettingsUpdate) =>
+      schedulingService.updateSettings(data),
+    onSuccess: (settings) => {
+      queryClient.setQueryData(schedulingQueryKeys.settings(), settings)
+      queryClient.invalidateQueries({ queryKey: schedulingQueryKeys.settings() })
+    },
+  })
+}
+
+export function usePublicBookingContext(token: string) {
+  return useQuery({
+    queryKey: schedulingQueryKeys.publicContext(token),
+    queryFn: () => schedulingService.getPublicBookingContext(token),
+    enabled: !!token,
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useAvailability(token: string, startDate: string, endDate: string) {
+  return useQuery({
+    queryKey: schedulingQueryKeys.availability(token, startDate, endDate),
+    queryFn: () => schedulingService.getAvailability(token, startDate, endDate),
+    enabled: !!token && !!startDate && !!endDate,
+    staleTime: 1000 * 15,
+  })
+}
+
+export function useHoldSlot() {
+  return useMutation({
+    mutationFn: ({ token, slot }: { token: string; slot: string }) =>
+      schedulingService.holdSlot(token, slot),
+  })
+}
+
+export function useConfirmBooking() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: {
+      token: string
+      holdId: string
+      slot: string
+      contactDetails: { name: string; email: string; phone?: string }
+    }) => schedulingService.confirmBooking(input),
+    onSuccess: (_result, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: schedulingQueryKeys.all,
+      })
+      queryClient.invalidateQueries({
+        queryKey: schedulingQueryKeys.publicContext(variables.token),
+      })
+    },
+  })
+}

--- a/client/src/hooks/useSchedulingQuery.ts
+++ b/client/src/hooks/useSchedulingQuery.ts
@@ -53,8 +53,6 @@ export function useHoldSlot() {
 }
 
 export function useConfirmBooking() {
-  const queryClient = useQueryClient()
-
   return useMutation({
     mutationFn: (input: {
       token: string
@@ -62,13 +60,5 @@ export function useConfirmBooking() {
       slot: string
       contactDetails: { name: string; email: string; phone?: string }
     }) => schedulingService.confirmBooking(input),
-    onSuccess: (_result, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: schedulingQueryKeys.all,
-      })
-      queryClient.invalidateQueries({
-        queryKey: schedulingQueryKeys.publicContext(variables.token),
-      })
-    },
   })
 }

--- a/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/client/src/integrations/tanstack-query/root-provider.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createLeadsService } from '../../services/leads.service'
 import { createUsersService } from '../../services/users.service'
+import { createSchedulingService } from '../../services/scheduling.service'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,6 +26,7 @@ const queryClient = new QueryClient({
 // Initialize the leads and users services with the query client
 createLeadsService(queryClient)
 createUsersService(queryClient)
+createSchedulingService(queryClient)
 
 export function getContext() {
   return {

--- a/client/src/pages/ScheduleBookingPage.tsx
+++ b/client/src/pages/ScheduleBookingPage.tsx
@@ -8,7 +8,11 @@ import {
 } from '../hooks/useSchedulingQuery'
 
 function toDateString(date: Date) {
-  return date.toISOString().slice(0, 10)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
 }
 
 function addDays(date: Date, days: number) {
@@ -68,6 +72,22 @@ export default function ScheduleBookingPage() {
     [],
   )
 
+  if (bookingComplete) {
+    return (
+      <main className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+        <div className="max-w-md rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-200">
+          <h1 className="text-xl font-semibold text-gray-900">
+            Booking confirmed
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            You&apos;re confirmed. A calendar invitation and confirmation email
+            are on the way.
+          </p>
+        </div>
+      </main>
+    )
+  }
+
   if (contextQuery.isLoading) {
     return (
       <main className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
@@ -113,20 +133,6 @@ export default function ScheduleBookingPage() {
       setSubmitError(error?.message || 'Unable to book this slot. Please try another time.')
       availabilityQuery.refetch()
     }
-  }
-
-  if (bookingComplete) {
-    return (
-      <main className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
-        <div className="max-w-md rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-200">
-          <h1 className="text-xl font-semibold text-gray-900">Demo booked</h1>
-          <p className="mt-2 text-sm text-gray-600">
-            You&apos;re confirmed. A calendar invitation and confirmation email
-            are on the way.
-          </p>
-        </div>
-      </main>
-    )
   }
 
   return (
@@ -211,21 +217,44 @@ export default function ScheduleBookingPage() {
           <div className="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-4">
             <h3 className="text-sm font-medium text-gray-900">Your details</h3>
             <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              <input
-                value={contactName}
-                onChange={(event) => setContactName(event.target.value)}
-                className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
-              />
-              <input
-                value={contactEmail}
-                onChange={(event) => setContactEmail(event.target.value)}
-                className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
-              />
-              <input
-                value={contactPhone}
-                onChange={(event) => setContactPhone(event.target.value)}
-                className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 sm:col-span-2"
-              />
+              <label className="block">
+                <span className="mb-1 block text-sm font-medium text-gray-700">
+                  Name
+                </span>
+                <input
+                  value={contactName}
+                  onChange={(event) => setContactName(event.target.value)}
+                  placeholder="Jane Smith"
+                  autoComplete="name"
+                  className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-sm font-medium text-gray-700">
+                  Email
+                </span>
+                <input
+                  type="email"
+                  value={contactEmail}
+                  onChange={(event) => setContactEmail(event.target.value)}
+                  placeholder="jane@example.com"
+                  autoComplete="email"
+                  className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
+                />
+              </label>
+              <label className="block sm:col-span-2">
+                <span className="mb-1 block text-sm font-medium text-gray-700">
+                  Phone
+                </span>
+                <input
+                  type="tel"
+                  value={contactPhone}
+                  onChange={(event) => setContactPhone(event.target.value)}
+                  placeholder="(555) 123-4567"
+                  autoComplete="tel"
+                  className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
+                />
+              </label>
             </div>
           </div>
 

--- a/client/src/pages/ScheduleBookingPage.tsx
+++ b/client/src/pages/ScheduleBookingPage.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useParams } from '@tanstack/react-router'
+import {
+  useConfirmBooking,
+  useAvailability,
+  useHoldSlot,
+  usePublicBookingContext,
+} from '../hooks/useSchedulingQuery'
+
+function toDateString(date: Date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date)
+  next.setDate(next.getDate() + days)
+  return next
+}
+
+export default function ScheduleBookingPage() {
+  const { token } = useParams({ strict: false }) as { token: string }
+  const [selectedDate, setSelectedDate] = useState(toDateString(new Date()))
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(null)
+  const [contactName, setContactName] = useState('')
+  const [contactEmail, setContactEmail] = useState('')
+  const [contactPhone, setContactPhone] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [bookingComplete, setBookingComplete] = useState(false)
+
+  const contextQuery = usePublicBookingContext(token)
+  const availabilityQuery = useAvailability(token, selectedDate, selectedDate)
+  const holdSlot = useHoldSlot()
+  const confirmBooking = useConfirmBooking()
+
+  useEffect(() => {
+    const context = contextQuery.data
+    if (!context) return
+    setContactName((current) => current || context.contact.name)
+    setContactEmail((current) => current || context.contact.email || '')
+    setContactPhone((current) => current || context.contact.phone || '')
+  }, [contextQuery.data])
+
+  const slots = useMemo(() => {
+    const timezone = availabilityQuery.data?.timezone
+    return (availabilityQuery.data?.availableSlots ?? []).map((slot) => ({
+      value: slot,
+      label: new Intl.DateTimeFormat('en-US', {
+        timeZone: timezone,
+        hour: 'numeric',
+        minute: '2-digit',
+      }).format(new Date(slot)),
+    }))
+  }, [availabilityQuery.data])
+
+  const dateOptions = useMemo(
+    () =>
+      Array.from({ length: 14 }, (_, index) => {
+        const date = addDays(new Date(), index)
+        return {
+          value: toDateString(date),
+          label: new Intl.DateTimeFormat('en-US', {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric',
+          }).format(date),
+        }
+      }),
+    [],
+  )
+
+  if (contextQuery.isLoading) {
+    return (
+      <main className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+        <p className="text-sm text-gray-600">Loading booking page...</p>
+      </main>
+    )
+  }
+
+  if (contextQuery.error || !contextQuery.data) {
+    return (
+      <main className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+        <div className="max-w-md rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-200">
+          <h1 className="text-xl font-semibold text-gray-900">
+            Booking link unavailable
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            This scheduling link is invalid, expired, or no longer available.
+          </p>
+        </div>
+      </main>
+    )
+  }
+
+  const context = contextQuery.data
+
+  const handleConfirm = async () => {
+    if (!selectedSlot) return
+    try {
+      setSubmitError(null)
+      const hold = await holdSlot.mutateAsync({ token, slot: selectedSlot })
+      await confirmBooking.mutateAsync({
+        token,
+        holdId: hold.holdId,
+        slot: selectedSlot,
+        contactDetails: {
+          name: contactName,
+          email: contactEmail,
+          phone: contactPhone || undefined,
+        },
+      })
+      setBookingComplete(true)
+    } catch (error: any) {
+      setSubmitError(error?.message || 'Unable to book this slot. Please try another time.')
+      availabilityQuery.refetch()
+    }
+  }
+
+  if (bookingComplete) {
+    return (
+      <main className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+        <div className="max-w-md rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-200">
+          <h1 className="text-xl font-semibold text-gray-900">Demo booked</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            You&apos;re confirmed. A calendar invitation and confirmation email
+            are on the way.
+          </p>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 p-6">
+      <div className="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[320px_1fr]">
+        <aside className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200">
+          <p className="text-sm font-medium text-[var(--color-primary-700)]">
+            DripIQ Smart Scheduling
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold text-gray-900">
+            Book a sales demo
+          </h1>
+          <p className="mt-3 text-sm text-gray-600">
+            Select a time that works for you. Availability is checked against
+            the rep&apos;s live calendar before booking.
+          </p>
+
+          <div className="mt-6 rounded-xl bg-gray-50 p-4 text-sm text-gray-700">
+            <p className="font-medium text-gray-900">{context.contact.name}</p>
+            {context.contact.email && <p>{context.contact.email}</p>}
+            {context.contact.phone && <p>{context.contact.phone}</p>}
+            <p className="mt-2 text-gray-500">{context.lead.name}</p>
+          </div>
+
+          <p className="mt-4 text-xs text-gray-500">
+            Timezone: {context.timezone}
+          </p>
+        </aside>
+
+        <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Choose a date</h2>
+          <div className="mt-4 grid gap-2 sm:grid-cols-4 lg:grid-cols-7">
+            {dateOptions.map((date) => (
+              <button
+                key={date.value}
+                onClick={() => {
+                  setSelectedDate(date.value)
+                  setSelectedSlot(null)
+                }}
+                className={`rounded-lg border px-3 py-2 text-sm ${
+                  selectedDate === date.value
+                    ? 'border-[var(--color-primary-600)] bg-[var(--color-primary-50)] text-[var(--color-primary-800)]'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {date.label}
+              </button>
+            ))}
+          </div>
+
+          <h2 className="mt-8 text-lg font-semibold text-gray-900">
+            Available times
+          </h2>
+          {availabilityQuery.isLoading ? (
+            <p className="mt-4 text-sm text-gray-600">Checking availability...</p>
+          ) : availabilityQuery.error ? (
+            <p className="mt-4 text-sm text-red-600">
+              Unable to load availability. Please try again.
+            </p>
+          ) : slots.length === 0 ? (
+            <p className="mt-4 text-sm text-gray-600">
+              No slots are available for this date.
+            </p>
+          ) : (
+            <div className="mt-4 grid gap-2 sm:grid-cols-3 lg:grid-cols-4">
+              {slots.map((slot) => (
+                <button
+                  key={slot.value}
+                  onClick={() => setSelectedSlot(slot.value)}
+                  className={`rounded-lg border px-4 py-3 text-sm font-medium ${
+                    selectedSlot === slot.value
+                      ? 'border-[var(--color-primary-600)] bg-[var(--color-primary-600)] text-white'
+                      : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  {slot.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-4">
+            <h3 className="text-sm font-medium text-gray-900">Your details</h3>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <input
+                value={contactName}
+                onChange={(event) => setContactName(event.target.value)}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
+              />
+              <input
+                value={contactEmail}
+                onChange={(event) => setContactEmail(event.target.value)}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700"
+              />
+              <input
+                value={contactPhone}
+                onChange={(event) => setContactPhone(event.target.value)}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 sm:col-span-2"
+              />
+            </div>
+          </div>
+
+          {submitError && (
+            <p className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              {submitError}
+            </p>
+          )}
+
+          <button
+            onClick={handleConfirm}
+            disabled={
+              !selectedSlot ||
+              !contactName ||
+              !contactEmail ||
+              holdSlot.isPending ||
+              confirmBooking.isPending
+            }
+            className="mt-6 inline-flex w-full items-center justify-center rounded-lg bg-[var(--color-primary-600)] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-[var(--color-primary-700)] disabled:opacity-50"
+          >
+            {holdSlot.isPending || confirmBooking.isPending
+              ? 'Booking...'
+              : 'Confirm booking'}
+          </button>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/client/src/pages/users/UserEditPage.tsx
+++ b/client/src/pages/users/UserEditPage.tsx
@@ -7,6 +7,7 @@ import { UrlValidator } from '../../utils/urlValidation'
 import { DEFAULT_CALENDAR_TIE_IN } from '../../constants/user.constants'
 import TestEmailComponent from '../../components/TestEmailComponent'
 import EmailProvider from '../../components/EmailProvider'
+import SchedulingSettingsCard from '../../components/SchedulingSettingsCard'
 
 export default function UserEditPage() {
   const params = useParams({ strict: false }) as { userId?: string }
@@ -243,6 +244,8 @@ export default function UserEditPage() {
 
         {/* Email Provider Card */}
         <EmailProvider onError={(error) => setError(error)} />
+
+        {!isAdminMode && <SchedulingSettingsCard />}
 
         {/* Test Email Card - only show for non-admin mode */}
         {!isAdminMode && (

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -31,6 +31,7 @@ import TermsOfServicePage from './pages/legal/TermsOfServicePage'
 import NotFoundPage from './pages/NotFoundPage'
 import UserEditPage from './pages/users/UserEditPage'
 import UnsubscribePage from './pages/UnsubscribePage'
+import ScheduleBookingPage from './pages/ScheduleBookingPage'
 
 // Import layout components
 import TanStackQueryLayout from './integrations/tanstack-query/layout'
@@ -113,6 +114,12 @@ const unsubscribeSuccessRoute = createRoute({
   validateSearch: (search: Record<string, unknown>) => ({
     email: search.email as string | undefined,
   }),
+})
+
+const scheduleBookingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/schedule/$token',
+  component: () => <ScheduleBookingPage />,
 })
 
 // Protected index route - redirect to dashboard
@@ -268,6 +275,7 @@ const routeTree = rootRoute.addChildren([
   privacyPolicyRoute,
   termsOfServiceRoute,
   unsubscribeSuccessRoute,
+  scheduleBookingRoute,
   protectedRouteTree,
   authRouteTree,
   notFoundRoute,

--- a/client/src/services/scheduling.service.ts
+++ b/client/src/services/scheduling.service.ts
@@ -1,0 +1,214 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { authService } from './auth.service'
+
+export interface WorkingHourRange {
+  start: string
+  end: string
+}
+
+export type WorkingHours = Record<
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday',
+  WorkingHourRange[]
+>
+
+export interface SchedulingSettings {
+  id: string
+  tenantId: string
+  userId: string
+  timezone: string
+  workingHours: WorkingHours
+  meetingDurationMinutes: number
+  bufferBeforeMinutes: number
+  bufferAfterMinutes: number
+  minNoticeMinutes: number
+  bookingHorizonDays: number
+  respectFreeBusy: boolean
+}
+
+export type SchedulingSettingsUpdate = Partial<
+  Omit<SchedulingSettings, 'id' | 'tenantId' | 'userId'>
+>
+
+export interface PublicBookingContext {
+  tokenId: string
+  timezone: string
+  meetingDurationMinutes: number
+  lead: {
+    id: string
+    name: string
+    url: string
+  }
+  contact: {
+    id: string
+    name: string
+    email?: string
+    phone?: string
+    company?: string
+  }
+}
+
+export interface AvailabilityResponse {
+  availableSlots: string[]
+  timezone: string
+}
+
+export interface ScheduleHoldResponse {
+  holdId: string
+  expiresAt: string
+}
+
+export interface ScheduleConfirmResponse {
+  meetingId: string
+  calendarEventLink?: string
+}
+
+export const schedulingQueryKeys = {
+  all: ['scheduling'] as const,
+  settings: () => [...schedulingQueryKeys.all, 'settings'] as const,
+  publicContext: (token: string) =>
+    [...schedulingQueryKeys.all, 'public-context', token] as const,
+  availability: (token: string, start: string, end: string) =>
+    [...schedulingQueryKeys.all, 'availability', token, start, end] as const,
+}
+
+class SchedulingService {
+  private baseUrl = import.meta.env.VITE_API_BASE_URL + '/api'
+  private queryClient: QueryClient | null = null
+
+  constructor(queryClient?: QueryClient) {
+    if (queryClient) {
+      this.queryClient = queryClient
+    }
+  }
+
+  async getSettings(): Promise<SchedulingSettings> {
+    const authHeaders = await authService.getAuthHeaders()
+    const response = await fetch(`${this.baseUrl}/schedule/settings`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+      },
+    })
+
+    return this.parseResponse(response, 'Failed to fetch scheduling settings')
+  }
+
+  async updateSettings(
+    data: SchedulingSettingsUpdate,
+  ): Promise<SchedulingSettings> {
+    const authHeaders = await authService.getAuthHeaders()
+    const response = await fetch(`${this.baseUrl}/schedule/settings`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+      },
+      body: JSON.stringify(data),
+    })
+
+    const settings = await this.parseResponse<SchedulingSettings>(
+      response,
+      'Failed to update scheduling settings',
+    )
+    this.queryClient?.setQueryData(schedulingQueryKeys.settings(), settings)
+    return settings
+  }
+
+  async getPublicBookingContext(
+    token: string,
+  ): Promise<PublicBookingContext> {
+    const response = await fetch(
+      `${this.baseUrl}/schedule/public/${encodeURIComponent(token)}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+
+    return this.parseResponse(response, 'Failed to load booking link')
+  }
+
+  async getAvailability(
+    token: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<AvailabilityResponse> {
+    const url = new URL(`${this.baseUrl}/schedule/availability`)
+    url.searchParams.set('token', token)
+    url.searchParams.set('startDate', startDate)
+    url.searchParams.set('endDate', endDate)
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    return this.parseResponse(response, 'Failed to load availability')
+  }
+
+  async holdSlot(token: string, slot: string): Promise<ScheduleHoldResponse> {
+    const response = await fetch(`${this.baseUrl}/schedule/hold`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ token, slot }),
+    })
+
+    return this.parseResponse(response, 'Failed to hold selected slot')
+  }
+
+  async confirmBooking(input: {
+    token: string
+    holdId: string
+    slot: string
+    contactDetails: { name: string; email: string; phone?: string }
+  }): Promise<ScheduleConfirmResponse> {
+    const response = await fetch(`${this.baseUrl}/schedule/confirm`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(input),
+    })
+
+    return this.parseResponse(response, 'Failed to confirm booking')
+  }
+
+  private async parseResponse<T>(
+    response: Response,
+    fallbackMessage: string,
+  ): Promise<T> {
+    if (!response.ok) {
+      let message = fallbackMessage
+      try {
+        const body = await response.json()
+        message = body.message || body.error || message
+      } catch {
+        message = `${fallbackMessage}: ${response.statusText}`
+      }
+      throw new Error(message)
+    }
+
+    return response.json()
+  }
+}
+
+export let schedulingService = new SchedulingService()
+
+export function createSchedulingService(queryClient: QueryClient) {
+  schedulingService = new SchedulingService(queryClient)
+  return schedulingService
+}
+
+export function getSchedulingService() {
+  return schedulingService
+}

--- a/client/src/services/users.service.ts
+++ b/client/src/services/users.service.ts
@@ -178,6 +178,24 @@ class UsersService {
 
     return result
   }
+
+  async disconnectEmailProvider(
+    providerId: string,
+  ): Promise<{ message: string; provider: EmailProvider }> {
+    const authHeaders = await authService.getAuthHeaders()
+    const res = await fetch(`${this.baseUrl}/me/email-providers/${providerId}`, {
+      method: 'DELETE',
+      headers: {
+        ...authHeaders,
+      },
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.message || 'Failed to disconnect email provider')
+    }
+
+    return res.json()
+  }
 }
 
 let usersServiceInstance: UsersService | null = null

--- a/server/src/cache/ThirdPartyAuthStateCache.ts
+++ b/server/src/cache/ThirdPartyAuthStateCache.ts
@@ -4,6 +4,7 @@ export interface ThirdPartyAuthState {
   tenantId: string;
   userId: string;
   isNewMailAccount: boolean;
+  purpose?: 'mail' | 'calendar';
 }
 
 class ThirdPartyAuthStateCache {

--- a/server/src/db/migrations/0043_smart_scheduling.sql
+++ b/server/src/db/migrations/0043_smart_scheduling.sql
@@ -1,0 +1,104 @@
+CREATE TABLE "dripiq_app"."calendar_connections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"mail_account_id" text,
+	"provider" text NOT NULL,
+	"provider_calendar_id" text DEFAULT 'primary' NOT NULL,
+	"display_name" text,
+	"primary_email" text,
+	"scopes" text[] DEFAULT '{}' NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"reauth_required" boolean DEFAULT false NOT NULL,
+	"connected_at" timestamp DEFAULT now() NOT NULL,
+	"disconnected_at" timestamp,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "dripiq_app"."schedule_booking_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"lead_id" text NOT NULL,
+	"contact_id" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"campaign_id" text,
+	"node_id" text,
+	"outbound_message_id" text,
+	"expires_at" timestamp NOT NULL,
+	"used_at" timestamp,
+	"revoked_at" timestamp,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "schedule_booking_tokens_hash_uq" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "dripiq_app"."scheduled_meetings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"lead_id" text,
+	"contact_id" text,
+	"booking_token_id" text,
+	"campaign_id" text,
+	"calendar_connection_id" text,
+	"start_time" timestamp NOT NULL,
+	"end_time" timestamp NOT NULL,
+	"calendar_event_id" text,
+	"provider" text NOT NULL,
+	"status" text DEFAULT 'confirmed' NOT NULL,
+	"contact_details" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "scheduled_meetings_provider_event_uq" UNIQUE("provider","calendar_event_id")
+);
+--> statement-breakpoint
+CREATE TABLE "dripiq_app"."user_schedule_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"timezone" text DEFAULT 'America/Chicago' NOT NULL,
+	"working_hours" jsonb DEFAULT '{"monday":[{"start":"09:00","end":"17:00"}],"tuesday":[{"start":"09:00","end":"17:00"}],"wednesday":[{"start":"09:00","end":"17:00"}],"thursday":[{"start":"09:00","end":"17:00"}],"friday":[{"start":"09:00","end":"17:00"}],"saturday":[],"sunday":[]}'::jsonb NOT NULL,
+	"meeting_duration_minutes" integer DEFAULT 30 NOT NULL,
+	"buffer_before_minutes" integer DEFAULT 0 NOT NULL,
+	"buffer_after_minutes" integer DEFAULT 0 NOT NULL,
+	"min_notice_minutes" integer DEFAULT 120 NOT NULL,
+	"booking_horizon_days" integer DEFAULT 14 NOT NULL,
+	"respect_free_busy" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_schedule_settings_tenant_user_uq" UNIQUE("tenant_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "dripiq_app"."calendar_connections" ADD CONSTRAINT "calendar_connections_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "dripiq_app"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."calendar_connections" ADD CONSTRAINT "calendar_connections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "dripiq_app"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."calendar_connections" ADD CONSTRAINT "calendar_connections_mail_account_id_mail_accounts_id_fk" FOREIGN KEY ("mail_account_id") REFERENCES "dripiq_app"."mail_accounts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."schedule_booking_tokens" ADD CONSTRAINT "schedule_booking_tokens_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "dripiq_app"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."schedule_booking_tokens" ADD CONSTRAINT "schedule_booking_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "dripiq_app"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."schedule_booking_tokens" ADD CONSTRAINT "schedule_booking_tokens_lead_id_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "dripiq_app"."leads"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."schedule_booking_tokens" ADD CONSTRAINT "schedule_booking_tokens_contact_id_lead_point_of_contacts_id_fk" FOREIGN KEY ("contact_id") REFERENCES "dripiq_app"."lead_point_of_contacts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."schedule_booking_tokens" ADD CONSTRAINT "schedule_booking_tokens_campaign_id_contact_campaigns_id_fk" FOREIGN KEY ("campaign_id") REFERENCES "dripiq_app"."contact_campaigns"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."schedule_booking_tokens" ADD CONSTRAINT "schedule_booking_tokens_outbound_message_id_outbound_messages_id_fk" FOREIGN KEY ("outbound_message_id") REFERENCES "dripiq_app"."outbound_messages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "dripiq_app"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "dripiq_app"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_lead_id_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "dripiq_app"."leads"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_contact_id_lead_point_of_contacts_id_fk" FOREIGN KEY ("contact_id") REFERENCES "dripiq_app"."lead_point_of_contacts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_booking_token_id_schedule_booking_tokens_id_fk" FOREIGN KEY ("booking_token_id") REFERENCES "dripiq_app"."schedule_booking_tokens"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_campaign_id_contact_campaigns_id_fk" FOREIGN KEY ("campaign_id") REFERENCES "dripiq_app"."contact_campaigns"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."scheduled_meetings" ADD CONSTRAINT "scheduled_meetings_calendar_connection_id_calendar_connections_id_fk" FOREIGN KEY ("calendar_connection_id") REFERENCES "dripiq_app"."calendar_connections"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."user_schedule_settings" ADD CONSTRAINT "user_schedule_settings_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "dripiq_app"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dripiq_app"."user_schedule_settings" ADD CONSTRAINT "user_schedule_settings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "dripiq_app"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "calendar_connections_tenant_user_idx" ON "dripiq_app"."calendar_connections" USING btree ("tenant_id","user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "calendar_connections_active_user_uq" ON "dripiq_app"."calendar_connections" USING btree ("tenant_id","user_id") WHERE "dripiq_app"."calendar_connections"."is_active" = true;--> statement-breakpoint
+CREATE INDEX "schedule_booking_tokens_tenant_user_idx" ON "dripiq_app"."schedule_booking_tokens" USING btree ("tenant_id","user_id");--> statement-breakpoint
+CREATE INDEX "schedule_booking_tokens_contact_idx" ON "dripiq_app"."schedule_booking_tokens" USING btree ("tenant_id","contact_id");--> statement-breakpoint
+CREATE INDEX "schedule_booking_tokens_expires_at_idx" ON "dripiq_app"."schedule_booking_tokens" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "scheduled_meetings_tenant_user_start_idx" ON "dripiq_app"."scheduled_meetings" USING btree ("tenant_id","user_id","start_time");--> statement-breakpoint
+CREATE INDEX "scheduled_meetings_contact_idx" ON "dripiq_app"."scheduled_meetings" USING btree ("tenant_id","contact_id");--> statement-breakpoint
+CREATE INDEX "scheduled_meetings_status_idx" ON "dripiq_app"."scheduled_meetings" USING btree ("tenant_id","status");--> statement-breakpoint
+CREATE INDEX "user_schedule_settings_tenant_idx" ON "dripiq_app"."user_schedule_settings" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "user_schedule_settings_user_idx" ON "dripiq_app"."user_schedule_settings" USING btree ("user_id");

--- a/server/src/db/migrations/meta/0043_snapshot.json
+++ b/server/src/db/migrations/meta/0043_snapshot.json
@@ -1,0 +1,5099 @@
+{
+  "id": "f126055d-e6bb-4662-bd93-dbe0489542e0",
+  "prevId": "e58cb4a0-20f9-4dba-9537-ab88a67f11d5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "dripiq_app.calendar_connections": {
+      "name": "calendar_connections",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_account_id": {
+          "name": "mail_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_calendar_id": {
+          "name": "provider_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reauth_required": {
+          "name": "reauth_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_connections_tenant_user_idx": {
+          "name": "calendar_connections_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_connections_active_user_uq": {
+          "name": "calendar_connections_active_user_uq",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dripiq_app\".\"calendar_connections\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_connections_tenant_id_tenants_id_fk": {
+          "name": "calendar_connections_tenant_id_tenants_id_fk",
+          "tableFrom": "calendar_connections",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_connections_user_id_users_id_fk": {
+          "name": "calendar_connections_user_id_users_id_fk",
+          "tableFrom": "calendar_connections",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_connections_mail_account_id_mail_accounts_id_fk": {
+          "name": "calendar_connections_mail_account_id_mail_accounts_id_fk",
+          "tableFrom": "calendar_connections",
+          "tableTo": "mail_accounts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "mail_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.calendar_link_clicks": {
+      "name": "calendar_link_clicks",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbound_message_id": {
+          "name": "outbound_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_link_clicks_tenant_id_idx": {
+          "name": "calendar_link_clicks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_link_clicks_lead_id_idx": {
+          "name": "calendar_link_clicks_lead_id_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_link_clicks_contact_id_idx": {
+          "name": "calendar_link_clicks_contact_id_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_link_clicks_user_id_idx": {
+          "name": "calendar_link_clicks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_link_clicks_clicked_at_idx": {
+          "name": "calendar_link_clicks_clicked_at_idx",
+          "columns": [
+            {
+              "expression": "clicked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_link_clicks_tenant_id_tenants_id_fk": {
+          "name": "calendar_link_clicks_tenant_id_tenants_id_fk",
+          "tableFrom": "calendar_link_clicks",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_link_clicks_lead_id_leads_id_fk": {
+          "name": "calendar_link_clicks_lead_id_leads_id_fk",
+          "tableFrom": "calendar_link_clicks",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_link_clicks_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "calendar_link_clicks_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "calendar_link_clicks",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_link_clicks_user_id_users_id_fk": {
+          "name": "calendar_link_clicks_user_id_users_id_fk",
+          "tableFrom": "calendar_link_clicks",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.campaign_plan_versions": {
+      "name": "campaign_plan_versions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_json": {
+          "name": "plan_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_hash": {
+          "name": "plan_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_plan_versions_hash_idx": {
+          "name": "campaign_plan_versions_hash_idx",
+          "columns": [
+            {
+              "expression": "plan_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_plan_versions_plan_json_gin_idx": {
+          "name": "campaign_plan_versions_plan_json_gin_idx",
+          "columns": [
+            {
+              "expression": "plan_json",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_plan_versions_tenant_id_tenants_id_fk": {
+          "name": "campaign_plan_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "campaign_plan_versions",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_plan_versions_campaign_id_contact_campaigns_id_fk": {
+          "name": "campaign_plan_versions_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "campaign_plan_versions",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_plan_versions_created_by_users_id_fk": {
+          "name": "campaign_plan_versions_created_by_users_id_fk",
+          "tableFrom": "campaign_plan_versions",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "campaign_version_unique": {
+          "name": "campaign_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "campaign_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.campaign_transitions": {
+      "name": "campaign_transitions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "campaign_status",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "campaign_status",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_transitions_campaign_idx": {
+          "name": "campaign_transitions_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_transitions_tenant_id_tenants_id_fk": {
+          "name": "campaign_transitions_tenant_id_tenants_id_fk",
+          "tableFrom": "campaign_transitions",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_transitions_campaign_id_contact_campaigns_id_fk": {
+          "name": "campaign_transitions_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "campaign_transitions",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_transitions_created_by_users_id_fk": {
+          "name": "campaign_transitions_created_by_users_id_fk",
+          "tableFrom": "campaign_transitions",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.communication_suppressions": {
+      "name": "communication_suppressions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "campaign_channel",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communication_suppressions_suppressed_at_idx": {
+          "name": "communication_suppressions_suppressed_at_idx",
+          "columns": [
+            {
+              "expression": "suppressed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communication_suppressions_tenant_id_tenants_id_fk": {
+          "name": "communication_suppressions_tenant_id_tenants_id_fk",
+          "tableFrom": "communication_suppressions",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "communication_suppressions_unique": {
+          "name": "communication_suppressions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "channel",
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.contact_campaigns": {
+      "name": "contact_campaigns",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "campaign_channel",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "campaign_status",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_node_id": {
+          "name": "current_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_json": {
+          "name": "plan_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "plan_hash": {
+          "name": "plan_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_campaigns_status_idx": {
+          "name": "contact_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_campaigns_plan_hash_idx": {
+          "name": "contact_campaigns_plan_hash_idx",
+          "columns": [
+            {
+              "expression": "plan_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_campaigns_plan_json_gin_idx": {
+          "name": "contact_campaigns_plan_json_gin_idx",
+          "columns": [
+            {
+              "expression": "plan_json",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_campaigns_tenant_id_tenants_id_fk": {
+          "name": "contact_campaigns_tenant_id_tenants_id_fk",
+          "tableFrom": "contact_campaigns",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_campaigns_lead_id_leads_id_fk": {
+          "name": "contact_campaigns_lead_id_leads_id_fk",
+          "tableFrom": "contact_campaigns",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_campaigns_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "contact_campaigns_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "contact_campaigns",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_channel_unique": {
+          "name": "contact_channel_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "contact_id",
+            "channel"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.contact_channels": {
+      "name": "contact_channels",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "campaign_channel",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_result_id": {
+          "name": "validation_result_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_channels_primary_idx": {
+          "name": "contact_channels_primary_idx",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_channels_tenant_id_tenants_id_fk": {
+          "name": "contact_channels_tenant_id_tenants_id_fk",
+          "tableFrom": "contact_channels",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_channels_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "contact_channels_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "contact_channels",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_channels_validation_result_id_email_validation_results_id_fk": {
+          "name": "contact_channels_validation_result_id_email_validation_results_id_fk",
+          "tableFrom": "contact_channels",
+          "tableTo": "email_validation_results",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "validation_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_channels_unique": {
+          "name": "contact_channels_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "contact_id",
+            "type",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.contact_unsubscribes": {
+      "name": "contact_unsubscribes",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_value": {
+          "name": "channel_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribe_source": {
+          "name": "unsubscribe_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_unsubscribes_tenant_channel_idx": {
+          "name": "contact_unsubscribes_tenant_channel_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_unsubscribes_channel_value_idx": {
+          "name": "contact_unsubscribes_channel_value_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_unsubscribes_unsubscribed_at_idx": {
+          "name": "contact_unsubscribes_unsubscribed_at_idx",
+          "columns": [
+            {
+              "expression": "unsubscribed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_unsubscribes_source_idx": {
+          "name": "contact_unsubscribes_source_idx",
+          "columns": [
+            {
+              "expression": "unsubscribe_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_unsubscribes_tenant_id_tenants_id_fk": {
+          "name": "contact_unsubscribes_tenant_id_tenants_id_fk",
+          "tableFrom": "contact_unsubscribes",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_unsubscribes_campaign_id_contact_campaigns_id_fk": {
+          "name": "contact_unsubscribes_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "contact_unsubscribes",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_unsubscribes_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "contact_unsubscribes_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "contact_unsubscribes",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_unsubscribes_unique": {
+          "name": "contact_unsubscribes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "channel",
+            "channel_value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.domain_validation": {
+      "name": "domain_validation",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_validation_domain_idx": {
+          "name": "domain_validation_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_validation_domain_unique": {
+          "name": "domain_validation_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.email_validation_results": {
+      "name": "email_validation_results",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_validation_results_checked_at_idx": {
+          "name": "email_validation_results_checked_at_idx",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_validation_results_tenant_id_tenants_id_fk": {
+          "name": "email_validation_results_tenant_id_tenants_id_fk",
+          "tableFrom": "email_validation_results",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_validation_results_unique": {
+          "name": "email_validation_results_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.inbound_messages": {
+      "name": "inbound_messages",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "campaign_channel",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbound_messages_received_at_idx": {
+          "name": "inbound_messages_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_provider_id_idx": {
+          "name": "inbound_messages_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_messages_tenant_id_tenants_id_fk": {
+          "name": "inbound_messages_tenant_id_tenants_id_fk",
+          "tableFrom": "inbound_messages",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_messages_campaign_id_contact_campaigns_id_fk": {
+          "name": "inbound_messages_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "inbound_messages",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_messages_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "inbound_messages_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "inbound_messages",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.lead_point_of_contacts": {
+      "name": "lead_point_of_contacts",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_result": {
+          "name": "email_verification_result",
+          "type": "email_verification_result",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_reviewed": {
+          "name": "manually_reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "strategy_status": {
+          "name": "strategy_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_point_of_contacts_lead_id_leads_id_fk": {
+          "name": "lead_point_of_contacts_lead_id_leads_id_fk",
+          "tableFrom": "lead_point_of_contacts",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.lead_products": {
+      "name": "lead_products",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_products_lead_id_leads_id_fk": {
+          "name": "lead_products_lead_id_leads_id_fk",
+          "tableFrom": "lead_products",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_products_product_id_products_id_fk": {
+          "name": "lead_products_product_id_products_id_fk",
+          "tableFrom": "lead_products",
+          "tableTo": "products",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lead_products_lead_id_product_id_unique": {
+          "name": "lead_products_lead_id_product_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lead_id",
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.lead_statuses": {
+      "name": "lead_statuses",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_statuses_lead_id_leads_id_fk": {
+          "name": "lead_statuses_lead_id_leads_id_fk",
+          "tableFrom": "lead_statuses",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lead_statuses_tenant_id_tenants_id_fk": {
+          "name": "lead_statuses_tenant_id_tenants_id_fk",
+          "tableFrom": "lead_statuses",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lead_status_unique": {
+          "name": "lead_status_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lead_id",
+            "status"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.leads": {
+      "name": "leads",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "products": {
+          "name": "products",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "differentiators": {
+          "name": "differentiators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_colors": {
+          "name": "brand_colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_contact_id": {
+          "name": "primary_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_embedding_domain_id": {
+          "name": "site_embedding_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leads_owner_id_users_id_fk": {
+          "name": "leads_owner_id_users_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "leads_tenant_id_tenants_id_fk": {
+          "name": "leads_tenant_id_tenants_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leads_site_embedding_domain_id_site_embedding_domains_id_fk": {
+          "name": "leads_site_embedding_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "site_embedding_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.mail_accounts": {
+      "name": "mail_accounts",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id_provider": {
+          "name": "tenant_id_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required": {
+          "name": "reauth_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_accounts_email_idx": {
+          "name": "mail_accounts_email_idx",
+          "columns": [
+            {
+              "expression": "primary_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_accounts_user_idx": {
+          "name": "mail_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_accounts_tenant_idx": {
+          "name": "mail_accounts_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_accounts_user_primary_uq": {
+          "name": "mail_accounts_user_primary_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dripiq_app\".\"mail_accounts\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_accounts_user_id_users_id_fk": {
+          "name": "mail_accounts_user_id_users_id_fk",
+          "tableFrom": "mail_accounts",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_accounts_tenant_id_tenants_id_fk": {
+          "name": "mail_accounts_tenant_id_tenants_id_fk",
+          "tableFrom": "mail_accounts",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_accounts_provider_identity_uq": {
+          "name": "mail_accounts_provider_identity_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ]
+        },
+        "mail_accounts_user_provider_uq": {
+          "name": "mail_accounts_user_provider_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.message_events": {
+      "name": "message_events",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sg_event_id": {
+          "name": "sg_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_events_tenant_type_idx": {
+          "name": "message_events_tenant_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_events_event_at_idx": {
+          "name": "message_events_event_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_events_sg_event_id_idx": {
+          "name": "message_events_sg_event_id_idx",
+          "columns": [
+            {
+              "expression": "sg_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_events_tenant_id_tenants_id_fk": {
+          "name": "message_events_tenant_id_tenants_id_fk",
+          "tableFrom": "message_events",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_events_message_id_outbound_messages_id_fk": {
+          "name": "message_events_message_id_outbound_messages_id_fk",
+          "tableFrom": "message_events",
+          "tableTo": "outbound_messages",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mail_account_id": {
+          "name": "mail_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "token_status",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inactive_after": {
+          "name": "inactive_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_tokens_account_idx": {
+          "name": "oauth_tokens_account_idx",
+          "columns": [
+            {
+              "expression": "mail_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_tokens_active_idx": {
+          "name": "oauth_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "mail_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_tokens_mail_account_id_mail_accounts_id_fk": {
+          "name": "oauth_tokens_mail_account_id_mail_accounts_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "mail_accounts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "mail_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.outbound_messages": {
+      "name": "outbound_messages",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "campaign_channel",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "outbound_message_state",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_at": {
+          "name": "error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "outbound_messages_state_idx": {
+          "name": "outbound_messages_state_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_provider_id_idx": {
+          "name": "outbound_messages_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbound_messages_tenant_id_tenants_id_fk": {
+          "name": "outbound_messages_tenant_id_tenants_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "outbound_messages_campaign_id_contact_campaigns_id_fk": {
+          "name": "outbound_messages_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "outbound_messages_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "outbound_messages_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "outbound_messages_dedupe_unique": {
+          "name": "outbound_messages_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "dedupe_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.permissions": {
+      "name": "permissions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.products": {
+      "name": "products",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_voice": {
+          "name": "sales_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_tenant_id_tenants_id_fk": {
+          "name": "products_tenant_id_tenants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.role_permissions": {
+      "name": "role_permissions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_permission_unique": {
+          "name": "role_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.roles": {
+      "name": "roles",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.schedule_booking_tokens": {
+      "name": "schedule_booking_tokens",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbound_message_id": {
+          "name": "outbound_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_booking_tokens_tenant_user_idx": {
+          "name": "schedule_booking_tokens_tenant_user_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_booking_tokens_contact_idx": {
+          "name": "schedule_booking_tokens_contact_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_booking_tokens_expires_at_idx": {
+          "name": "schedule_booking_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_booking_tokens_tenant_id_tenants_id_fk": {
+          "name": "schedule_booking_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "schedule_booking_tokens",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_booking_tokens_user_id_users_id_fk": {
+          "name": "schedule_booking_tokens_user_id_users_id_fk",
+          "tableFrom": "schedule_booking_tokens",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_booking_tokens_lead_id_leads_id_fk": {
+          "name": "schedule_booking_tokens_lead_id_leads_id_fk",
+          "tableFrom": "schedule_booking_tokens",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_booking_tokens_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "schedule_booking_tokens_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "schedule_booking_tokens",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_booking_tokens_campaign_id_contact_campaigns_id_fk": {
+          "name": "schedule_booking_tokens_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "schedule_booking_tokens",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_booking_tokens_outbound_message_id_outbound_messages_id_fk": {
+          "name": "schedule_booking_tokens_outbound_message_id_outbound_messages_id_fk",
+          "tableFrom": "schedule_booking_tokens",
+          "tableTo": "outbound_messages",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "outbound_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "schedule_booking_tokens_hash_uq": {
+          "name": "schedule_booking_tokens_hash_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.scheduled_actions": {
+      "name": "scheduled_actions",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scheduled_action_status",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bullmq_job_id": {
+          "name": "bullmq_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_actions_tenant_status_idx": {
+          "name": "scheduled_actions_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_actions_scheduled_at_idx": {
+          "name": "scheduled_actions_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_actions_tenant_id_tenants_id_fk": {
+          "name": "scheduled_actions_tenant_id_tenants_id_fk",
+          "tableFrom": "scheduled_actions",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_actions_campaign_id_contact_campaigns_id_fk": {
+          "name": "scheduled_actions_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "scheduled_actions",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.scheduled_meetings": {
+      "name": "scheduled_meetings",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booking_token_id": {
+          "name": "booking_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_connection_id": {
+          "name": "calendar_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "contact_details": {
+          "name": "contact_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_meetings_tenant_user_start_idx": {
+          "name": "scheduled_meetings_tenant_user_start_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_meetings_contact_idx": {
+          "name": "scheduled_meetings_contact_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_meetings_status_idx": {
+          "name": "scheduled_meetings_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_meetings_tenant_id_tenants_id_fk": {
+          "name": "scheduled_meetings_tenant_id_tenants_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_meetings_user_id_users_id_fk": {
+          "name": "scheduled_meetings_user_id_users_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_meetings_lead_id_leads_id_fk": {
+          "name": "scheduled_meetings_lead_id_leads_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "leads",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_meetings_contact_id_lead_point_of_contacts_id_fk": {
+          "name": "scheduled_meetings_contact_id_lead_point_of_contacts_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "lead_point_of_contacts",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_meetings_booking_token_id_schedule_booking_tokens_id_fk": {
+          "name": "scheduled_meetings_booking_token_id_schedule_booking_tokens_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "schedule_booking_tokens",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "booking_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_meetings_campaign_id_contact_campaigns_id_fk": {
+          "name": "scheduled_meetings_campaign_id_contact_campaigns_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "contact_campaigns",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scheduled_meetings_calendar_connection_id_calendar_connections_id_fk": {
+          "name": "scheduled_meetings_calendar_connection_id_calendar_connections_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "calendar_connections",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "calendar_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scheduled_meetings_provider_event_uq": {
+          "name": "scheduled_meetings_provider_event_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "calendar_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.send_rate_limits": {
+      "name": "send_rate_limits",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "campaign_channel",
+          "typeSchema": "dripiq_app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tenant'"
+        },
+        "window_seconds": {
+          "name": "window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_sends": {
+          "name": "max_sends",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "send_rate_limits_channel_idx": {
+          "name": "send_rate_limits_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "send_rate_limits_tenant_id_tenants_id_fk": {
+          "name": "send_rate_limits_tenant_id_tenants_id_fk",
+          "tableFrom": "send_rate_limits",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "send_rate_limits_unique": {
+          "name": "send_rate_limits_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "channel",
+            "scope"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.site_embedding_domains": {
+      "name": "site_embedding_domains",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "site_scraped_at_idx": {
+          "name": "site_scraped_at_idx",
+          "columns": [
+            {
+              "expression": "scraped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "site_embedding_domains_domain_unique": {
+          "name": "site_embedding_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.site_embeddings": {
+      "name": "site_embeddings",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_summary": {
+          "name": "content_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firecrawl_id": {
+          "name": "firecrawl_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_embeddings_idx": {
+          "name": "domain_embeddings_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_embedding_idx": {
+          "name": "site_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "site_embedding_token_count_idx": {
+          "name": "site_embedding_token_count_idx",
+          "columns": [
+            {
+              "expression": "token_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_embedding_content_idx": {
+          "name": "site_embedding_content_idx",
+          "columns": [
+            {
+              "expression": "content",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_embeddings_domain_id_site_embedding_domains_id_fk": {
+          "name": "site_embeddings_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "site_embeddings",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.tenant_domain_mappings": {
+      "name": "tenant_domain_mappings",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_domain_mapping_tenant_idx": {
+          "name": "tenant_domain_mapping_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_domain_mappings_tenant_id_tenants_id_fk": {
+          "name": "tenant_domain_mappings_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_domain_mappings",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_domain_mapping_domain_unique": {
+          "name": "tenant_domain_mapping_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.tenants": {
+      "name": "tenants",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_name": {
+          "name": "organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_website": {
+          "name": "organization_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_summary": {
+          "name": "organization_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "differentiators": {
+          "name": "differentiators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_colors": {
+          "name": "brand_colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_embedding_domain_id": {
+          "name": "site_embedding_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenants_site_embedding_domain_id_site_embedding_domains_id_fk": {
+          "name": "tenants_site_embedding_domain_id_site_embedding_domains_id_fk",
+          "tableFrom": "tenants",
+          "tableTo": "site_embedding_domains",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "site_embedding_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.user_schedule_settings": {
+      "name": "user_schedule_settings",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Chicago'"
+        },
+        "working_hours": {
+          "name": "working_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"monday\":[{\"start\":\"09:00\",\"end\":\"17:00\"}],\"tuesday\":[{\"start\":\"09:00\",\"end\":\"17:00\"}],\"wednesday\":[{\"start\":\"09:00\",\"end\":\"17:00\"}],\"thursday\":[{\"start\":\"09:00\",\"end\":\"17:00\"}],\"friday\":[{\"start\":\"09:00\",\"end\":\"17:00\"}],\"saturday\":[],\"sunday\":[]}'::jsonb"
+        },
+        "meeting_duration_minutes": {
+          "name": "meeting_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "buffer_before_minutes": {
+          "name": "buffer_before_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "buffer_after_minutes": {
+          "name": "buffer_after_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_notice_minutes": {
+          "name": "min_notice_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "booking_horizon_days": {
+          "name": "booking_horizon_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "respect_free_busy": {
+          "name": "respect_free_busy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_schedule_settings_tenant_idx": {
+          "name": "user_schedule_settings_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_schedule_settings_user_idx": {
+          "name": "user_schedule_settings_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_schedule_settings_tenant_id_tenants_id_fk": {
+          "name": "user_schedule_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "user_schedule_settings",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_schedule_settings_user_id_users_id_fk": {
+          "name": "user_schedule_settings_user_id_users_id_fk",
+          "tableFrom": "user_schedule_settings",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_schedule_settings_tenant_user_uq": {
+          "name": "user_schedule_settings_tenant_user_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.user_tenants": {
+      "name": "user_tenants",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_user": {
+          "name": "is_super_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tenants_user_id_users_id_fk": {
+          "name": "user_tenants_user_id_users_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "users",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenants_tenant_id_tenants_id_fk": {
+          "name": "user_tenants_tenant_id_tenants_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenants_role_id_roles_id_fk": {
+          "name": "user_tenants_role_id_roles_id_fk",
+          "tableFrom": "user_tenants",
+          "tableTo": "roles",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_tenant_unique": {
+          "name": "user_tenant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.users": {
+      "name": "users",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supabase_id": {
+          "name": "supabase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_link": {
+          "name": "calendar_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_tie_in": {
+          "name": "calendar_tie_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'If you''re interested, feel free to grab some time on my calendar'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_supabase_id_unique": {
+          "name": "users_supabase_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "dripiq_app.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "dripiq_app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_provider_idx": {
+          "name": "webhook_deliveries_provider_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_received_at_idx": {
+          "name": "webhook_deliveries_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_tenant_id_tenants_id_fk": {
+          "name": "webhook_deliveries_tenant_id_tenants_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "tenants",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_message_id_outbound_messages_id_fk": {
+          "name": "webhook_deliveries_message_id_outbound_messages_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "outbound_messages",
+          "schemaTo": "dripiq_app",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "dripiq_app.campaign_status": {
+      "name": "campaign_status",
+      "schema": "dripiq_app",
+      "values": [
+        "draft",
+        "active",
+        "paused",
+        "completed",
+        "stopped",
+        "error"
+      ]
+    },
+    "dripiq_app.campaign_channel": {
+      "name": "campaign_channel",
+      "schema": "dripiq_app",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "dripiq_app.email_verification_result": {
+      "name": "email_verification_result",
+      "schema": "dripiq_app",
+      "values": [
+        "valid",
+        "invalid",
+        "unknown",
+        "ok_for_all",
+        "inferred"
+      ]
+    },
+    "dripiq_app.outbound_message_state": {
+      "name": "outbound_message_state",
+      "schema": "dripiq_app",
+      "values": [
+        "queued",
+        "scheduled",
+        "sent",
+        "failed",
+        "canceled"
+      ]
+    },
+    "dripiq_app.provider": {
+      "name": "provider",
+      "schema": "dripiq_app",
+      "values": [
+        "google",
+        "microsoft"
+      ]
+    },
+    "dripiq_app.scheduled_action_status": {
+      "name": "scheduled_action_status",
+      "schema": "dripiq_app",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "dripiq_app.token_status": {
+      "name": "token_status",
+      "schema": "dripiq_app",
+      "values": [
+        "active",
+        "revoked"
+      ]
+    }
+  },
+  "schemas": {
+    "dripiq_app": "dripiq_app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1766500000000,
       "tag": "0042_tenant_domain_mappings",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1777225184900,
+      "tag": "0043_smart_scheduling",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -881,6 +881,160 @@ export const calendarLinkClicks = appSchema.table(
   ]
 );
 
+export const userScheduleSettings = appSchema.table(
+  'user_schedule_settings',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    timezone: text('timezone').notNull().default('America/Chicago'),
+    workingHours: jsonb('working_hours')
+      .notNull()
+      .default(
+        sql`'{"monday":[{"start":"09:00","end":"17:00"}],"tuesday":[{"start":"09:00","end":"17:00"}],"wednesday":[{"start":"09:00","end":"17:00"}],"thursday":[{"start":"09:00","end":"17:00"}],"friday":[{"start":"09:00","end":"17:00"}],"saturday":[],"sunday":[]}'::jsonb`
+      ),
+    meetingDurationMinutes: integer('meeting_duration_minutes').notNull().default(30),
+    bufferBeforeMinutes: integer('buffer_before_minutes').notNull().default(0),
+    bufferAfterMinutes: integer('buffer_after_minutes').notNull().default(0),
+    minNoticeMinutes: integer('min_notice_minutes').notNull().default(120),
+    bookingHorizonDays: integer('booking_horizon_days').notNull().default(14),
+    respectFreeBusy: boolean('respect_free_busy').notNull().default(true),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    unique('user_schedule_settings_tenant_user_uq').on(table.tenantId, table.userId),
+    index('user_schedule_settings_tenant_idx').on(table.tenantId),
+    index('user_schedule_settings_user_idx').on(table.userId),
+  ]
+);
+
+export const scheduleBookingTokens = appSchema.table(
+  'schedule_booking_tokens',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    leadId: text('lead_id')
+      .notNull()
+      .references(() => leads.id, { onDelete: 'cascade' }),
+    contactId: text('contact_id')
+      .notNull()
+      .references(() => leadPointOfContacts.id, { onDelete: 'cascade' }),
+    tokenHash: text('token_hash').notNull(),
+    campaignId: text('campaign_id').references(() => contactCampaigns.id, { onDelete: 'set null' }),
+    nodeId: text('node_id'),
+    outboundMessageId: text('outbound_message_id').references(() => outboundMessages.id, {
+      onDelete: 'set null',
+    }),
+    expiresAt: timestamp('expires_at').notNull(),
+    usedAt: timestamp('used_at'),
+    revokedAt: timestamp('revoked_at'),
+    metadata: jsonb('metadata').notNull().default({}),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    unique('schedule_booking_tokens_hash_uq').on(table.tokenHash),
+    index('schedule_booking_tokens_tenant_user_idx').on(table.tenantId, table.userId),
+    index('schedule_booking_tokens_contact_idx').on(table.tenantId, table.contactId),
+    index('schedule_booking_tokens_expires_at_idx').on(table.expiresAt),
+  ]
+);
+
+export const calendarConnections = appSchema.table(
+  'calendar_connections',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    mailAccountId: text('mail_account_id').references(() => mailAccounts.id, {
+      onDelete: 'set null',
+    }),
+    provider: text('provider').notNull(),
+    providerCalendarId: text('provider_calendar_id').notNull().default('primary'),
+    displayName: text('display_name'),
+    primaryEmail: text('primary_email'),
+    scopes: text('scopes').array().notNull().default([]),
+    isActive: boolean('is_active').notNull().default(true),
+    reauthRequired: boolean('reauth_required').notNull().default(false),
+    connectedAt: timestamp('connected_at').notNull().defaultNow(),
+    disconnectedAt: timestamp('disconnected_at'),
+    metadata: jsonb('metadata').notNull().default({}),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    index('calendar_connections_tenant_user_idx').on(table.tenantId, table.userId),
+    uniqueIndex('calendar_connections_active_user_uq')
+      .on(table.tenantId, table.userId)
+      .where(sql`${table.isActive} = true`),
+  ]
+);
+
+export const scheduledMeetings = appSchema.table(
+  'scheduled_meetings',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    leadId: text('lead_id').references(() => leads.id, { onDelete: 'set null' }),
+    contactId: text('contact_id').references(() => leadPointOfContacts.id, {
+      onDelete: 'set null',
+    }),
+    bookingTokenId: text('booking_token_id').references(() => scheduleBookingTokens.id, {
+      onDelete: 'set null',
+    }),
+    campaignId: text('campaign_id').references(() => contactCampaigns.id, { onDelete: 'set null' }),
+    calendarConnectionId: text('calendar_connection_id').references(() => calendarConnections.id, {
+      onDelete: 'set null',
+    }),
+    startTime: timestamp('start_time').notNull(),
+    endTime: timestamp('end_time').notNull(),
+    calendarEventId: text('calendar_event_id'),
+    provider: text('provider').notNull(),
+    status: text('status').notNull().default('confirmed'),
+    contactDetails: jsonb('contact_details').notNull().default({}),
+    metadata: jsonb('metadata').notNull().default({}),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    index('scheduled_meetings_tenant_user_start_idx').on(
+      table.tenantId,
+      table.userId,
+      table.startTime
+    ),
+    index('scheduled_meetings_contact_idx').on(table.tenantId, table.contactId),
+    index('scheduled_meetings_status_idx').on(table.tenantId, table.status),
+    unique('scheduled_meetings_provider_event_uq').on(table.provider, table.calendarEventId),
+  ]
+);
+
 // ---- Email Provider Connection Enums
 export const providerEnum = appSchema.enum('provider', ['google', 'microsoft']);
 export const tokenStatusEnum = appSchema.enum('token_status', ['active', 'revoked']);
@@ -1156,6 +1310,92 @@ export const calendarLinkClicksRelations = relations(calendarLinkClicks, ({ one 
   }),
 }));
 
+export const userScheduleSettingsRelations = relations(userScheduleSettings, ({ one }) => ({
+  tenant: one(tenants, {
+    fields: [userScheduleSettings.tenantId],
+    references: [tenants.id],
+  }),
+  user: one(users, {
+    fields: [userScheduleSettings.userId],
+    references: [users.id],
+  }),
+}));
+
+export const scheduleBookingTokensRelations = relations(scheduleBookingTokens, ({ one, many }) => ({
+  tenant: one(tenants, {
+    fields: [scheduleBookingTokens.tenantId],
+    references: [tenants.id],
+  }),
+  user: one(users, {
+    fields: [scheduleBookingTokens.userId],
+    references: [users.id],
+  }),
+  lead: one(leads, {
+    fields: [scheduleBookingTokens.leadId],
+    references: [leads.id],
+  }),
+  contact: one(leadPointOfContacts, {
+    fields: [scheduleBookingTokens.contactId],
+    references: [leadPointOfContacts.id],
+  }),
+  campaign: one(contactCampaigns, {
+    fields: [scheduleBookingTokens.campaignId],
+    references: [contactCampaigns.id],
+  }),
+  outboundMessage: one(outboundMessages, {
+    fields: [scheduleBookingTokens.outboundMessageId],
+    references: [outboundMessages.id],
+  }),
+  scheduledMeetings: many(scheduledMeetings),
+}));
+
+export const calendarConnectionsRelations = relations(calendarConnections, ({ one, many }) => ({
+  tenant: one(tenants, {
+    fields: [calendarConnections.tenantId],
+    references: [tenants.id],
+  }),
+  user: one(users, {
+    fields: [calendarConnections.userId],
+    references: [users.id],
+  }),
+  mailAccount: one(mailAccounts, {
+    fields: [calendarConnections.mailAccountId],
+    references: [mailAccounts.id],
+  }),
+  scheduledMeetings: many(scheduledMeetings),
+}));
+
+export const scheduledMeetingsRelations = relations(scheduledMeetings, ({ one }) => ({
+  tenant: one(tenants, {
+    fields: [scheduledMeetings.tenantId],
+    references: [tenants.id],
+  }),
+  user: one(users, {
+    fields: [scheduledMeetings.userId],
+    references: [users.id],
+  }),
+  lead: one(leads, {
+    fields: [scheduledMeetings.leadId],
+    references: [leads.id],
+  }),
+  contact: one(leadPointOfContacts, {
+    fields: [scheduledMeetings.contactId],
+    references: [leadPointOfContacts.id],
+  }),
+  bookingToken: one(scheduleBookingTokens, {
+    fields: [scheduledMeetings.bookingTokenId],
+    references: [scheduleBookingTokens.id],
+  }),
+  campaign: one(contactCampaigns, {
+    fields: [scheduledMeetings.campaignId],
+    references: [contactCampaigns.id],
+  }),
+  calendarConnection: one(calendarConnections, {
+    fields: [scheduledMeetings.calendarConnectionId],
+    references: [calendarConnections.id],
+  }),
+}));
+
 // Email Provider Connection Relations
 export const mailAccountsRelations = relations(mailAccounts, ({ one, many }) => ({
   user: one(users, {
@@ -1235,6 +1475,14 @@ export type DomainValidation = typeof domainValidation.$inferSelect;
 export type NewDomainValidation = typeof domainValidation.$inferInsert;
 export type CalendarLinkClick = typeof calendarLinkClicks.$inferSelect;
 export type NewCalendarLinkClick = typeof calendarLinkClicks.$inferInsert;
+export type UserScheduleSetting = typeof userScheduleSettings.$inferSelect;
+export type NewUserScheduleSetting = typeof userScheduleSettings.$inferInsert;
+export type ScheduleBookingToken = typeof scheduleBookingTokens.$inferSelect;
+export type NewScheduleBookingToken = typeof scheduleBookingTokens.$inferInsert;
+export type CalendarConnection = typeof calendarConnections.$inferSelect;
+export type NewCalendarConnection = typeof calendarConnections.$inferInsert;
+export type ScheduledMeeting = typeof scheduledMeetings.$inferSelect;
+export type NewScheduledMeeting = typeof scheduledMeetings.$inferInsert;
 export type MailAccount = typeof mailAccounts.$inferSelect;
 export type NewMailAccount = typeof mailAccounts.$inferInsert;
 export type OauthToken = typeof oauthTokens.$inferSelect;

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { TenantService } from '@/modules/tenant.service';
 import { RoleService } from '@/modules/role.service';
 import { logger } from '@/libs/logger';
@@ -64,49 +64,54 @@ async function seed() {
 }
 
 async function createSeedUser() {
-  // Check if seed user already exists
+  const localSeedEmail = 'ryanzhutch+local@gmail.com';
+  const localSupabaseId = await resolveLocalSeedSupabaseId(localSeedEmail);
   const supabaseId =
     process.env.NODE_ENV === 'production'
       ? 'fee55c3d-5077-41ba-8e42-a2f97c64cd92'
-      : '91d39f85-07b7-4ae7-8da9-b4e4e675ce55';
-  const existingSeedUser = await db
+      : localSupabaseId;
+
+  const seedUserData = [
+    {
+      supabaseId: 'fee55c3d-5077-41ba-8e42-a2f97c64cd92',
+      email: `ryanzhutch+production@gmail.com`,
+      name: 'Ryan Prod',
+      createdAt: new Date('2025-06-30T03:46:22.185Z'),
+      updatedAt: new Date('2025-06-30T16:58:18.567Z'),
+    },
+    {
+      supabaseId: localSupabaseId,
+      email: localSeedEmail,
+      name: 'Ryan Local',
+      createdAt: new Date('2025-06-30T03:46:22.185Z'),
+      updatedAt: new Date('2025-06-30T16:58:18.567Z'),
+    },
+  ];
+
+  await db
+    .insert(users)
+    .values(seedUserData)
+    .onConflictDoUpdate({
+      target: users.email,
+      set: {
+        supabaseId: sql`excluded.supabase_id`,
+        name: sql`excluded.name`,
+        updatedAt: sql`excluded.updated_at`,
+      },
+    });
+
+  const [seedUser] = await db
     .select()
     .from(users)
     .where(eq(users.supabaseId, supabaseId))
     .limit(1);
 
-  if (existingSeedUser.length > 0) {
-    logger.debug('ℹ️  Seed user already exists, skipping creation');
-    return;
-  }
-
-  // Create the seed user
-  const [seedUser] = await db
-    .insert(users)
-    .values([
-      {
-        supabaseId: 'fee55c3d-5077-41ba-8e42-a2f97c64cd92',
-        email: `ryanzhutch+production@gmail.com`,
-        name: 'Ryan Prod',
-        createdAt: new Date('2025-06-30T03:46:22.185Z'),
-        updatedAt: new Date('2025-06-30T16:58:18.567Z'),
-      },
-      {
-        supabaseId: '91d39f85-07b7-4ae7-8da9-b4e4e675ce55',
-        email: `ryanzhutch+local@gmail.com`,
-        name: 'Ryan Local',
-        createdAt: new Date('2025-06-30T03:46:22.185Z'),
-        updatedAt: new Date('2025-06-30T16:58:18.567Z'),
-      },
-    ])
-    .returning();
-
   if (!seedUser) {
-    logger.error('❌ Failed to create seed user');
+    logger.error('❌ Failed to resolve seed user', { supabaseId });
     return;
   }
 
-  logger.debug('✅ Seed user created', { email: seedUser.email });
+  logger.debug('✅ Seed user resolved', { email: seedUser.email });
 
   // Get the first tenant to assign the user to
   const firstTenant = await db.select().from(tenants).limit(1);
@@ -132,6 +137,17 @@ async function createSeedUser() {
     return;
   }
 
+  const existingUserTenant = await db
+    .select()
+    .from(userTenants)
+    .where(and(eq(userTenants.userId, seedUser.id), eq(userTenants.tenantId, tenant.id)))
+    .limit(1);
+
+  if (existingUserTenant.length > 0) {
+    logger.debug('ℹ️  Seed user tenant assignment already exists, skipping creation');
+    return;
+  }
+
   await db.insert(userTenants).values({
     userId: seedUser.id,
     tenantId: tenant.id,
@@ -142,6 +158,17 @@ async function createSeedUser() {
   logger.debug(
     `✅ Assigned seed user to tenant "${tenant.name}" as Admin with super user privileges`
   );
+}
+
+async function resolveLocalSeedSupabaseId(email: string) {
+  const authUsers = await db.execute<{ id: string }>(sql`
+    select id::text as id
+    from auth.users
+    where lower(email) = lower(${email})
+    limit 1
+  `);
+
+  return authUsers[0]?.id || '91d39f85-07b7-4ae7-8da9-b4e4e675ce55';
 }
 
 // Export for external use and auto-execute

--- a/server/src/libs/isFakeMail.client.spec.ts
+++ b/server/src/libs/isFakeMail.client.spec.ts
@@ -1,0 +1,52 @@
+const mockHttpClient = {
+  get: jest.fn(),
+};
+
+jest.mock('axios', () => ({
+  create: jest.fn(() => mockHttpClient),
+}));
+
+import isFakeMail from './isFakeMail.client';
+
+describe('isFakeMail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects public provider emails when verification runs', async () => {
+    mockHttpClient.get.mockResolvedValue({
+      data: {
+        isDisposable: false,
+        isPublicProvider: true,
+        mx: ['gmail-smtp-in.l.google.com'],
+      },
+    });
+
+    await expect(isFakeMail('rzhutch98@gmail.com')).resolves.toBe(false);
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/check?url=rzhutch98%40gmail.com&mx=true');
+  });
+
+  it('rejects disposable emails', async () => {
+    mockHttpClient.get.mockResolvedValue({
+      data: {
+        isDisposable: true,
+        isPublicProvider: false,
+        mx: ['mx.example.com'],
+      },
+    });
+
+    await expect(isFakeMail('user@example.com')).resolves.toBe(false);
+  });
+
+  it('rejects emails without MX records', async () => {
+    mockHttpClient.get.mockResolvedValue({
+      data: {
+        isDisposable: false,
+        isPublicProvider: false,
+        mx: [],
+      },
+    });
+
+    await expect(isFakeMail('user@example.com')).resolves.toBe(false);
+  });
+});

--- a/server/src/libs/isFakeMail.client.ts
+++ b/server/src/libs/isFakeMail.client.ts
@@ -5,7 +5,7 @@ const isFakeMailClient = axios.create({
 });
 
 async function isFakeMail(email: string): Promise<boolean> {
-  const response = await isFakeMailClient.get(`/check?url=${email}&mx=true`);
+  const response = await isFakeMailClient.get(`/check?url=${encodeURIComponent(email)}&mx=true`);
 
   const { isDisposable, isPublicProvider, mx } = response.data;
 

--- a/server/src/libs/thirdPartyAuth/GoogleAuth.ts
+++ b/server/src/libs/thirdPartyAuth/GoogleAuth.ts
@@ -19,3 +19,10 @@ export const googleScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'openid',
 ];
+
+export const googleCalendarScopes = [
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+  'https://www.googleapis.com/auth/calendar.events',
+  'openid',
+];

--- a/server/src/libs/thirdPartyAuth/GoogleAuth.ts
+++ b/server/src/libs/thirdPartyAuth/GoogleAuth.ts
@@ -17,6 +17,7 @@ export const googleScopes = [
   'https://www.googleapis.com/auth/userinfo.email',
   'https://www.googleapis.com/auth/userinfo.profile',
   'https://www.googleapis.com/auth/gmail.send',
+  'https://www.googleapis.com/auth/calendar.events',
   'openid',
 ];
 

--- a/server/src/libs/thirdPartyAuth/MicrosoftAuth.ts
+++ b/server/src/libs/thirdPartyAuth/MicrosoftAuth.ts
@@ -130,3 +130,12 @@ export const microsoftScopes = [
   'offline_access',
   'openid',
 ];
+
+export const microsoftCalendarScopes = [
+  'email',
+  'User.Read',
+  'Calendars.ReadWrite',
+  'profile',
+  'offline_access',
+  'openid',
+];

--- a/server/src/modules/email/EmailProcessor.ts
+++ b/server/src/modules/email/EmailProcessor.ts
@@ -107,29 +107,48 @@ export class EmailProcessor {
       // Prepare email body and calendar information
       let emailBody = body;
 
-      if (calendarInfo?.calendarLink && calendarInfo?.calendarTieIn) {
+      if (calendarInfo?.calendarTieIn) {
         try {
-          let trackedCalendarUrl = calendarUrlWrapper.generateTrackedCalendarUrl({
-            tenantId,
-            leadId: calendarInfo.leadId,
-            contactId,
-            campaignId,
-            nodeId,
-            outboundMessageId,
-          });
+          const configuredCalendarLink = calendarInfo.calendarLink?.trim();
+          let trackedCalendarUrl: string | undefined;
 
           if (!skipMessageRecord) {
-            const { rawToken } = await bookingTokenService.issue({
+            try {
+              const { rawToken } = await bookingTokenService.issue({
+                tenantId,
+                leadId: calendarInfo.leadId,
+                contactId,
+                userId,
+                campaignId,
+                nodeId,
+                outboundMessageId,
+              });
+              trackedCalendarUrl = bookingTokenService.buildBookingUrl(rawToken);
+            } catch (bookingTokenError) {
+              logger.error('[EmailProcessor] Failed to create Smart Scheduling link', {
+                tenantId,
+                campaignId,
+                contactId,
+                nodeId,
+                error:
+                  bookingTokenError instanceof Error
+                    ? bookingTokenError.message
+                    : 'Unknown error',
+              });
+            }
+          }
+
+          trackedCalendarUrl =
+            trackedCalendarUrl ||
+            configuredCalendarLink ||
+            calendarUrlWrapper.generateTrackedCalendarUrl({
               tenantId,
               leadId: calendarInfo.leadId,
               contactId,
-              userId,
               campaignId,
               nodeId,
               outboundMessageId,
             });
-            trackedCalendarUrl = bookingTokenService.buildBookingUrl(rawToken);
-          }
 
           const calendarMessage = calendarUrlWrapper.createCalendarMessage(
             calendarInfo.calendarTieIn,

--- a/server/src/modules/email/EmailProcessor.ts
+++ b/server/src/modules/email/EmailProcessor.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import { logger } from '@/libs/logger';
 import { calendarUrlWrapper } from '@/libs/calendar/calendarUrlWrapper';
+import { bookingTokenService } from '@/modules/scheduling/BookingTokenService';
 import {
   formatEmailBodyForHtml,
   formatEmailBodyForText,
@@ -108,7 +109,7 @@ export class EmailProcessor {
 
       if (calendarInfo?.calendarLink && calendarInfo?.calendarTieIn) {
         try {
-          const trackedCalendarUrl = calendarUrlWrapper.generateTrackedCalendarUrl({
+          let trackedCalendarUrl = calendarUrlWrapper.generateTrackedCalendarUrl({
             tenantId,
             leadId: calendarInfo.leadId,
             contactId,
@@ -116,6 +117,19 @@ export class EmailProcessor {
             nodeId,
             outboundMessageId,
           });
+
+          if (!skipMessageRecord) {
+            const { rawToken } = await bookingTokenService.issue({
+              tenantId,
+              leadId: calendarInfo.leadId,
+              contactId,
+              userId,
+              campaignId,
+              nodeId,
+              outboundMessageId,
+            });
+            trackedCalendarUrl = bookingTokenService.buildBookingUrl(rawToken);
+          }
 
           const calendarMessage = calendarUrlWrapper.createCalendarMessage(
             calendarInfo.calendarTieIn,

--- a/server/src/modules/newGoogleProvider.service.ts
+++ b/server/src/modules/newGoogleProvider.service.ts
@@ -5,7 +5,7 @@ import { mailAccountRepository, oauthTokenRepository } from '@/repositories';
 import { CreateOauthTokenPayload } from '@/repositories/entities/OauthTokenRepository';
 
 class NewGoogleProviderService {
-  async setupNewAccount(tenantId: string, userId: string, code: string): Promise<void> {
+  async setupNewAccount(tenantId: string, userId: string, code: string): Promise<MailAccount> {
     const oauth2Client = getGoogleOAuth2Client();
 
     // Exchange authorization code for tokens
@@ -24,12 +24,17 @@ class NewGoogleProviderService {
       throw new Error('Failed to get user payload from ID token');
     }
 
+    if (!payload.sub) {
+      throw new Error('Google account identity missing from ID token');
+    }
+
     if (!tokens.refresh_token) {
       throw new Error('Failed to get refresh token');
     }
 
     const mailAccount = await this.createMailAccount(tenantId, userId, payload, tokens.scope);
     await this.createOAuthToken(mailAccount.id, tokens.refresh_token);
+    return mailAccount;
   }
 
   private async createOAuthToken(mailAccountId: string, refreshToken: string): Promise<void> {
@@ -49,6 +54,23 @@ class NewGoogleProviderService {
     scopes?: string
   ): Promise<MailAccount> {
     const { sub, email, name } = tokenPayload;
+
+    if (!sub) {
+      throw new Error('Google account identity missing from ID token');
+    }
+
+    const existingMailAccount = await mailAccountRepository.findByProviderIdentity('google', sub);
+    if (existingMailAccount) {
+      if (existingMailAccount.tenantId !== tenantId || existingMailAccount.userId !== userId) {
+        throw new Error('Google account is already connected to another user');
+      }
+
+      return await mailAccountRepository.reconnectProvider(userId, existingMailAccount.id, {
+        primaryEmail: email || existingMailAccount.primaryEmail,
+        displayName: name || existingMailAccount.displayName,
+        scopes: scopes?.split(' ') || existingMailAccount.scopes,
+      });
+    }
 
     const mailAccount: NewMailAccount = {
       userId: userId,

--- a/server/src/modules/newMicrosoftProvider.service.ts
+++ b/server/src/modules/newMicrosoftProvider.service.ts
@@ -4,7 +4,7 @@ import { mailAccountRepository, oauthTokenRepository } from '@/repositories';
 import { CreateOauthTokenPayload } from '@/repositories/entities/OauthTokenRepository';
 
 class NewMicrosoftProviderService {
-  async setupNewAccount(tenantId: string, userId: string, code: string): Promise<void> {
+  async setupNewAccount(tenantId: string, userId: string, code: string): Promise<MailAccount> {
     const oauth2Client = getMicrosoftOAuth2Client();
 
     // Exchange authorization code for tokens
@@ -24,6 +24,7 @@ class NewMicrosoftProviderService {
       tokenResponse.scope
     );
     await this.createOAuthToken(mailAccount.id, tokenResponse.refresh_token);
+    return mailAccount;
   }
 
   private async createOAuthToken(mailAccountId: string, refreshToken: string): Promise<void> {
@@ -47,6 +48,19 @@ class NewMicrosoftProviderService {
 
     // Use mail if available, otherwise fall back to userPrincipalName
     const primaryEmail = mail || userPrincipalName;
+
+    const existingMailAccount = await mailAccountRepository.findByProviderIdentity('microsoft', id);
+    if (existingMailAccount) {
+      if (existingMailAccount.tenantId !== tenantId || existingMailAccount.userId !== userId) {
+        throw new Error('Microsoft account is already connected to another user');
+      }
+
+      return await mailAccountRepository.reconnectProvider(userId, existingMailAccount.id, {
+        primaryEmail,
+        displayName: displayName || existingMailAccount.displayName,
+        scopes: scopes?.split(' ') || existingMailAccount.scopes,
+      });
+    }
 
     const mailAccount: NewMailAccount = {
       userId: userId,

--- a/server/src/modules/scheduling/AvailabilityService.ts
+++ b/server/src/modules/scheduling/AvailabilityService.ts
@@ -1,0 +1,265 @@
+import { calendarConnectionService } from './calendar/CalendarConnectionService';
+import { calendarProviderFactory } from './calendar/CalendarProviderFactory';
+import { bookingTokenService } from './BookingTokenService';
+import {
+  SchedulingSettingsService,
+  WorkingHours,
+  schedulingSettingsService,
+} from './SchedulingSettingsService';
+import { ServiceUnavailableError } from '@/exceptions/error';
+
+export interface TimeInterval {
+  start: Date;
+  end: Date;
+}
+
+export interface AvailabilityRequest {
+  tenantId: string;
+  userId: string;
+  startDate: string;
+  endDate: string;
+  now?: Date;
+}
+
+export interface AvailabilityResponse {
+  availableSlots: string[];
+  timezone: string;
+}
+
+const DAY_KEYS: Array<keyof WorkingHours> = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+];
+
+export class AvailabilityService {
+  constructor(private readonly settingsService: SchedulingSettingsService) {}
+
+  async getAvailabilityForToken(
+    rawToken: string,
+    startDate: string,
+    endDate: string,
+    now = new Date()
+  ): Promise<AvailabilityResponse> {
+    const context = await bookingTokenService.resolve(rawToken);
+    return await this.getAvailability({
+      tenantId: context.token.tenantId,
+      userId: context.token.userId,
+      startDate,
+      endDate,
+      now,
+    });
+  }
+
+  async getAvailability(request: AvailabilityRequest): Promise<AvailabilityResponse> {
+    const settings = await this.settingsService.getForUser(request.tenantId, request.userId);
+    const connection = await calendarConnectionService.getActiveConnection(
+      request.tenantId,
+      request.userId
+    );
+    if (!connection) {
+      throw new ServiceUnavailableError('No scheduling calendar connected');
+    }
+
+    const provider = calendarProviderFactory.create(connection);
+    const rangeStart = this.zonedTimeToUtc(request.startDate, '00:00', settings.timezone);
+    const rangeEnd = this.zonedTimeToUtc(request.endDate, '23:59', settings.timezone);
+    const events = await provider.listEvents({
+      calendarId: connection.providerCalendarId,
+      timeMin: rangeStart,
+      timeMax: rangeEnd,
+    });
+
+    const blockers = this.mergeIntervals(
+      events
+        .filter((event) => (settings.respectFreeBusy ? event.isBusy : true))
+        .map((event) => ({
+          start: this.addMinutes(event.start, -settings.bufferBeforeMinutes),
+          end: this.addMinutes(event.end, settings.bufferAfterMinutes),
+        }))
+    );
+
+    const now = request.now ?? new Date();
+    const noticeStart = new Date(now.getTime() + settings.minNoticeMinutes * 60 * 1000);
+    const horizonEnd = new Date(now.getTime() + settings.bookingHorizonDays * 24 * 60 * 60 * 1000);
+    const workingIntervals = this.workingIntervals(
+      request.startDate,
+      request.endDate,
+      settings.timezone,
+      settings.workingHours as WorkingHours
+    ).map((interval) => ({
+      start: new Date(
+        Math.max(interval.start.getTime(), noticeStart.getTime(), rangeStart.getTime())
+      ),
+      end: new Date(Math.min(interval.end.getTime(), horizonEnd.getTime(), rangeEnd.getTime())),
+    }));
+
+    const availableIntervals = workingIntervals.flatMap((interval) =>
+      this.subtractIntervals(interval, blockers)
+    );
+
+    const slots = this.slotsFromIntervals(availableIntervals, settings.meetingDurationMinutes);
+
+    return {
+      availableSlots: slots.map((slot) => slot.toISOString()),
+      timezone: settings.timezone,
+    };
+  }
+
+  isSlotAvailable(slotStart: Date, availableSlots: string[]): boolean {
+    return availableSlots.some((slot) => new Date(slot).getTime() === slotStart.getTime());
+  }
+
+  workingIntervals(
+    startDate: string,
+    endDate: string,
+    timezone: string,
+    workingHours: WorkingHours
+  ): TimeInterval[] {
+    const dates = this.dateStringsBetween(startDate, endDate);
+    return dates.flatMap((dateString) => {
+      const dayKey = DAY_KEYS[this.localDayIndex(dateString, timezone)];
+      if (!dayKey) return [];
+
+      return (workingHours[dayKey] ?? []).map((range) => ({
+        start: this.zonedTimeToUtc(dateString, range.start, timezone),
+        end: this.zonedTimeToUtc(dateString, range.end, timezone),
+      }));
+    });
+  }
+
+  mergeIntervals(intervals: TimeInterval[]): TimeInterval[] {
+    const sorted = intervals
+      .filter((interval) => interval.start < interval.end)
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+    const merged: TimeInterval[] = [];
+
+    for (const interval of sorted) {
+      const last = merged.at(-1);
+      if (!last || interval.start > last.end) {
+        merged.push({ ...interval });
+      } else if (interval.end > last.end) {
+        last.end = interval.end;
+      }
+    }
+
+    return merged;
+  }
+
+  subtractIntervals(interval: TimeInterval, blockers: TimeInterval[]): TimeInterval[] {
+    let remaining = [interval];
+
+    for (const blocker of blockers) {
+      remaining = remaining.flatMap((candidate) => {
+        if (blocker.end <= candidate.start || blocker.start >= candidate.end) {
+          return [candidate];
+        }
+
+        const pieces: TimeInterval[] = [];
+        if (blocker.start > candidate.start) {
+          pieces.push({ start: candidate.start, end: blocker.start });
+        }
+        if (blocker.end < candidate.end) {
+          pieces.push({ start: blocker.end, end: candidate.end });
+        }
+        return pieces;
+      });
+    }
+
+    return remaining;
+  }
+
+  slotsFromIntervals(intervals: TimeInterval[], durationMinutes: number): Date[] {
+    const durationMs = durationMinutes * 60 * 1000;
+    const slots: Date[] = [];
+
+    for (const interval of intervals) {
+      for (
+        let cursor = interval.start.getTime();
+        cursor + durationMs <= interval.end.getTime();
+        cursor += durationMs
+      ) {
+        slots.push(new Date(cursor));
+      }
+    }
+
+    return slots;
+  }
+
+  addMinutes(date: Date, minutes: number): Date {
+    return new Date(date.getTime() + minutes * 60 * 1000);
+  }
+
+  private dateStringsBetween(startDate: string, endDate: string): string[] {
+    const dates: string[] = [];
+    const cursor = new Date(`${startDate}T00:00:00.000Z`);
+    const end = new Date(`${endDate}T00:00:00.000Z`);
+
+    while (cursor <= end) {
+      dates.push(cursor.toISOString().slice(0, 10));
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+
+    return dates;
+  }
+
+  private localDayIndex(dateString: string, timezone: string): number {
+    const date = this.zonedTimeToUtc(dateString, '12:00', timezone);
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      weekday: 'short',
+    }).format(date);
+    return ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(parts);
+  }
+
+  private zonedTimeToUtc(dateString: string, time: string, timezone: string): Date {
+    const [year, month, day] = dateString.split('-').map(Number);
+    const [hour, minute] = time.split(':').map(Number);
+    if (
+      year === undefined ||
+      month === undefined ||
+      day === undefined ||
+      hour === undefined ||
+      minute === undefined
+    ) {
+      throw new Error('Invalid date or time');
+    }
+
+    const localAsUtc = new Date(Date.UTC(year, month - 1, day, hour, minute, 0));
+    const offset = this.getTimeZoneOffset(localAsUtc, timezone);
+    const firstPass = new Date(localAsUtc.getTime() - offset);
+    const correctedOffset = this.getTimeZoneOffset(firstPass, timezone);
+    return new Date(localAsUtc.getTime() - correctedOffset);
+  }
+
+  private getTimeZoneOffset(date: Date, timezone: string): number {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(date);
+
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    const asUtc = Date.UTC(
+      Number(values.year),
+      Number(values.month) - 1,
+      Number(values.day),
+      Number(values.hour),
+      Number(values.minute),
+      Number(values.second)
+    );
+
+    return asUtc - date.getTime();
+  }
+}
+
+export const availabilityService = new AvailabilityService(schedulingSettingsService);

--- a/server/src/modules/scheduling/AvailabilityService.ts
+++ b/server/src/modules/scheduling/AvailabilityService.ts
@@ -65,10 +65,9 @@ export class AvailabilityService {
       throw new ServiceUnavailableError('No scheduling calendar connected');
     }
 
-    const provider = calendarProviderFactory.create(connection);
     const rangeStart = this.zonedTimeToUtc(request.startDate, '00:00', settings.timezone);
     const rangeEnd = this.zonedTimeToUtc(request.endDate, '23:59', settings.timezone);
-    const events = await provider.listEvents({
+    const events = await calendarProviderFactory.create(connection).listEvents({
       calendarId: connection.providerCalendarId,
       timeMin: rangeStart,
       timeMax: rangeEnd,

--- a/server/src/modules/scheduling/BookingTokenService.ts
+++ b/server/src/modules/scheduling/BookingTokenService.ts
@@ -1,0 +1,141 @@
+import crypto from 'crypto';
+import { FRONTEND_ORIGIN } from '@/config';
+import {
+  leadPointOfContactRepository,
+  leadRepository,
+  scheduleBookingTokenRepository,
+} from '@/repositories';
+import { BadRequestError, NotFoundError } from '@/exceptions/error';
+import { ScheduleBookingToken } from '@/db/schema';
+
+export interface IssueBookingTokenInput {
+  tenantId: string;
+  leadId: string;
+  contactId: string;
+  userId: string;
+  campaignId?: string;
+  nodeId?: string;
+  outboundMessageId?: string;
+  expiresAt?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BookingTokenContext {
+  token: ScheduleBookingToken;
+  lead: {
+    id: string;
+    name: string;
+    url: string;
+  };
+  contact: {
+    id: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    company: string | null;
+  };
+}
+
+const DEFAULT_TOKEN_TTL_DAYS = 90;
+
+export class BookingTokenService {
+  async issue(input: IssueBookingTokenInput): Promise<{ rawToken: string; record: ScheduleBookingToken }> {
+    const lead = await leadRepository.findByIdForTenant(input.leadId, input.tenantId);
+    if (!lead) {
+      throw new NotFoundError('Lead not found');
+    }
+
+    if (lead.ownerId !== input.userId) {
+      throw new BadRequestError('Lead owner does not match scheduling user');
+    }
+
+    const contact = await leadPointOfContactRepository.findByIdForTenant(
+      input.contactId,
+      input.tenantId
+    );
+    if (!contact || contact.leadId !== input.leadId) {
+      throw new NotFoundError('Contact not found');
+    }
+
+    const rawToken = this.generateRawToken();
+    const tokenHash = this.hashToken(rawToken);
+    const expiresAt =
+      input.expiresAt ?? new Date(Date.now() + DEFAULT_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+    const record = await scheduleBookingTokenRepository.createForTenant(input.tenantId, {
+      userId: input.userId,
+      leadId: input.leadId,
+      contactId: input.contactId,
+      tokenHash,
+      campaignId: input.campaignId,
+      nodeId: input.nodeId,
+      outboundMessageId: input.outboundMessageId,
+      expiresAt,
+      metadata: input.metadata ?? {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return { rawToken, record };
+  }
+
+  async resolve(rawToken: string): Promise<BookingTokenContext> {
+    const token = await scheduleBookingTokenRepository.findActiveByTokenHash(this.hashToken(rawToken));
+    if (!token) {
+      throw new NotFoundError('Booking link not found or expired');
+    }
+
+    const lead = await leadRepository.findByIdForTenant(token.leadId, token.tenantId);
+    if (!lead) {
+      throw new NotFoundError('Lead not found');
+    }
+
+    const contact = await leadPointOfContactRepository.findByIdForTenant(
+      token.contactId,
+      token.tenantId
+    );
+    if (!contact || contact.leadId !== lead.id) {
+      throw new NotFoundError('Contact not found');
+    }
+
+    return {
+      token,
+      lead: {
+        id: lead.id,
+        name: lead.name,
+        url: lead.url,
+      },
+      contact: {
+        id: contact.id,
+        name: contact.name,
+        email: contact.email,
+        phone: contact.phone,
+        company: contact.company,
+      },
+    };
+  }
+
+  buildBookingUrl(rawToken: string): string {
+    const origin = (FRONTEND_ORIGIN || process.env.API_URL || '').replace(/\/$/, '');
+    if (!origin) {
+      throw new Error('FRONTEND_ORIGIN or API_URL is required to build booking URLs');
+    }
+
+    return `${origin}/schedule/${encodeURIComponent(rawToken)}`;
+  }
+
+  async cleanupExpired(before = new Date()): Promise<number> {
+    const deleted = await scheduleBookingTokenRepository.deleteExpired(before);
+    return deleted.length;
+  }
+
+  hashToken(rawToken: string): string {
+    return crypto.createHash('sha256').update(rawToken).digest('hex');
+  }
+
+  private generateRawToken(): string {
+    return crypto.randomBytes(32).toString('base64url');
+  }
+}
+
+export const bookingTokenService = new BookingTokenService();

--- a/server/src/modules/scheduling/LockService.ts
+++ b/server/src/modules/scheduling/LockService.ts
@@ -1,0 +1,70 @@
+import crypto from 'crypto';
+import { createRedisConnection } from '@/libs/bullmq';
+import { ConflictError, NotFoundError } from '@/exceptions/error';
+
+export interface ScheduleHold {
+  holdId: string;
+  tenantId: string;
+  userId: string;
+  tokenId: string;
+  slot: string;
+}
+
+const HOLD_TTL_SECONDS = 10;
+
+export class LockService {
+  async hold(input: Omit<ScheduleHold, 'holdId'>): Promise<{ holdId: string; expiresAt: Date }> {
+    const redis = createRedisConnection();
+    const holdId = crypto.randomBytes(24).toString('base64url');
+    const key = this.key(input.userId, input.slot);
+    const expiresAt = new Date(Date.now() + HOLD_TTL_SECONDS * 1000);
+    const value: ScheduleHold = { ...input, holdId };
+
+    const result = await redis.set(key, JSON.stringify(value), 'EX', HOLD_TTL_SECONDS, 'NX');
+    if (result !== 'OK') {
+      throw new ConflictError('Selected slot is temporarily held');
+    }
+
+    return { holdId, expiresAt };
+  }
+
+  async validate(holdId: string, userId: string, slot: string): Promise<ScheduleHold> {
+    const redis = createRedisConnection();
+    const value = await redis.get(this.key(userId, slot));
+    if (!value) {
+      throw new NotFoundError('Hold expired');
+    }
+
+    const hold = JSON.parse(value) as ScheduleHold;
+    if (hold.holdId !== holdId) {
+      throw new ConflictError('Hold does not match selected slot');
+    }
+
+    return hold;
+  }
+
+  async release(userId: string, slot: string, holdId: string): Promise<void> {
+    const redis = createRedisConnection();
+    const script = `
+      if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("DEL", KEYS[1])
+      end
+      return 0
+    `;
+    const key = this.key(userId, slot);
+    const value = await redis.get(key);
+    if (!value) return;
+
+    const hold = JSON.parse(value) as ScheduleHold;
+    if (hold.holdId !== holdId) return;
+
+    await redis.eval(script, 1, key, value);
+  }
+
+  private key(userId: string, slot: string): string {
+    const date = new Date(slot);
+    return `schedule:lock:${userId}:${date.toISOString().slice(0, 10)}:${date.toISOString()}`;
+  }
+}
+
+export const lockService = new LockService();

--- a/server/src/modules/scheduling/SchedulingService.ts
+++ b/server/src/modules/scheduling/SchedulingService.ts
@@ -1,0 +1,218 @@
+import { createId } from '@paralleldrive/cuid2';
+import { calendarConnectionService } from './calendar/CalendarConnectionService';
+import { calendarProviderFactory } from './calendar/CalendarProviderFactory';
+import { availabilityService } from './AvailabilityService';
+import { bookingTokenService } from './BookingTokenService';
+import { lockService } from './LockService';
+import { schedulingSettingsService } from './SchedulingSettingsService';
+import {
+  contactCampaignRepository,
+  scheduleBookingTokenRepository,
+  scheduledActionRepository,
+  scheduledMeetingRepository,
+} from '@/repositories';
+import { ConflictError, ServiceUnavailableError } from '@/exceptions/error';
+import { ScheduledMeeting } from '@/db/schema';
+import { logger } from '@/libs/logger';
+import { emailOrchestrator } from '@/libs/email/email.orchestrator';
+
+export interface ConfirmBookingInput {
+  token: string;
+  holdId: string;
+  slot: string;
+  contactDetails: {
+    name: string;
+    email: string;
+    phone?: string;
+  };
+}
+
+export interface ConfirmBookingResult {
+  meeting: ScheduledMeeting;
+  calendarEventLink?: string;
+}
+
+export class SchedulingService {
+  async confirmBooking(input: ConfirmBookingInput): Promise<ConfirmBookingResult> {
+    const context = await bookingTokenService.resolve(input.token);
+    const slotStart = new Date(input.slot);
+    const settings = await schedulingSettingsService.getForUser(
+      context.token.tenantId,
+      context.token.userId
+    );
+    const slotEnd = availabilityService.addMinutes(slotStart, settings.meetingDurationMinutes);
+
+    await lockService.validate(input.holdId, context.token.userId, input.slot);
+
+    try {
+      const localDate = this.formatDateInTimezone(slotStart, settings.timezone);
+      const availability = await availabilityService.getAvailability({
+        tenantId: context.token.tenantId,
+        userId: context.token.userId,
+        startDate: localDate,
+        endDate: localDate,
+      });
+
+      if (!availabilityService.isSlotAvailable(slotStart, availability.availableSlots)) {
+        throw new ConflictError('Selected slot is no longer available');
+      }
+
+      const connection = await calendarConnectionService.getActiveConnection(
+        context.token.tenantId,
+        context.token.userId
+      );
+      if (!connection) {
+        throw new ServiceUnavailableError('No scheduling calendar connected');
+      }
+
+      const provider = calendarProviderFactory.create(connection);
+      const event = await provider.createEvent({
+        calendarId: connection.providerCalendarId,
+        start: slotStart,
+        end: slotEnd,
+        timezone: settings.timezone,
+        title: `Sales Demo - ${context.contact.company || context.lead.name || context.contact.name}`,
+        description: `Booked from DripIQ Smart Scheduling for ${context.contact.name}.`,
+        attendees: [
+          {
+            email: input.contactDetails.email,
+            name: input.contactDetails.name,
+          },
+        ],
+      });
+
+      const meeting = await scheduledMeetingRepository.createConfirmed(context.token.tenantId, {
+        userId: context.token.userId,
+        leadId: context.token.leadId,
+        contactId: context.token.contactId,
+        bookingTokenId: context.token.id,
+        campaignId: context.token.campaignId,
+        calendarConnectionId: connection.id,
+        startTime: slotStart,
+        endTime: slotEnd,
+        calendarEventId: event.id || createId(),
+        provider: connection.provider,
+        contactDetails: input.contactDetails,
+        metadata: {
+          calendarEventLink: event.htmlLink,
+          nodeId: context.token.nodeId,
+          outboundMessageId: context.token.outboundMessageId,
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await scheduleBookingTokenRepository.markUsed(context.token.id, context.token.tenantId);
+      await this.sendConfirmationEmail({
+        tenantId: context.token.tenantId,
+        userId: context.token.userId,
+        campaignId: context.token.campaignId ?? meeting.id,
+        contactName: input.contactDetails.name,
+        contactEmail: input.contactDetails.email,
+        start: slotStart,
+        end: slotEnd,
+        timezone: settings.timezone,
+        calendarEventLink: event.htmlLink,
+      });
+      await this.stopActiveSequence(context.token.tenantId, context.token.contactId);
+
+      return {
+        meeting,
+        calendarEventLink: event.htmlLink,
+      };
+    } catch (error) {
+      await lockService.release(context.token.userId, input.slot, input.holdId);
+      logger.warn('[SchedulingService] Booking confirmation failed', {
+        tenantId: context.token.tenantId,
+        userId: context.token.userId,
+        tokenId: context.token.id,
+        slot: input.slot,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  }
+
+  private formatDateInTimezone(date: Date, timezone: string): string {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(date);
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    return `${values.year}-${values.month}-${values.day}`;
+  }
+
+  private async sendConfirmationEmail(input: {
+    tenantId: string;
+    userId: string;
+    campaignId: string;
+    contactName: string;
+    contactEmail: string;
+    start: Date;
+    end: Date;
+    timezone: string;
+    calendarEventLink?: string;
+  }): Promise<void> {
+    try {
+      const when = new Intl.DateTimeFormat('en-US', {
+        timeZone: input.timezone,
+        dateStyle: 'full',
+        timeStyle: 'short',
+      }).format(input.start);
+      const outboundMessageId = createId();
+      const link = input.calendarEventLink
+        ? `<p><a href="${input.calendarEventLink}">Open calendar event</a></p>`
+        : '';
+
+      await emailOrchestrator.sendEmail(input.userId, {
+        tenantId: input.tenantId,
+        campaignId: input.campaignId,
+        nodeId: 'smart-scheduling-confirmation',
+        outboundMessageId,
+        dedupeKey: `${input.tenantId}:${input.contactEmail}:${input.start.toISOString()}:smart-scheduling-confirmation`,
+        to: input.contactEmail,
+        subject: 'Your sales demo is booked',
+        html: `<p>Hi ${input.contactName},</p><p>Your sales demo is booked for ${when}.</p>${link}`,
+        text: `Hi ${input.contactName},\n\nYour sales demo is booked for ${when}.\n${input.calendarEventLink ?? ''}`,
+        categories: ['smart-scheduling', `tenant:${input.tenantId}`],
+      });
+    } catch (error) {
+      logger.error('[SchedulingService] Failed to send booking confirmation email', {
+        tenantId: input.tenantId,
+        userId: input.userId,
+        contactEmail: input.contactEmail,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+
+  private async stopActiveSequence(tenantId: string, contactId: string): Promise<void> {
+    try {
+      const campaign = await contactCampaignRepository.findByContactAndChannelForTenant(
+        tenantId,
+        contactId,
+        'email'
+      );
+      if (!campaign || !['active', 'paused', 'draft'].includes(campaign.status)) {
+        return;
+      }
+
+      await contactCampaignRepository.updateByIdForTenant(campaign.id, tenantId, {
+        status: 'stopped',
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await scheduledActionRepository.cancelByCampaignForTenant(tenantId, campaign.id);
+    } catch (error) {
+      logger.error('[SchedulingService] Failed to stop active sequence after booking', {
+        tenantId,
+        contactId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+}
+
+export const schedulingService = new SchedulingService();

--- a/server/src/modules/scheduling/SchedulingSettingsService.ts
+++ b/server/src/modules/scheduling/SchedulingSettingsService.ts
@@ -1,0 +1,172 @@
+import { userScheduleSettingsRepository } from '@/repositories';
+import { BadRequestError } from '@/exceptions/error';
+import { UserScheduleSetting } from '@/db/schema';
+
+export interface WorkingHourRange {
+  start: string;
+  end: string;
+}
+
+export type WorkingHours = Record<string, WorkingHourRange[]>;
+
+export interface SchedulingSettingsInput {
+  timezone?: string;
+  workingHours?: WorkingHours;
+  meetingDurationMinutes?: number;
+  bufferBeforeMinutes?: number;
+  bufferAfterMinutes?: number;
+  minNoticeMinutes?: number;
+  bookingHorizonDays?: number;
+  respectFreeBusy?: boolean;
+}
+
+export const DEFAULT_WORKING_HOURS: WorkingHours = {
+  monday: [{ start: '09:00', end: '17:00' }],
+  tuesday: [{ start: '09:00', end: '17:00' }],
+  wednesday: [{ start: '09:00', end: '17:00' }],
+  thursday: [{ start: '09:00', end: '17:00' }],
+  friday: [{ start: '09:00', end: '17:00' }],
+  saturday: [],
+  sunday: [],
+};
+
+const DAYS = Object.keys(DEFAULT_WORKING_HOURS);
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+export class SchedulingSettingsService {
+  async getForUser(tenantId: string, userId: string): Promise<UserScheduleSetting> {
+    const existing = await userScheduleSettingsRepository.findByUserForTenant(tenantId, userId);
+    if (existing) return existing;
+
+    return await this.upsertForUser(tenantId, userId, {});
+  }
+
+  async upsertForUser(
+    tenantId: string,
+    userId: string,
+    input: SchedulingSettingsInput
+  ): Promise<UserScheduleSetting> {
+    const normalized = this.normalize(input);
+
+    return await userScheduleSettingsRepository.upsertForUser(tenantId, userId, {
+      timezone: normalized.timezone,
+      workingHours: normalized.workingHours,
+      meetingDurationMinutes: normalized.meetingDurationMinutes,
+      bufferBeforeMinutes: normalized.bufferBeforeMinutes,
+      bufferAfterMinutes: normalized.bufferAfterMinutes,
+      minNoticeMinutes: normalized.minNoticeMinutes,
+      bookingHorizonDays: normalized.bookingHorizonDays,
+      respectFreeBusy: normalized.respectFreeBusy,
+    });
+  }
+
+  normalize(input: SchedulingSettingsInput): Required<SchedulingSettingsInput> {
+    const timezone = input.timezone?.trim() || 'America/Chicago';
+    this.validateTimezone(timezone);
+
+    const workingHours = this.normalizeWorkingHours(input.workingHours ?? DEFAULT_WORKING_HOURS);
+
+    return {
+      timezone,
+      workingHours,
+      meetingDurationMinutes: this.validatePositiveInteger(
+        input.meetingDurationMinutes ?? 30,
+        'meetingDurationMinutes',
+        5,
+        240
+      ),
+      bufferBeforeMinutes: this.validateNonNegativeInteger(
+        input.bufferBeforeMinutes ?? 0,
+        'bufferBeforeMinutes',
+        0,
+        240
+      ),
+      bufferAfterMinutes: this.validateNonNegativeInteger(
+        input.bufferAfterMinutes ?? 0,
+        'bufferAfterMinutes',
+        0,
+        240
+      ),
+      minNoticeMinutes: this.validateNonNegativeInteger(
+        input.minNoticeMinutes ?? 120,
+        'minNoticeMinutes',
+        0,
+        30 * 24 * 60
+      ),
+      bookingHorizonDays: this.validatePositiveInteger(
+        input.bookingHorizonDays ?? 14,
+        'bookingHorizonDays',
+        1,
+        365
+      ),
+      respectFreeBusy: input.respectFreeBusy ?? true,
+    };
+  }
+
+  private normalizeWorkingHours(workingHours: WorkingHours): WorkingHours {
+    const normalized: WorkingHours = {};
+
+    for (const day of DAYS) {
+      const ranges = workingHours[day] ?? [];
+      if (!Array.isArray(ranges)) {
+        throw new BadRequestError(`Working hours for ${day} must be an array`);
+      }
+
+      normalized[day] = ranges.map((range) => this.validateRange(day, range));
+    }
+
+    return normalized;
+  }
+
+  private validateRange(day: string, range: WorkingHourRange): WorkingHourRange {
+    if (!range || !TIME_PATTERN.test(range.start) || !TIME_PATTERN.test(range.end)) {
+      throw new BadRequestError(`Invalid working hours range for ${day}`);
+    }
+
+    if (this.minutes(range.start) >= this.minutes(range.end)) {
+      throw new BadRequestError(`Working hours start must be before end for ${day}`);
+    }
+
+    return { start: range.start, end: range.end };
+  }
+
+  private validateTimezone(timezone: string): void {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date());
+    } catch {
+      throw new BadRequestError('Invalid timezone');
+    }
+  }
+
+  private validatePositiveInteger(
+    value: number,
+    field: string,
+    min: number,
+    max: number
+  ): number {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new BadRequestError(`${field} must be an integer between ${min} and ${max}`);
+    }
+    return value;
+  }
+
+  private validateNonNegativeInteger(
+    value: number,
+    field: string,
+    min: number,
+    max: number
+  ): number {
+    return this.validatePositiveInteger(value, field, min, max);
+  }
+
+  private minutes(value: string): number {
+    const [hours, minutes] = value.split(':').map(Number);
+    if (hours === undefined || minutes === undefined) {
+      throw new BadRequestError('Invalid time value');
+    }
+
+    return hours * 60 + minutes;
+  }
+}
+
+export const schedulingSettingsService = new SchedulingSettingsService();

--- a/server/src/modules/scheduling/calendar/CalendarConnectionService.ts
+++ b/server/src/modules/scheduling/calendar/CalendarConnectionService.ts
@@ -1,0 +1,153 @@
+import { TokenPayload } from 'google-auth-library';
+import { getGoogleOAuth2Client } from '@/libs/thirdPartyAuth/GoogleAuth';
+import { getMicrosoftOAuth2Client, MicrosoftUserInfo } from '@/libs/thirdPartyAuth/MicrosoftAuth';
+import {
+  calendarConnectionRepository,
+  mailAccountRepository,
+  oauthTokenRepository,
+} from '@/repositories';
+import { CalendarConnection, MailAccount, NewMailAccount } from '@/db/schema';
+import { CreateOauthTokenPayload } from '@/repositories/entities/OauthTokenRepository';
+
+export class CalendarConnectionService {
+  async setupGoogleConnection(
+    tenantId: string,
+    userId: string,
+    code: string
+  ): Promise<CalendarConnection> {
+    const oauth2Client = getGoogleOAuth2Client();
+    const { tokens } = await oauth2Client.getToken(code);
+    oauth2Client.setCredentials(tokens);
+
+    if (!tokens.id_token) {
+      throw new Error('Google ID token missing from calendar OAuth response');
+    }
+
+    if (!tokens.refresh_token) {
+      throw new Error('Google refresh token missing from calendar OAuth response');
+    }
+
+    const ticket = await oauth2Client.verifyIdToken({
+      idToken: tokens.id_token,
+      audience: process.env.GOOGLE_CLIENT_ID,
+    });
+    const payload = ticket.getPayload();
+    if (!payload?.sub) {
+      throw new Error('Google account identity missing from calendar OAuth response');
+    }
+
+    const mailAccount = await this.findOrCreateMailAccount(tenantId, userId, payload, tokens.scope);
+    await this.storeRefreshToken(mailAccount.id, tokens.refresh_token);
+
+    return await calendarConnectionRepository.upsertActiveForUser(tenantId, userId, {
+      mailAccountId: mailAccount.id,
+      provider: 'google',
+      providerCalendarId: 'primary',
+      displayName: payload.name,
+      primaryEmail: payload.email,
+      scopes: tokens.scope?.split(' ') ?? [],
+      metadata: {},
+      connectedAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  async getActiveConnection(tenantId: string, userId: string): Promise<CalendarConnection | undefined> {
+    return await calendarConnectionRepository.findActiveForUser(tenantId, userId);
+  }
+
+  async setupMicrosoftConnection(
+    tenantId: string,
+    userId: string,
+    code: string
+  ): Promise<CalendarConnection> {
+    const oauth2Client = getMicrosoftOAuth2Client();
+    const tokenResponse = await oauth2Client.getToken(code);
+
+    if (!tokenResponse.refresh_token) {
+      throw new Error('Microsoft refresh token missing from calendar OAuth response');
+    }
+
+    const userInfo = await oauth2Client.getUserInfo(tokenResponse.access_token);
+    const mailAccount = await this.findOrCreateMicrosoftMailAccount(
+      tenantId,
+      userId,
+      userInfo,
+      tokenResponse.scope
+    );
+    await this.storeRefreshToken(mailAccount.id, tokenResponse.refresh_token);
+
+    return await calendarConnectionRepository.upsertActiveForUser(tenantId, userId, {
+      mailAccountId: mailAccount.id,
+      provider: 'microsoft',
+      providerCalendarId: 'primary',
+      displayName: userInfo.displayName,
+      primaryEmail: userInfo.mail || userInfo.userPrincipalName,
+      scopes: tokenResponse.scope?.split(' ') ?? [],
+      metadata: {},
+      connectedAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  private async findOrCreateMailAccount(
+    tenantId: string,
+    userId: string,
+    payload: TokenPayload,
+    scopes?: string
+  ): Promise<MailAccount> {
+    const existing = (await mailAccountRepository.findAccountsByUserId(userId)).find(
+      (account) => account.provider === 'google' && account.providerUserId === payload.sub
+    );
+    if (existing) return existing;
+
+    const mailAccount: NewMailAccount = {
+      tenantId,
+      userId,
+      provider: 'google',
+      providerUserId: payload.sub,
+      primaryEmail: payload.email || '',
+      displayName: payload.name || '',
+      scopes: scopes?.split(' ') || [],
+    };
+
+    return await mailAccountRepository.create(mailAccount);
+  }
+
+  private async findOrCreateMicrosoftMailAccount(
+    tenantId: string,
+    userId: string,
+    userInfo: MicrosoftUserInfo,
+    scopes?: string
+  ): Promise<MailAccount> {
+    const existing = (await mailAccountRepository.findAccountsByUserId(userId)).find(
+      (account) => account.provider === 'microsoft' && account.providerUserId === userInfo.id
+    );
+    if (existing) return existing;
+
+    const mailAccount: NewMailAccount = {
+      tenantId,
+      userId,
+      provider: 'microsoft',
+      providerUserId: userInfo.id,
+      primaryEmail: userInfo.mail || userInfo.userPrincipalName,
+      displayName: userInfo.displayName || '',
+      scopes: scopes?.split(' ') || [],
+    };
+
+    return await mailAccountRepository.create(mailAccount);
+  }
+
+  private async storeRefreshToken(mailAccountId: string, refreshToken: string): Promise<void> {
+    const newOauthToken: CreateOauthTokenPayload = {
+      mailAccountId,
+      refreshToken,
+      tokenVersion: 1,
+      status: 'active',
+    };
+
+    await oauthTokenRepository.createOAuth(newOauthToken);
+  }
+}
+
+export const calendarConnectionService = new CalendarConnectionService();

--- a/server/src/modules/scheduling/calendar/CalendarConnectionService.ts
+++ b/server/src/modules/scheduling/calendar/CalendarConnectionService.ts
@@ -10,6 +10,32 @@ import { CalendarConnection, MailAccount, NewMailAccount } from '@/db/schema';
 import { CreateOauthTokenPayload } from '@/repositories/entities/OauthTokenRepository';
 
 export class CalendarConnectionService {
+  async connectMailAccountCalendar(params: {
+    tenantId: string;
+    userId: string;
+    mailAccountId: string;
+    provider: 'google' | 'microsoft';
+    primaryEmail?: string;
+    displayName?: string | null;
+    scopes?: string[];
+  }): Promise<CalendarConnection | undefined> {
+    if (!this.hasCalendarScopes(params.provider, params.scopes ?? [])) {
+      return undefined;
+    }
+
+    return await calendarConnectionRepository.upsertActiveForUser(params.tenantId, params.userId, {
+      mailAccountId: params.mailAccountId,
+      provider: params.provider,
+      providerCalendarId: 'primary',
+      displayName: params.displayName ?? undefined,
+      primaryEmail: params.primaryEmail,
+      scopes: params.scopes ?? [],
+      metadata: {},
+      connectedAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
   async setupGoogleConnection(
     tenantId: string,
     userId: string,
@@ -147,6 +173,15 @@ export class CalendarConnectionService {
     };
 
     await oauthTokenRepository.createOAuth(newOauthToken);
+  }
+
+  private hasCalendarScopes(provider: 'google' | 'microsoft', scopes: string[]): boolean {
+    const normalizedScopes = scopes.map((scope) => scope.toLowerCase());
+    if (provider === 'google') {
+      return normalizedScopes.includes('https://www.googleapis.com/auth/calendar.events');
+    }
+
+    return normalizedScopes.includes('calendars.readwrite');
   }
 }
 

--- a/server/src/modules/scheduling/calendar/CalendarProvider.ts
+++ b/server/src/modules/scheduling/calendar/CalendarProvider.ts
@@ -1,0 +1,31 @@
+export interface CalendarEventInterval {
+  start: Date;
+  end: Date;
+  isBusy: boolean;
+}
+
+export interface CreateCalendarEventInput {
+  calendarId: string;
+  start: Date;
+  end: Date;
+  timezone: string;
+  title: string;
+  description?: string;
+  attendees: Array<{ email: string; name?: string }>;
+}
+
+export interface CreatedCalendarEvent {
+  id: string;
+  htmlLink?: string;
+  icsLink?: string;
+}
+
+export interface CalendarProvider {
+  listEvents(input: {
+    calendarId: string;
+    timeMin: Date;
+    timeMax: Date;
+  }): Promise<CalendarEventInterval[]>;
+
+  createEvent(input: CreateCalendarEventInput): Promise<CreatedCalendarEvent>;
+}

--- a/server/src/modules/scheduling/calendar/CalendarProviderFactory.ts
+++ b/server/src/modules/scheduling/calendar/CalendarProviderFactory.ts
@@ -1,0 +1,25 @@
+import { BadRequestError, ServiceUnavailableError } from '@/exceptions/error';
+import { CalendarConnection } from '@/db/schema';
+import { CalendarProvider } from './CalendarProvider';
+import { GoogleCalendarProvider } from './GoogleCalendarProvider';
+import { OutlookCalendarProvider } from './OutlookCalendarProvider';
+
+export class CalendarProviderFactory {
+  create(connection: CalendarConnection): CalendarProvider {
+    if (!connection.mailAccountId) {
+      throw new ServiceUnavailableError('Calendar connection is missing OAuth account');
+    }
+
+    if (connection.provider === 'google') {
+      return new GoogleCalendarProvider(connection.mailAccountId);
+    }
+
+    if (connection.provider === 'microsoft') {
+      return new OutlookCalendarProvider(connection.mailAccountId);
+    }
+
+    throw new BadRequestError(`Unsupported calendar provider: ${connection.provider}`);
+  }
+}
+
+export const calendarProviderFactory = new CalendarProviderFactory();

--- a/server/src/modules/scheduling/calendar/GoogleCalendarProvider.ts
+++ b/server/src/modules/scheduling/calendar/GoogleCalendarProvider.ts
@@ -1,0 +1,88 @@
+import { google, calendar_v3 } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import { getGoogleOAuth2Client } from '@/libs/thirdPartyAuth/GoogleAuth';
+import { oauthTokenRepository } from '@/repositories';
+import {
+  CalendarEventInterval,
+  CalendarProvider,
+  CreateCalendarEventInput,
+  CreatedCalendarEvent,
+} from './CalendarProvider';
+
+export class GoogleCalendarProvider implements CalendarProvider {
+  constructor(private readonly mailAccountId: string) {}
+
+  async listEvents(input: {
+    calendarId: string;
+    timeMin: Date;
+    timeMax: Date;
+  }): Promise<CalendarEventInterval[]> {
+    const calendar = await this.getCalendarClient();
+    const response = await calendar.events.list({
+      calendarId: input.calendarId,
+      timeMin: input.timeMin.toISOString(),
+      timeMax: input.timeMax.toISOString(),
+      singleEvents: true,
+      orderBy: 'startTime',
+      showDeleted: false,
+    });
+
+    return (response.data.items ?? [])
+      .map((event) => this.toInterval(event))
+      .filter((event): event is CalendarEventInterval => !!event);
+  }
+
+  async createEvent(input: CreateCalendarEventInput): Promise<CreatedCalendarEvent> {
+    const calendar = await this.getCalendarClient();
+    const response = await calendar.events.insert({
+      calendarId: input.calendarId,
+      sendUpdates: 'all',
+      requestBody: {
+        summary: input.title,
+        description: input.description,
+        start: {
+          dateTime: input.start.toISOString(),
+          timeZone: input.timezone,
+        },
+        end: {
+          dateTime: input.end.toISOString(),
+          timeZone: input.timezone,
+        },
+        attendees: input.attendees.map((attendee) => ({
+          email: attendee.email,
+          displayName: attendee.name,
+        })),
+      },
+    });
+
+    return {
+      id: response.data.id ?? '',
+      htmlLink: response.data.htmlLink ?? undefined,
+      icsLink: response.data.htmlLink ?? undefined,
+    };
+  }
+
+  private async getCalendarClient(): Promise<calendar_v3.Calendar> {
+    const oauth2Client = await this.getAuthedClient();
+    return google.calendar({ version: 'v3', auth: oauth2Client });
+  }
+
+  private async getAuthedClient(): Promise<OAuth2Client> {
+    const refreshToken = await oauthTokenRepository.getRefreshTokenByMailAccountId(this.mailAccountId);
+    const oauth2Client = getGoogleOAuth2Client();
+    oauth2Client.setCredentials({ refresh_token: refreshToken });
+    return oauth2Client;
+  }
+
+  private toInterval(event: calendar_v3.Schema$Event): CalendarEventInterval | null {
+    const startValue = event.start?.dateTime ?? event.start?.date;
+    const endValue = event.end?.dateTime ?? event.end?.date;
+    if (!startValue || !endValue) return null;
+
+    return {
+      start: new Date(startValue),
+      end: new Date(endValue),
+      isBusy: event.transparency !== 'transparent',
+    };
+  }
+}

--- a/server/src/modules/scheduling/calendar/OutlookCalendarProvider.ts
+++ b/server/src/modules/scheduling/calendar/OutlookCalendarProvider.ts
@@ -1,0 +1,108 @@
+import axios from 'axios';
+import { getMicrosoftOAuth2Client } from '@/libs/thirdPartyAuth/MicrosoftAuth';
+import { oauthTokenRepository } from '@/repositories';
+import {
+  CalendarEventInterval,
+  CalendarProvider,
+  CreateCalendarEventInput,
+  CreatedCalendarEvent,
+} from './CalendarProvider';
+
+interface OutlookEvent {
+  id: string;
+  showAs?: string;
+  webLink?: string;
+  start?: {
+    dateTime?: string;
+    timeZone?: string;
+  };
+  end?: {
+    dateTime?: string;
+    timeZone?: string;
+  };
+}
+
+export class OutlookCalendarProvider implements CalendarProvider {
+  constructor(private readonly mailAccountId: string) {}
+
+  async listEvents(input: {
+    calendarId: string;
+    timeMin: Date;
+    timeMax: Date;
+  }): Promise<CalendarEventInterval[]> {
+    const accessToken = await this.getAccessToken();
+    const calendarPath =
+      input.calendarId === 'primary' ? 'me/calendarView' : `me/calendars/${input.calendarId}/calendarView`;
+    const response = await axios.get<{ value: OutlookEvent[] }>(
+      `https://graph.microsoft.com/v1.0/${calendarPath}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        params: {
+          startDateTime: input.timeMin.toISOString(),
+          endDateTime: input.timeMax.toISOString(),
+          '$orderby': 'start/dateTime',
+        },
+      }
+    );
+
+    return response.data.value
+      .map((event) => this.toInterval(event))
+      .filter((event): event is CalendarEventInterval => !!event);
+  }
+
+  async createEvent(input: CreateCalendarEventInput): Promise<CreatedCalendarEvent> {
+    const accessToken = await this.getAccessToken();
+    const calendarPath =
+      input.calendarId === 'primary' ? 'me/events' : `me/calendars/${input.calendarId}/events`;
+    const response = await axios.post<OutlookEvent>(
+      `https://graph.microsoft.com/v1.0/${calendarPath}`,
+      {
+        subject: input.title,
+        body: {
+          contentType: 'HTML',
+          content: input.description ?? '',
+        },
+        start: {
+          dateTime: input.start.toISOString(),
+          timeZone: input.timezone,
+        },
+        end: {
+          dateTime: input.end.toISOString(),
+          timeZone: input.timezone,
+        },
+        attendees: input.attendees.map((attendee) => ({
+          emailAddress: {
+            address: attendee.email,
+            name: attendee.name ?? attendee.email,
+          },
+          type: 'required',
+        })),
+      },
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
+    );
+
+    return {
+      id: response.data.id,
+      htmlLink: response.data.webLink,
+      icsLink: response.data.webLink,
+    };
+  }
+
+  private async getAccessToken(): Promise<string> {
+    const refreshToken = await oauthTokenRepository.getRefreshTokenByMailAccountId(this.mailAccountId);
+    const tokenResponse = await getMicrosoftOAuth2Client().refreshToken(refreshToken);
+    return tokenResponse.access_token;
+  }
+
+  private toInterval(event: OutlookEvent): CalendarEventInterval | null {
+    if (!event.start?.dateTime || !event.end?.dateTime) return null;
+
+    return {
+      start: new Date(event.start.dateTime),
+      end: new Date(event.end.dateTime),
+      isBusy: event.showAs !== 'free',
+    };
+  }
+}

--- a/server/src/plugins/rate-limit.plugin.ts
+++ b/server/src/plugins/rate-limit.plugin.ts
@@ -1,0 +1,8 @@
+import fp from 'fastify-plugin';
+import rateLimit from '@fastify/rate-limit';
+
+export default fp(async (fastify) => {
+  await fastify.register(rateLimit, {
+    global: false,
+  });
+});

--- a/server/src/repositories/entities/CalendarConnectionRepository.ts
+++ b/server/src/repositories/entities/CalendarConnectionRepository.ts
@@ -70,4 +70,17 @@ export class CalendarConnectionRepository extends TenantAwareRepository<
 
     return result;
   }
+
+  async disconnectByMailAccountId(mailAccountId: string): Promise<CalendarConnection[]> {
+    return await this.db
+      .update(this.table)
+      .set({
+        isActive: false,
+        disconnectedAt: new Date(),
+        reauthRequired: true,
+        updatedAt: new Date(),
+      })
+      .where(eq(this.table.mailAccountId, mailAccountId))
+      .returning();
+  }
 }

--- a/server/src/repositories/entities/CalendarConnectionRepository.ts
+++ b/server/src/repositories/entities/CalendarConnectionRepository.ts
@@ -1,0 +1,73 @@
+import { and, eq } from 'drizzle-orm';
+import { calendarConnections, CalendarConnection, NewCalendarConnection } from '@/db/schema';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export class CalendarConnectionRepository extends TenantAwareRepository<
+  typeof calendarConnections,
+  CalendarConnection,
+  NewCalendarConnection
+> {
+  constructor() {
+    super(calendarConnections);
+  }
+
+  async findActiveForUser(tenantId: string, userId: string): Promise<CalendarConnection | undefined> {
+    const [result] = await this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.tenantId, tenantId),
+          eq(this.table.userId, userId),
+          eq(this.table.isActive, true)
+        )
+      )
+      .limit(1);
+
+    return result;
+  }
+
+  async upsertActiveForUser(
+    tenantId: string,
+    userId: string,
+    data: Omit<NewCalendarConnection, 'tenantId' | 'userId'>
+  ): Promise<CalendarConnection> {
+    await this.db
+      .update(this.table)
+      .set({ isActive: false, disconnectedAt: new Date(), updatedAt: new Date() })
+      .where(
+        and(
+          eq(this.table.tenantId, tenantId),
+          eq(this.table.userId, userId),
+          eq(this.table.isActive, true)
+        )
+      );
+
+    const [result] = await this.db
+      .insert(this.table)
+      .values({
+        ...data,
+        tenantId,
+        userId,
+        isActive: true,
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    return result as CalendarConnection;
+  }
+
+  async markReauthRequired(
+    tenantId: string,
+    id: string,
+    reauthRequired = true
+  ): Promise<CalendarConnection | undefined> {
+    const [result] = await this.db
+      .update(this.table)
+      .set({ reauthRequired, updatedAt: new Date() })
+      .where(and(eq(this.table.id, id), eq(this.table.tenantId, tenantId)))
+      .returning();
+
+    return result;
+  }
+}

--- a/server/src/repositories/entities/MailAccountRepository.ts
+++ b/server/src/repositories/entities/MailAccountRepository.ts
@@ -68,6 +68,51 @@ export class MailAccountRepository extends TenantAwareRepository<
     return results;
   }
 
+  async findByProviderIdentity(
+    provider: MailAccount['provider'],
+    providerUserId: string
+  ): Promise<MailAccount | undefined> {
+    const [result] = await this.db
+      .select()
+      .from(this.table)
+      .where(and(eq(this.table.provider, provider), eq(this.table.providerUserId, providerUserId)))
+      .limit(1);
+
+    return result;
+  }
+
+  async reconnectProvider(
+    userId: string,
+    providerId: string,
+    data: Pick<NewMailAccount, 'primaryEmail' | 'displayName' | 'scopes'>
+  ): Promise<MailAccount> {
+    const existingAccounts = await this.findAccountsByUserId(userId);
+    const hasPrimaryAccount = existingAccounts.some(
+      (account) => account.id !== providerId && account.isPrimary
+    );
+
+    const [updatedAccount] = await this.db
+      .update(this.table)
+      .set({
+        ...data,
+        isPrimary: !hasPrimaryAccount,
+        disconnectedAt: null,
+        reauthRequired: false,
+        connectedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(this.table.userId, userId), eq(this.table.id, providerId)))
+      .returning();
+
+    if (!updatedAccount) {
+      throw new NotFoundError(
+        `Mail account not found with id: ${providerId} for user: ${userId}`
+      );
+    }
+
+    return updatedAccount as MailAccount;
+  }
+
   /**
    * Switch primary provider for a user
    * Sets the specified provider as primary and all others as non-primary
@@ -107,5 +152,43 @@ export class MailAccountRepository extends TenantAwareRepository<
       });
       throw error;
     }
+  }
+
+  async disconnectProvider(userId: string, providerId: string): Promise<MailAccount> {
+    return await this.db.transaction(async (tx) => {
+      const [account] = await tx
+        .select()
+        .from(this.table)
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, providerId)))
+        .limit(1);
+
+      if (!account) {
+        throw new NotFoundError(
+          `Mail account not found with id: ${providerId} for user: ${userId}`
+        );
+      }
+
+      const [deletedAccount] = await tx
+        .delete(this.table)
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, providerId)))
+        .returning();
+
+      if (account.isPrimary) {
+        const [nextPrimary] = await tx
+          .select()
+          .from(this.table)
+          .where(and(eq(this.table.userId, userId), eq(this.table.reauthRequired, false)))
+          .limit(1);
+
+        if (nextPrimary) {
+          await tx
+            .update(this.table)
+            .set({ isPrimary: true, updatedAt: new Date() })
+            .where(eq(this.table.id, nextPrimary.id));
+        }
+      }
+
+      return deletedAccount as MailAccount;
+    });
   }
 }

--- a/server/src/repositories/entities/OauthTokenRepository.ts
+++ b/server/src/repositories/entities/OauthTokenRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, desc } from 'drizzle-orm';
 import { oauthTokens, OauthToken, NewOauthToken } from '@/db/schema';
 import { NotFoundError } from '@/exceptions/error';
 import { encrypt, decrypt } from '@/utils/crypto';
@@ -51,6 +51,7 @@ export class OauthTokenRepository extends BaseRepository<
       .select()
       .from(this.table)
       .where(and(eq(this.table.mailAccountId, mailAccountId)))
+      .orderBy(desc(this.table.addedAt))
       .limit(1);
 
     if (!result || !result[0]) {

--- a/server/src/repositories/entities/OauthTokenRepository.ts
+++ b/server/src/repositories/entities/OauthTokenRepository.ts
@@ -61,4 +61,12 @@ export class OauthTokenRepository extends BaseRepository<
     const { refreshTokenEnc } = result[0];
     return decrypt(refreshTokenEnc);
   }
+
+  async revokeByMailAccountId(mailAccountId: string): Promise<OauthToken[]> {
+    return await this.db
+      .update(this.table)
+      .set({ status: 'revoked', updatedAt: new Date() })
+      .where(eq(this.table.mailAccountId, mailAccountId))
+      .returning();
+  }
 }

--- a/server/src/repositories/entities/ScheduleBookingTokenRepository.ts
+++ b/server/src/repositories/entities/ScheduleBookingTokenRepository.ts
@@ -1,0 +1,58 @@
+import { and, eq, gt, isNull, lt } from 'drizzle-orm';
+import {
+  scheduleBookingTokens,
+  ScheduleBookingToken,
+  NewScheduleBookingToken,
+} from '@/db/schema';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export class ScheduleBookingTokenRepository extends TenantAwareRepository<
+  typeof scheduleBookingTokens,
+  ScheduleBookingToken,
+  NewScheduleBookingToken
+> {
+  constructor() {
+    super(scheduleBookingTokens);
+  }
+
+  async findActiveByTokenHash(tokenHash: string): Promise<ScheduleBookingToken | undefined> {
+    const [result] = await this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.tokenHash, tokenHash),
+          isNull(this.table.revokedAt),
+          isNull(this.table.usedAt),
+          gt(this.table.expiresAt, new Date())
+        )
+      )
+      .limit(1);
+
+    return result;
+  }
+
+  async markUsed(id: string, tenantId: string): Promise<ScheduleBookingToken | undefined> {
+    const [result] = await this.db
+      .update(this.table)
+      .set({ usedAt: new Date(), updatedAt: new Date() })
+      .where(and(eq(this.table.id, id), eq(this.table.tenantId, tenantId)))
+      .returning();
+
+    return result;
+  }
+
+  async revoke(id: string, tenantId: string): Promise<ScheduleBookingToken | undefined> {
+    const [result] = await this.db
+      .update(this.table)
+      .set({ revokedAt: new Date(), updatedAt: new Date() })
+      .where(and(eq(this.table.id, id), eq(this.table.tenantId, tenantId)))
+      .returning();
+
+    return result;
+  }
+
+  async deleteExpired(before = new Date()): Promise<ScheduleBookingToken[]> {
+    return await this.db.delete(this.table).where(lt(this.table.expiresAt, before)).returning();
+  }
+}

--- a/server/src/repositories/entities/ScheduledMeetingRepository.ts
+++ b/server/src/repositories/entities/ScheduledMeetingRepository.ts
@@ -1,0 +1,67 @@
+import { and, eq, gte, lt } from 'drizzle-orm';
+import { scheduledMeetings, ScheduledMeeting, NewScheduledMeeting } from '@/db/schema';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export class ScheduledMeetingRepository extends TenantAwareRepository<
+  typeof scheduledMeetings,
+  ScheduledMeeting,
+  NewScheduledMeeting
+> {
+  constructor() {
+    super(scheduledMeetings);
+  }
+
+  async findByUserInRange(
+    tenantId: string,
+    userId: string,
+    start: Date,
+    end: Date
+  ): Promise<ScheduledMeeting[]> {
+    return await this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.tenantId, tenantId),
+          eq(this.table.userId, userId),
+          gte(this.table.startTime, start),
+          lt(this.table.startTime, end)
+        )
+      )
+      .orderBy(this.table.startTime);
+  }
+
+  async createConfirmed(
+    tenantId: string,
+    data: Omit<NewScheduledMeeting, 'tenantId' | 'status'>
+  ): Promise<ScheduledMeeting> {
+    const [result] = await this.db
+      .insert(this.table)
+      .values({
+        ...data,
+        tenantId,
+        status: 'confirmed',
+      })
+      .returning();
+
+    return result as ScheduledMeeting;
+  }
+
+  async cancel(
+    tenantId: string,
+    id: string,
+    metadata?: Record<string, unknown>
+  ): Promise<ScheduledMeeting | undefined> {
+    const [result] = await this.db
+      .update(this.table)
+      .set({
+        status: 'canceled',
+        metadata: metadata ?? {},
+        updatedAt: new Date(),
+      })
+      .where(and(eq(this.table.id, id), eq(this.table.tenantId, tenantId)))
+      .returning();
+
+    return result;
+  }
+}

--- a/server/src/repositories/entities/UserScheduleSettingsRepository.ts
+++ b/server/src/repositories/entities/UserScheduleSettingsRepository.ts
@@ -1,0 +1,55 @@
+import { and, eq } from 'drizzle-orm';
+import {
+  userScheduleSettings,
+  UserScheduleSetting,
+  NewUserScheduleSetting,
+} from '@/db/schema';
+import { TenantAwareRepository } from '../base/TenantAwareRepository';
+
+export class UserScheduleSettingsRepository extends TenantAwareRepository<
+  typeof userScheduleSettings,
+  UserScheduleSetting,
+  NewUserScheduleSetting
+> {
+  constructor() {
+    super(userScheduleSettings);
+  }
+
+  async findByUserForTenant(
+    tenantId: string,
+    userId: string
+  ): Promise<UserScheduleSetting | undefined> {
+    const [result] = await this.db
+      .select()
+      .from(this.table)
+      .where(and(eq(this.table.tenantId, tenantId), eq(this.table.userId, userId)))
+      .limit(1);
+
+    return result;
+  }
+
+  async upsertForUser(
+    tenantId: string,
+    userId: string,
+    data: Omit<NewUserScheduleSetting, 'tenantId' | 'userId'>
+  ): Promise<UserScheduleSetting> {
+    const [result] = await this.db
+      .insert(this.table)
+      .values({
+        ...data,
+        tenantId,
+        userId,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [this.table.tenantId, this.table.userId],
+        set: {
+          ...data,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+
+    return result as UserScheduleSetting;
+  }
+}

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -33,6 +33,10 @@ import { CalendarLinkClickRepository } from './entities/CalendarLinkClickReposit
 import { MailAccountRepository } from './entities/MailAccountRepository';
 import { OauthTokenRepository } from './entities/OauthTokenRepository';
 import { TenantDomainMappingRepository } from './entities/TenantDomainMappingRepository';
+import { UserScheduleSettingsRepository } from './entities/UserScheduleSettingsRepository';
+import { ScheduleBookingTokenRepository } from './entities/ScheduleBookingTokenRepository';
+import { CalendarConnectionRepository } from './entities/CalendarConnectionRepository';
+import { ScheduledMeetingRepository } from './entities/ScheduledMeetingRepository';
 
 // Base repositories
 export { BaseRepository } from './base/BaseRepository';
@@ -70,6 +74,10 @@ export { CalendarLinkClickRepository } from './entities/CalendarLinkClickReposit
 export { MailAccountRepository } from './entities/MailAccountRepository';
 export { OauthTokenRepository } from './entities/OauthTokenRepository';
 export { TenantDomainMappingRepository } from './entities/TenantDomainMappingRepository';
+export { UserScheduleSettingsRepository } from './entities/UserScheduleSettingsRepository';
+export { ScheduleBookingTokenRepository } from './entities/ScheduleBookingTokenRepository';
+export { CalendarConnectionRepository } from './entities/CalendarConnectionRepository';
+export { ScheduledMeetingRepository } from './entities/ScheduledMeetingRepository';
 
 // Transaction repositories
 export { LeadTransactionRepository } from './transactions/LeadTransactionRepository';
@@ -143,6 +151,10 @@ const calendarLinkClickRepository = new CalendarLinkClickRepository();
 const mailAccountRepository = new MailAccountRepository();
 const oauthTokenRepository = new OauthTokenRepository();
 const tenantDomainMappingRepository = new TenantDomainMappingRepository();
+const userScheduleSettingsRepository = new UserScheduleSettingsRepository();
+const scheduleBookingTokenRepository = new ScheduleBookingTokenRepository();
+const calendarConnectionRepository = new CalendarConnectionRepository();
+const scheduledMeetingRepository = new ScheduledMeetingRepository();
 
 // Transaction repository instances
 const leadTransactionRepository = new LeadTransactionRepository();
@@ -183,6 +195,10 @@ export const repositories = {
   mailAccount: mailAccountRepository,
   oauthToken: oauthTokenRepository,
   tenantDomainMapping: tenantDomainMappingRepository,
+  userScheduleSettings: userScheduleSettingsRepository,
+  scheduleBookingToken: scheduleBookingTokenRepository,
+  calendarConnection: calendarConnectionRepository,
+  scheduledMeeting: scheduledMeetingRepository,
 
   // Transaction repositories
   leadTransaction: leadTransactionRepository,
@@ -223,6 +239,10 @@ export {
   mailAccountRepository,
   oauthTokenRepository,
   tenantDomainMappingRepository,
+  userScheduleSettingsRepository,
+  scheduleBookingTokenRepository,
+  calendarConnectionRepository,
+  scheduledMeetingRepository,
   leadTransactionRepository,
   userInvitationTransactionRepository,
   tenantSetupTransactionRepository,

--- a/server/src/routes/apiSchema/scheduling/index.ts
+++ b/server/src/routes/apiSchema/scheduling/index.ts
@@ -1,0 +1,100 @@
+import { Type } from '@sinclair/typebox';
+
+const WorkingHourRangeSchema = Type.Object({
+  start: Type.String({ pattern: '^([01]\\d|2[0-3]):([0-5]\\d)$' }),
+  end: Type.String({ pattern: '^([01]\\d|2[0-3]):([0-5]\\d)$' }),
+});
+
+export const WorkingHoursSchema = Type.Object({
+  monday: Type.Array(WorkingHourRangeSchema),
+  tuesday: Type.Array(WorkingHourRangeSchema),
+  wednesday: Type.Array(WorkingHourRangeSchema),
+  thursday: Type.Array(WorkingHourRangeSchema),
+  friday: Type.Array(WorkingHourRangeSchema),
+  saturday: Type.Array(WorkingHourRangeSchema),
+  sunday: Type.Array(WorkingHourRangeSchema),
+});
+
+export const SchedulingSettingsRequestSchema = Type.Object({
+  timezone: Type.Optional(Type.String()),
+  workingHours: Type.Optional(WorkingHoursSchema),
+  meetingDurationMinutes: Type.Optional(Type.Integer({ minimum: 5, maximum: 240 })),
+  bufferBeforeMinutes: Type.Optional(Type.Integer({ minimum: 0, maximum: 240 })),
+  bufferAfterMinutes: Type.Optional(Type.Integer({ minimum: 0, maximum: 240 })),
+  minNoticeMinutes: Type.Optional(Type.Integer({ minimum: 0, maximum: 43200 })),
+  bookingHorizonDays: Type.Optional(Type.Integer({ minimum: 1, maximum: 365 })),
+  respectFreeBusy: Type.Optional(Type.Boolean()),
+});
+
+export const SchedulingSettingsResponseSchema = Type.Object({
+  id: Type.String(),
+  tenantId: Type.String(),
+  userId: Type.String(),
+  timezone: Type.String(),
+  workingHours: WorkingHoursSchema,
+  meetingDurationMinutes: Type.Integer(),
+  bufferBeforeMinutes: Type.Integer(),
+  bufferAfterMinutes: Type.Integer(),
+  minNoticeMinutes: Type.Integer(),
+  bookingHorizonDays: Type.Integer(),
+  respectFreeBusy: Type.Boolean(),
+});
+
+export const BookingTokenParamsSchema = Type.Object({
+  token: Type.String(),
+});
+
+export const PublicBookingContextResponseSchema = Type.Object({
+  tokenId: Type.String(),
+  timezone: Type.String(),
+  meetingDurationMinutes: Type.Integer(),
+  lead: Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+    url: Type.String(),
+  }),
+  contact: Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+    email: Type.Optional(Type.String()),
+    phone: Type.Optional(Type.String()),
+    company: Type.Optional(Type.String()),
+  }),
+});
+
+export const AvailabilityQuerySchema = Type.Object({
+  token: Type.String(),
+  startDate: Type.String({ pattern: '^\\d{4}-\\d{2}-\\d{2}$' }),
+  endDate: Type.String({ pattern: '^\\d{4}-\\d{2}-\\d{2}$' }),
+});
+
+export const AvailabilityResponseSchema = Type.Object({
+  availableSlots: Type.Array(Type.String()),
+  timezone: Type.String(),
+});
+
+export const ScheduleHoldRequestSchema = Type.Object({
+  token: Type.String(),
+  slot: Type.String({ format: 'date-time' }),
+});
+
+export const ScheduleHoldResponseSchema = Type.Object({
+  holdId: Type.String(),
+  expiresAt: Type.String(),
+});
+
+export const ScheduleConfirmRequestSchema = Type.Object({
+  token: Type.String(),
+  holdId: Type.String(),
+  slot: Type.String({ format: 'date-time' }),
+  contactDetails: Type.Object({
+    name: Type.String({ minLength: 1 }),
+    email: Type.String({ format: 'email' }),
+    phone: Type.Optional(Type.String()),
+  }),
+});
+
+export const ScheduleConfirmResponseSchema = Type.Object({
+  meetingId: Type.String(),
+  calendarEventLink: Type.Optional(Type.String()),
+});

--- a/server/src/routes/apiSchema/users/emailProviders.schema.ts
+++ b/server/src/routes/apiSchema/users/emailProviders.schema.ts
@@ -50,8 +50,24 @@ export const SwitchPrimaryProviderResponseSchema = Type.Object({
   provider: EmailProviderSchema,
 });
 
+export const EmailProviderParamsSchema = Type.Object({
+  providerId: Type.String({
+    description: 'ID of the mail account',
+    minLength: 1,
+  }),
+});
+
+export const DisconnectProviderResponseSchema = Type.Object({
+  message: Type.String({
+    description: 'Success message',
+  }),
+  provider: EmailProviderSchema,
+});
+
 // TypeScript types
 export type EmailProvider = typeof EmailProviderSchema.static;
 export type GetEmailProvidersResponse = typeof GetEmailProvidersResponseSchema.static;
 export type SwitchPrimaryProviderRequest = typeof SwitchPrimaryProviderRequestSchema.static;
 export type SwitchPrimaryProviderResponse = typeof SwitchPrimaryProviderResponseSchema.static;
+export type EmailProviderParams = typeof EmailProviderParamsSchema.static;
+export type DisconnectProviderResponse = typeof DisconnectProviderResponseSchema.static;

--- a/server/src/routes/authentication.routes.ts
+++ b/server/src/routes/authentication.routes.ts
@@ -4,6 +4,7 @@ import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { HttpMethods } from '@/utils/HttpMethods';
 import { logger } from '@/libs/logger';
 import { supabase } from '@/libs/supabase.client';
+import { IS_LOCAL } from '@/config';
 import { UserService, CreateUserData } from '@/modules/user.service';
 import { TenantService } from '@/modules/tenant.service';
 import { TenantDomainMappingService } from '@/modules/tenant-domain-mapping.service';
@@ -91,7 +92,7 @@ export default async function Authentication(fastify: FastifyInstance, _opts: Ro
       try {
         const { email, password, name, tenantName, enableSsoDomainMapping } = request.body;
 
-        const isRealEmail = await isFakeMail(email);
+        const isRealEmail = IS_LOCAL || (await isFakeMail(email));
 
         if (!isRealEmail) {
           reply.status(400).send({

--- a/server/src/routes/scheduling.routes.ts
+++ b/server/src/routes/scheduling.routes.ts
@@ -1,0 +1,236 @@
+import { FastifyInstance, FastifyReply, FastifyRequest, RouteOptions } from 'fastify';
+import { HttpMethods } from '@/utils/HttpMethods';
+import { AuthenticatedRequest } from '@/plugins/authentication.plugin';
+import { logger } from '@/libs/logger';
+import { schedulingSettingsService } from '@/modules/scheduling/SchedulingSettingsService';
+import { bookingTokenService } from '@/modules/scheduling/BookingTokenService';
+import { availabilityService } from '@/modules/scheduling/AvailabilityService';
+import { lockService } from '@/modules/scheduling/LockService';
+import { schedulingService } from '@/modules/scheduling/SchedulingService';
+import {
+  AvailabilityQuerySchema,
+  AvailabilityResponseSchema,
+  BookingTokenParamsSchema,
+  PublicBookingContextResponseSchema,
+  ScheduleConfirmRequestSchema,
+  ScheduleConfirmResponseSchema,
+  ScheduleHoldRequestSchema,
+  ScheduleHoldResponseSchema,
+  SchedulingSettingsRequestSchema,
+  SchedulingSettingsResponseSchema,
+} from './apiSchema/scheduling';
+
+const basePath = '/schedule';
+
+export default async function SchedulingRoutes(fastify: FastifyInstance, _opts: RouteOptions) {
+  fastify.route({
+    method: HttpMethods.GET,
+    url: `${basePath}/settings`,
+    preHandler: [fastify.authPrehandler],
+    schema: {
+      tags: ['Scheduling'],
+      summary: 'Get current user scheduling settings',
+      response: {
+        200: SchedulingSettingsResponseSchema,
+      },
+    },
+    handler: async (request: FastifyRequest, reply: FastifyReply) => {
+      const { tenantId, user } = request as AuthenticatedRequest;
+      const settings = await schedulingSettingsService.getForUser(tenantId, user.id);
+      return reply.send(settings);
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.PUT,
+    url: `${basePath}/settings`,
+    preHandler: [fastify.authPrehandler],
+    schema: {
+      tags: ['Scheduling'],
+      summary: 'Update current user scheduling settings',
+      body: SchedulingSettingsRequestSchema,
+      response: {
+        200: SchedulingSettingsResponseSchema,
+      },
+    },
+    handler: async (
+      request: FastifyRequest<{
+        Body: Parameters<typeof schedulingSettingsService.upsertForUser>[2];
+      }>,
+      reply: FastifyReply
+    ) => {
+      const { tenantId, user } = request as AuthenticatedRequest;
+      const settings = await schedulingSettingsService.upsertForUser(tenantId, user.id, request.body);
+      return reply.send(settings);
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.GET,
+    url: `${basePath}/public/:token`,
+    config: {
+      rateLimit: {
+        max: 60,
+        timeWindow: '1 minute',
+      },
+    },
+    schema: {
+      tags: ['Scheduling'],
+      summary: 'Resolve public booking token context',
+      params: BookingTokenParamsSchema,
+      response: {
+        200: PublicBookingContextResponseSchema,
+      },
+    },
+    handler: async (
+      request: FastifyRequest<{ Params: { token: string } }>,
+      reply: FastifyReply
+    ) => {
+      const context = await bookingTokenService.resolve(request.params.token);
+      logger.info('[SchedulingRoutes] Public booking token resolved', {
+        tenantId: context.token.tenantId,
+        userId: context.token.userId,
+        tokenId: context.token.id,
+      });
+      const settings = await schedulingSettingsService.getForUser(
+        context.token.tenantId,
+        context.token.userId
+      );
+
+      return reply.send({
+        tokenId: context.token.id,
+        timezone: settings.timezone,
+        meetingDurationMinutes: settings.meetingDurationMinutes,
+        lead: context.lead,
+        contact: {
+          id: context.contact.id,
+          name: context.contact.name,
+          email: context.contact.email ?? undefined,
+          phone: context.contact.phone ?? undefined,
+          company: context.contact.company ?? undefined,
+        },
+      });
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.GET,
+    url: `${basePath}/availability`,
+    config: {
+      rateLimit: {
+        max: 60,
+        timeWindow: '1 minute',
+      },
+    },
+    schema: {
+      tags: ['Scheduling'],
+      summary: 'Get public booking availability',
+      querystring: AvailabilityQuerySchema,
+      response: {
+        200: AvailabilityResponseSchema,
+      },
+    },
+    handler: async (
+      request: FastifyRequest<{
+        Querystring: { token: string; startDate: string; endDate: string };
+      }>,
+      reply: FastifyReply
+    ) => {
+      const { token, startDate, endDate } = request.query;
+      const availability = await availabilityService.getAvailabilityForToken(
+        token,
+        startDate,
+        endDate
+      );
+      logger.info('[SchedulingRoutes] Availability loaded', {
+        startDate,
+        endDate,
+        slotCount: availability.availableSlots.length,
+      });
+      return reply.send(availability);
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.POST,
+    url: `${basePath}/hold`,
+    config: {
+      rateLimit: {
+        max: 30,
+        timeWindow: '1 minute',
+      },
+    },
+    schema: {
+      tags: ['Scheduling'],
+      summary: 'Temporarily hold a public booking slot',
+      body: ScheduleHoldRequestSchema,
+      response: {
+        200: ScheduleHoldResponseSchema,
+      },
+    },
+    handler: async (
+      request: FastifyRequest<{ Body: { token: string; slot: string } }>,
+      reply: FastifyReply
+    ) => {
+      const context = await bookingTokenService.resolve(request.body.token);
+      const hold = await lockService.hold({
+        tenantId: context.token.tenantId,
+        userId: context.token.userId,
+        tokenId: context.token.id,
+        slot: request.body.slot,
+      });
+      logger.info('[SchedulingRoutes] Slot hold created', {
+        tenantId: context.token.tenantId,
+        userId: context.token.userId,
+        tokenId: context.token.id,
+      });
+
+      return reply.send({
+        holdId: hold.holdId,
+        expiresAt: hold.expiresAt.toISOString(),
+      });
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.POST,
+    url: `${basePath}/confirm`,
+    config: {
+      rateLimit: {
+        max: 20,
+        timeWindow: '1 minute',
+      },
+    },
+    schema: {
+      tags: ['Scheduling'],
+      summary: 'Confirm a public booking',
+      body: ScheduleConfirmRequestSchema,
+      response: {
+        200: ScheduleConfirmResponseSchema,
+      },
+    },
+    handler: async (
+      request: FastifyRequest<{
+        Body: {
+          token: string;
+          holdId: string;
+          slot: string;
+          contactDetails: { name: string; email: string; phone?: string };
+        };
+      }>,
+      reply: FastifyReply
+    ) => {
+      const result = await schedulingService.confirmBooking(request.body);
+      logger.info('[SchedulingRoutes] Booking confirmed', {
+        meetingId: result.meeting.id,
+        tenantId: result.meeting.tenantId,
+        userId: result.meeting.userId,
+      });
+
+      return reply.send({
+        meetingId: result.meeting.id,
+        calendarEventLink: result.calendarEventLink,
+      });
+    },
+  });
+}

--- a/server/src/routes/thirdPartyAuth.routes.ts
+++ b/server/src/routes/thirdPartyAuth.routes.ts
@@ -3,10 +3,15 @@ import { HttpMethods } from '@/utils/HttpMethods';
 import { logger } from '@/libs/logger';
 import { thirdPartyAuthStateCache } from '@/cache/ThirdPartyAuthStateCache';
 import { AuthenticatedRequest } from '@/plugins/authentication.plugin';
-import { getGoogleOAuth2Client, googleScopes } from '@/libs/thirdPartyAuth/GoogleAuth';
+import {
+  getGoogleOAuth2Client,
+  googleCalendarScopes,
+  googleScopes,
+} from '@/libs/thirdPartyAuth/GoogleAuth';
 import { getMicrosoftOAuth2Client, microsoftScopes } from '@/libs/thirdPartyAuth/MicrosoftAuth';
 import { newGoogleProviderService } from '@/modules/newGoogleProvider.service';
 import { newMicrosoftProviderService } from '@/modules/newMicrosoftProvider.service';
+import { calendarConnectionService } from '@/modules/scheduling/calendar/CalendarConnectionService';
 import {
   googleAuthUrlResponseSchema,
   googleCallbackResponseSchema,
@@ -41,6 +46,7 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
           tenantId,
           userId: user.id,
           isNewMailAccount: true,
+          purpose: 'mail',
         });
 
         const authUrl = oauth2Client.generateAuthUrl({
@@ -61,6 +67,52 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
         });
       } catch (error) {
         logger.error('Error generating Google OAuth URL:', error);
+        return reply.status(500).send({
+          message: 'Failed to generate authorization URL',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.GET,
+    url: `${basePath}/google/calendar/authorize`,
+    schema: {
+      response: {
+        200: googleAuthUrlResponseSchema,
+        500: errorResponseSchema,
+      },
+      tags: ['Third Party Authentication'],
+      summary: 'Initiate Google Calendar OAuth Flow',
+      description: 'Generate Google OAuth authorization URL for scheduling calendar access',
+    },
+    preHandler: [fastify.authPrehandler],
+    handler: async (request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        const { tenantId, user } = request as AuthenticatedRequest;
+
+        const oauth2Client = getGoogleOAuth2Client();
+        const state = await thirdPartyAuthStateCache.createAndSet({
+          tenantId,
+          userId: user.id,
+          isNewMailAccount: false,
+          purpose: 'calendar',
+        });
+
+        const authUrl = oauth2Client.generateAuthUrl({
+          access_type: 'offline',
+          scope: googleCalendarScopes,
+          state,
+          prompt: 'consent',
+        });
+
+        return reply.status(200).send({
+          authUrl,
+          state,
+        });
+      } catch (error) {
+        logger.error('Error generating Google Calendar OAuth URL:', error);
         return reply.status(500).send({
           message: 'Failed to generate authorization URL',
           error: error instanceof Error ? error.message : 'Unknown error',
@@ -99,9 +151,11 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
           throw new Error('Invalid state');
         }
 
-        const { tenantId, userId, isNewMailAccount } = stateData;
+        const { tenantId, userId, isNewMailAccount, purpose } = stateData;
 
-        if (isNewMailAccount) {
+        if (purpose === 'calendar') {
+          await calendarConnectionService.setupGoogleConnection(tenantId, userId, code);
+        } else if (isNewMailAccount) {
           await newGoogleProviderService.setupNewAccount(tenantId, userId, code);
         }
 
@@ -109,7 +163,10 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
 
         // redirect to the frontend
         return reply.redirect(
-          process.env.FRONTEND_ORIGIN + '/profile?google-auth-success=true',
+          process.env.FRONTEND_ORIGIN +
+            (purpose === 'calendar'
+              ? '/profile?google-calendar-auth-success=true'
+              : '/profile?google-auth-success=true'),
           301
         );
       } catch (error) {
@@ -146,6 +203,7 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
           tenantId,
           userId: user.id,
           isNewMailAccount: true,
+          purpose: 'mail',
         });
 
         const authUrl = oauth2Client.generateAuthUrl(microsoftScopes, stateId);
@@ -161,6 +219,47 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
         });
       } catch (error) {
         logger.error('Error generating Microsoft OAuth URL:', error);
+        return reply.status(500).send({
+          message: 'Failed to generate authorization URL',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    },
+  });
+
+  fastify.route({
+    method: HttpMethods.GET,
+    url: `${basePath}/microsoft/calendar/authorize`,
+    schema: {
+      response: {
+        200: microsoftAuthUrlResponseSchema,
+        500: errorResponseSchema,
+      },
+      tags: ['Third Party Authentication'],
+      summary: 'Initiate Microsoft Calendar OAuth Flow',
+      description: 'Generate Microsoft OAuth authorization URL for scheduling calendar access',
+    },
+    preHandler: [fastify.authPrehandler],
+    handler: async (request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        const { tenantId, user } = request as AuthenticatedRequest;
+
+        const oauth2Client = getMicrosoftOAuth2Client();
+        const stateId = await thirdPartyAuthStateCache.createAndSet({
+          tenantId,
+          userId: user.id,
+          isNewMailAccount: false,
+          purpose: 'calendar',
+        });
+
+        const authUrl = oauth2Client.generateAuthUrl(microsoftScopes, stateId);
+
+        return reply.status(200).send({
+          authUrl,
+          state: stateId,
+        });
+      } catch (error) {
+        logger.error('Error generating Microsoft Calendar OAuth URL:', error);
         return reply.status(500).send({
           message: 'Failed to generate authorization URL',
           error: error instanceof Error ? error.message : 'Unknown error',
@@ -200,9 +299,11 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
           throw new Error('Invalid state');
         }
 
-        const { tenantId, userId, isNewMailAccount } = stateData;
+        const { tenantId, userId, isNewMailAccount, purpose } = stateData;
 
-        if (isNewMailAccount) {
+        if (purpose === 'calendar') {
+          await calendarConnectionService.setupMicrosoftConnection(tenantId, userId, code);
+        } else if (isNewMailAccount) {
           await newMicrosoftProviderService.setupNewAccount(tenantId, userId, code);
         }
 
@@ -210,7 +311,10 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
 
         // redirect to the frontend
         return reply.redirect(
-          process.env.FRONTEND_ORIGIN + '/profile?microsoft-auth-success=true',
+          process.env.FRONTEND_ORIGIN +
+            (purpose === 'calendar'
+              ? '/profile?microsoft-calendar-auth-success=true'
+              : '/profile?microsoft-auth-success=true'),
           301
         );
       } catch (error) {

--- a/server/src/routes/thirdPartyAuth.routes.ts
+++ b/server/src/routes/thirdPartyAuth.routes.ts
@@ -8,7 +8,11 @@ import {
   googleCalendarScopes,
   googleScopes,
 } from '@/libs/thirdPartyAuth/GoogleAuth';
-import { getMicrosoftOAuth2Client, microsoftScopes } from '@/libs/thirdPartyAuth/MicrosoftAuth';
+import {
+  getMicrosoftOAuth2Client,
+  microsoftCalendarScopes,
+  microsoftScopes,
+} from '@/libs/thirdPartyAuth/MicrosoftAuth';
 import { newGoogleProviderService } from '@/modules/newGoogleProvider.service';
 import { newMicrosoftProviderService } from '@/modules/newMicrosoftProvider.service';
 import { calendarConnectionService } from '@/modules/scheduling/calendar/CalendarConnectionService';
@@ -156,7 +160,16 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
         if (purpose === 'calendar') {
           await calendarConnectionService.setupGoogleConnection(tenantId, userId, code);
         } else if (isNewMailAccount) {
-          await newGoogleProviderService.setupNewAccount(tenantId, userId, code);
+          const mailAccount = await newGoogleProviderService.setupNewAccount(tenantId, userId, code);
+          await calendarConnectionService.connectMailAccountCalendar({
+            tenantId,
+            userId,
+            mailAccountId: mailAccount.id,
+            provider: 'google',
+            primaryEmail: mailAccount.primaryEmail,
+            displayName: mailAccount.displayName,
+            scopes: mailAccount.scopes,
+          });
         }
 
         await thirdPartyAuthStateCache.clear(state);
@@ -252,7 +265,7 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
           purpose: 'calendar',
         });
 
-        const authUrl = oauth2Client.generateAuthUrl(microsoftScopes, stateId);
+        const authUrl = oauth2Client.generateAuthUrl(microsoftCalendarScopes, stateId);
 
         return reply.status(200).send({
           authUrl,
@@ -304,7 +317,20 @@ export default async function ThirdPartyAuth(fastify: FastifyInstance, _opts: Ro
         if (purpose === 'calendar') {
           await calendarConnectionService.setupMicrosoftConnection(tenantId, userId, code);
         } else if (isNewMailAccount) {
-          await newMicrosoftProviderService.setupNewAccount(tenantId, userId, code);
+          const mailAccount = await newMicrosoftProviderService.setupNewAccount(
+            tenantId,
+            userId,
+            code
+          );
+          await calendarConnectionService.connectMailAccountCalendar({
+            tenantId,
+            userId,
+            mailAccountId: mailAccount.id,
+            provider: 'microsoft',
+            primaryEmail: mailAccount.primaryEmail,
+            displayName: mailAccount.displayName,
+            scopes: mailAccount.scopes,
+          });
         }
 
         await thirdPartyAuthStateCache.clear(stateId);

--- a/server/src/routes/user.routes.ts
+++ b/server/src/routes/user.routes.ts
@@ -8,6 +8,7 @@ import {
   mailAccountRepository,
   leadRepository,
   leadPointOfContactRepository,
+  calendarConnectionRepository,
 } from '@/repositories';
 import { unsubscribeService } from '@/modules/unsubscribe';
 import { DEFAULT_CALENDAR_TIE_IN } from '@/constants';
@@ -21,6 +22,8 @@ import {
   TestEmailRequestSchema,
   TestEmailResponseSchema,
   GetEmailProvidersResponseSchema,
+  EmailProviderParamsSchema,
+  DisconnectProviderResponseSchema,
   SwitchPrimaryProviderRequestSchema,
   SwitchPrimaryProviderResponseSchema,
 } from './apiSchema/users';
@@ -269,6 +272,57 @@ export default async function UserRoutes(fastify: FastifyInstance, _opts: RouteO
       }
     },
   });
+
+  fastify.delete<{ Params: { providerId: string } }>(
+    `${basePath}/me/email-providers/:providerId`,
+    {
+      preHandler: [fastify.authPrehandler],
+      schema: {
+        params: EmailProviderParamsSchema,
+        response: {
+          200: DisconnectProviderResponseSchema,
+        },
+        tags: ['Users'],
+        summary: 'Disconnect email provider',
+        description: 'Disconnect a connected email provider for the authenticated user.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { providerId } = request.params;
+        const userId = ((request as any).user as IUser).id as string;
+
+        const existingAccount = await mailAccountRepository.findById(providerId);
+        if (!existingAccount || existingAccount.userId !== userId) {
+          return reply.status(404).send({ message: 'Mail account not found' });
+        }
+
+        await calendarConnectionRepository.disconnectByMailAccountId(providerId);
+        const disconnectedAccount = await mailAccountRepository.disconnectProvider(
+          userId,
+          providerId
+        );
+
+        reply.send({
+          message: 'Email provider disconnected successfully',
+          provider: {
+            id: disconnectedAccount.id,
+            provider: disconnectedAccount.provider,
+            primaryEmail: disconnectedAccount.primaryEmail,
+            displayName: disconnectedAccount.displayName || '',
+            isPrimary: false,
+            isConnected: false,
+            connectedAt: disconnectedAccount.connectedAt.toISOString(),
+          },
+        });
+      } catch (error: any) {
+        logger.error(`Error disconnecting email provider: ${error.message}`);
+        reply
+          .status(error.statusCode || 500)
+          .send({ message: error.message || 'Failed to disconnect email provider' });
+      }
+    }
+  );
 
   // Send test email
   fastify.route({

--- a/server/src/routes/user.routes.ts
+++ b/server/src/routes/user.routes.ts
@@ -3,11 +3,17 @@ import { createId } from '@paralleldrive/cuid2';
 import { HttpMethods } from '@/utils/HttpMethods';
 import { logger } from '@/libs/logger';
 import { UserService } from '@/modules/user.service';
-import { userTenantRepository, mailAccountRepository } from '@/repositories';
+import {
+  userTenantRepository,
+  mailAccountRepository,
+  leadRepository,
+  leadPointOfContactRepository,
+} from '@/repositories';
 import { unsubscribeService } from '@/modules/unsubscribe';
 import { DEFAULT_CALENDAR_TIE_IN } from '@/constants';
 import { EmailProcessor, type CampaignEmailData } from '@/modules/email';
 import { SenderIdentityResolverService } from '@/modules/email/senderIdentityResolver.service';
+import { bookingTokenService } from '@/modules/scheduling/BookingTokenService';
 import type { IUser } from '@/plugins/authentication.plugin';
 import {
   UpdateProfileRequestSchema,
@@ -362,16 +368,47 @@ export default async function UserRoutes(fastify: FastifyInstance, _opts: RouteO
         const testNodeId = 'test-email-node';
         const testLeadId = createId();
 
-        // Fetch calendar information if available (same as campaigns)
         let calendarInfo: CampaignEmailData['calendarInfo'];
         try {
-          if (user.calendarLink && user.calendarTieIn) {
-            calendarInfo = {
-              calendarLink: user.calendarLink,
-              calendarTieIn: user.calendarTieIn,
-              leadId: testLeadId,
-            };
-          }
+          const testLead = await leadRepository.createForTenant(tenantId, {
+            id: testLeadId,
+            name: `Test Email - ${recipientEmail}`,
+            url: 'https://dripiq.ai/test-email',
+            status: 'test',
+            ownerId: userId,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+          const testContact = await leadPointOfContactRepository.createForLeadAndTenant(
+            testLead.id,
+            tenantId,
+            {
+              id: testContactId,
+              name: 'Test Contact',
+              email: recipientEmail,
+              sourceUrl: 'https://dripiq.ai/test-email',
+              company: 'Test Email',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            }
+          );
+          const { rawToken } = await bookingTokenService.issue({
+            tenantId,
+            leadId: testLead.id,
+            contactId: testContact.id,
+            userId,
+            nodeId: testNodeId,
+            metadata: {
+              source: 'profile_test_email',
+              recipientEmail,
+            },
+          });
+
+          calendarInfo = {
+            calendarLink: bookingTokenService.buildBookingUrl(rawToken),
+            calendarTieIn: user.calendarTieIn?.trim() || DEFAULT_CALENDAR_TIE_IN,
+            leadId: testLead.id,
+          };
         } catch (calendarError) {
           logger.error('Failed to fetch calendar information for test email', {
             userId,


### PR DESCRIPTION
## Summary
- Add Smart Scheduling data model, repositories, public booking token flow, availability generation, Redis holds, and booking confirmation.
- Add Google and Outlook calendar provider adapters behind a shared scheduling calendar contract.
- Add scheduling settings UI and public booking page in the client.

## Test plan
- `client`: `npm run build`
- `server`: `npm run build`
- Note: `server` does not define `npm run prod`, so the requested prod command could not run.


Made with [Cursor](https://cursor.com)